### PR TITLE
Add Microsoft.Net.Compilers.Toolset reference so the internal source generator loads

### DIFF
--- a/Terminal.Gui/Terminal.Gui.csproj
+++ b/Terminal.Gui/Terminal.Gui.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <!-- =================================================================== -->
     <!-- Version numbers -->
     <!-- Automatically set by GitVersion.MsBuild from git history + GitVersion.yml -->
@@ -66,6 +66,7 @@
     <!-- =================================================================== -->
     <ItemGroup>
         <ProjectReference Include="..\Terminal.Gui.Analyzers.Internal\Terminal.Gui.Analyzers.Internal.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <PackageReference Include="Microsoft.Net.Compilers.Toolset" PrivateAssets="all" />
     </ItemGroup>
     <ItemGroup>
       <!-- Enable Nuget Source Link for github -->


### PR DESCRIPTION
## Problem

On `develop` (currently `956ba448b`), a clean `dotnet restore && dotnet build --configuration Debug --no-restore` fails with 233 `CS1061` errors about missing `FastHasFlags`, `FastIsDefined`, `AsInt32`, and `AsUInt32` members on `MouseFlags`, `ViewportSettingsFlags`, `ViewArrangement`, `DimAutoStyle`, `KeyCode`, and others. Those members are emitted by `EnumExtensionMethodsGenerator` in `Terminal.Gui.Analyzers.Internal`.

The build also prints this warning, which is the actual cause:

```txt
CSC : warning CS9057: Analyzer assembly 'Terminal.Gui.Analyzers.Internal.dll' cannot be used
because it references version '5.3.0.0' of the compiler, which is newer than the currently
running version '5.0.0.0'.
```

The analyzer project is compiled against `Microsoft.CodeAnalysis.CSharp` 5.3.0 (pinned in `Directory.Packages.props`), but `Terminal.Gui.csproj` does not reference `Microsoft.Net.Compilers.Toolset`, so MSBuild falls back to the Roslyn 5.0.0 host bundled with the .NET SDK (10.0.100 through at least 10.0.104). That host refuses to load analyzers targeting a newer compiler, the generator is silently dropped, and the solution fails to build.

`Microsoft.Net.Compilers.Toolset` 5.3.0 is already pinned in `Directory.Packages.props` and already used by `Tests/AppTestHelpers.XunitHelpers/AppTestHelpers.XunitHelpers.csproj`. It just never got wired into `Terminal.Gui.csproj` when the generator was introduced in 12eae5e52.

## Fix

Add the toolset `PackageReference` alongside the analyzer `ProjectReference` in `Terminal.Gui/Terminal.Gui.csproj`:

```xml
<PackageReference Include="Microsoft.Net.Compilers.Toolset" PrivateAssets="all" />
```

This is the officially documented remedy for `CS9057` (see the Roslyn wiki's [NuGet packages](https://github.com/dotnet/roslyn/wiki/NuGet-packages) page: "Installing this package overrides the compiler toolset installed in MSBuild"). The package is dev-only, so `PrivateAssets="all"` keeps it out of consumers of `Terminal.Gui`.

## Verification

After the change, on .NET SDK 10.0.104:

```txt
$ dotnet build --configuration Debug --no-restore
...
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

No more `CS9057`, generator loads, solution builds clean.

# To pull down this PR locally:

```bash
git remote add copilot git@github.com:rcdailey/Terminal.Gui.git
git fetch copilot fix/analyzer-compiler-toolset
git checkout copilot/fix/analyzer-compiler-toolset
```