### PR TITLE
Fixes #5028. TextView still has remaining's bugs

### DIFF
--- a/Terminal.Gui/Views/Autocomplete/PopupAutocomplete.cs
+++ b/Terminal.Gui/Views/Autocomplete/PopupAutocomplete.cs
@@ -75,6 +75,17 @@ public abstract partial class PopupAutocomplete : AutocompleteBase
         }
     }
 
+    /// <inheritdoc />
+    public override bool Visible
+    {
+        get;
+        set
+        {
+            field = value;
+            _popup.Visible = value;
+        }
+    }
+
     /// <inheritdoc/>
     public override void EnsureSelectedIdxIsValid ()
     {
@@ -388,7 +399,6 @@ public abstract partial class PopupAutocomplete : AutocompleteBase
                                );
         }
 
-        _popup.Visible = true;
         _popup.Move (0, 0);
 
         for (var i = 0; i < toRender.Length; i++)
@@ -426,7 +436,6 @@ public abstract partial class PopupAutocomplete : AutocompleteBase
         _closed = true;
 
         //RemovePopupFromTop ();
-        _popup.Visible = false;
         HostControl?.SetNeedsDraw ();
     }
 
@@ -514,7 +523,6 @@ public abstract partial class PopupAutocomplete : AutocompleteBase
         {
             Visible = true;
             _closed = false;
-            _popup.Visible = true;
             HostControl?.SetNeedsDraw ();
 
             return true;

--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Mouse.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Mouse.cs
@@ -224,7 +224,7 @@ public partial class TextView
             int desiredInsertionY = Math.Clamp (Viewport.Y + p.Y, 0, _model.Count);
             int movementY = desiredInsertionY - _lastMouseInsertionPointY;
 
-            if (Viewport.Y + p.Y > _model.Count || (IsSelecting && p.Y >= Math.Max (Viewport.Height - 1, 0)))
+            if (Viewport.Y + p.Y >= _model.Count || (IsSelecting && p.Y >= Math.Max (Viewport.Height - 1, 0)))
             {
                 CurrentRow = _model.Count - 1;
             }

--- a/Tests/UnitTestsParallelizable/Views/TextView.AutocompleteTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextView.AutocompleteTests.cs
@@ -352,4 +352,35 @@ public class TextViewAutocompleteTests (ITestOutputHelper output) : TestDriverBa
             }
         }
     }
+
+    [Fact]
+    public void Autocomplete_Popup_Sets_Visible_To_False_When_Clicked_Outside_Of_Popup ()
+    {
+        TextView tv = new () { Width = Dim.Fill (), Height = 10, Text = " some text" };
+        using IApplication testApp = RunTestApplication (50, 15, DoTest, false, output);
+
+        return;
+
+        void DoTest (object? _, EventArgs<IApplication?> args)
+        {
+            IApplication app = args.Value!;
+
+            (app.TopRunnable as View)!.Add (tv);
+
+            SingleWordSuggestionGenerator g = (SingleWordSuggestionGenerator)tv.Autocomplete.SuggestionGenerator;
+            g.AllSuggestions = ["item"];
+
+            tv.SetFocus ();
+
+            app.InjectKey (Key.I);
+            Assert.Equal ("i some text", tv.Text);
+            Assert.True (tv.Autocomplete.Visible);
+
+            // Click outside of popup
+            app.InjectMouse (new Mouse { ScreenPosition = new Point (5, 1), Flags = MouseFlags.LeftButtonClicked });
+
+            Assert.False (tv.Autocomplete.Visible);
+            app.RequestStop ();
+        }
+    }
 }

--- a/Tests/UnitTestsParallelizable/Views/TextViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextViewTests.cs
@@ -3614,6 +3614,45 @@ public class TextViewTests (ITestOutputHelper output)
     }
 
     [Fact]
+    public void Mouse_Click_At_Position_GreaterOrEqual_To_Lines_Count_Should_Set_InsertionPoint_To_Last_Line ()
+    {
+        // Create a TextView with 3 lines of text
+        TextView tv = new () { Width = 6, Height = 5 };
+        tv.Text = "Line1\nLine2\nLine3";
+        tv.BeginInit ();
+        tv.EndInit ();
+
+        // Verify initial state
+        Assert.False (tv.WordWrap);
+        Assert.Equal (3, tv.Lines);
+        Assert.Equal (new Point (0, 0), tv.InsertionPoint);
+        Assert.Equal (new Point (0, 0), tv.Viewport.Location);
+
+        // Simulate mouse click at Y position greater than or equal to LinesCount
+        Mouse ev = new () { Position = new Point (0, 3), Flags = MouseFlags.LeftButtonClicked };
+        tv.NewMouseEvent (ev);
+
+        // Verify InsertionPoint is set to the last line
+        Assert.Equal (new Point (0, 2), tv.InsertionPoint);
+
+        // Now test with WordWrap enabled
+        tv.WordWrap = true;
+
+        // Verify initial state with WordWrap enabled
+        Assert.True (tv.WordWrap);
+        Assert.Equal (3, tv.Lines);
+        Assert.Equal (new Point (0, 0), tv.InsertionPoint);
+        Assert.Equal (new Point (0, 0), tv.Viewport.Location);
+
+        // Simulate mouse click at Y position greater than or equal to LinesCount
+        ev = new Mouse { Position = new Point (0, 3), Flags = MouseFlags.LeftButtonClicked };
+        tv.NewMouseEvent (ev);
+
+        // Verify InsertionPoint is set to the last line
+        Assert.Equal (new Point (0, 2), tv.InsertionPoint);
+    }
+
+    [Fact]
     public void MoveEnd_AdjustsViewportToShowInsertionPoint_When_InsertionPointIsBeyondViewport ()
     {
         using IApplication app = Application.Create ().Init ();


### PR DESCRIPTION
## Fixes

- Fixes #5028

## Proposed Changes/Todos

- [x] Fix click set insertion point row greater than lines count
- [x] Fix autocomplete popup on close not flag host control to redraw

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
