### PR TITLE
Fix version numbering: auto-increment pre-release from existing tags

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
 
+# Prevent two prepare-release runs from picking the same version number
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
 jobs:
   prepare-release:
     name: Create Release PR
@@ -61,15 +66,28 @@ jobs:
           else
             VERSION="${{ steps.gitversion.outputs.MajorMinorPatch }}"
           fi
-          
+
           RELEASE_TYPE="${{ github.event.inputs.release_type }}"
-          
+
           if [ "$RELEASE_TYPE" = "stable" ]; then
             SEMVER="${VERSION}"
             TAG="v${VERSION}"
           else
-            SEMVER="${VERSION}-${RELEASE_TYPE}"
-            TAG="v${VERSION}-${RELEASE_TYPE}"
+            # Find the latest existing tag for this version + release type
+            # and increment the pre-release number.
+            # --sort=-v:refname gives correct numeric ordering (e.g., .9 before .10)
+            LATEST_TAG=$(git tag -l "v${VERSION}-${RELEASE_TYPE}.*" --sort=-v:refname | head -1)
+
+            if [ -z "$LATEST_TAG" ]; then
+              NEXT_NUM=1
+            else
+              # Extract the trailing number: v2.0.0-beta.217 → 217
+              CURRENT_NUM="${LATEST_TAG##*.}"
+              NEXT_NUM=$((CURRENT_NUM + 1))
+            fi
+
+            SEMVER="${VERSION}-${RELEASE_TYPE}.${NEXT_NUM}"
+            TAG="v${SEMVER}"
           fi
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
@@ -77,11 +95,24 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "release_type=${RELEASE_TYPE}" >> $GITHUB_OUTPUT
 
-      - name: Check if tag already exists
+          echo "::notice::Computed version: ${SEMVER} (tag: ${TAG})"
+
+      - name: Check for conflicts
         run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "::error::Tag ${{ steps.version.outputs.tag }} already exists."
+          TAG="${{ steps.version.outputs.tag }}"
+
+          # Ensure tag does not already exist
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists."
             echo "::error::Choose a different version or delete the existing tag first."
+            exit 1
+          fi
+
+          # Ensure no release branch or open PR already targets this version
+          BRANCH="release/${TAG}"
+          if git ls-remote --heads origin "${BRANCH}" | grep -q .; then
+            echo "::error::Branch ${BRANCH} already exists on the remote."
+            echo "::error::Delete it first or choose a different version."
             exit 1
           fi
 
@@ -97,22 +128,15 @@ jobs:
           RELEASE_TYPE="${{ steps.version.outputs.release_type }}"
 
           if [ "$RELEASE_TYPE" = "stable" ]; then
-            NEW_LABEL="    label: ''"
+            NEW_LABEL="''"
           else
-            NEW_LABEL="    label: ${RELEASE_TYPE}"
+            NEW_LABEL="${RELEASE_TYPE}"
           fi
 
           # Update the label line that follows the main branch regex.
-          # The main section has 'regex: ^main$' followed by a comment then 'label: ...'
-          # Use sed to replace the label line after the main regex match.
-          sed -i "/regex: \^main/,/^  [a-z]/{s/^    label: .*/    label: ${RELEASE_TYPE}/}" GitVersion.yml
+          sed -i "/regex: \^main/,/^  [a-z]/{s/^    label: .*/    label: ${NEW_LABEL}/}" GitVersion.yml
 
-          # For stable, label must be empty string
-          if [ "$RELEASE_TYPE" = "stable" ]; then
-            sed -i "/regex: \^main/,/^  [a-z]/{s/^    label: .*/    label: ''/}" GitVersion.yml
-          fi
-
-          echo "Updated GitVersion.yml main label to: '${RELEASE_TYPE}'"
+          echo "Updated GitVersion.yml main label to: '${NEW_LABEL}'"
           grep -A 5 "^  main:" GitVersion.yml
 
       - name: Commit label change


### PR DESCRIPTION
The workflow was manually constructing versions like '2.0.0-beta' without the incrementing number suffix. Now it scans existing git tags to find the latest matching tag (e.g., v2.0.0-beta.217) and increments to produce the next version (e.g., 2.0.0-beta.218).

Also adds:
- Concurrency group to prevent race conditions between runs
- Remote branch conflict detection before creating release branch
- Simplified GitVersion.yml label update logic

## Fixes

- Fixes #_____

## Proposed Changes/Todos

- [ ] Todo 1

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [ ] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [ ] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [ ] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working
