### PR TITLE
Fixes #5040. SelectorBase.TabBehavior setter calls CreateSubViews() without UpdateChecked(), desyncing CheckBox visual state

### DIFF
--- a/Terminal.Gui/Views/Selectors/OptionSelector.cs
+++ b/Terminal.Gui/Views/Selectors/OptionSelector.cs
@@ -135,6 +135,10 @@ public class OptionSelector : SelectorBase, IDesignable
     ///     Updates the checked state of all checkbox subviews so that only the checkbox corresponding
     ///     to the current <see cref="SelectorBase.Value"/> is checked.
     /// </summary>
+    /// <remarks>
+    ///     If <see cref="SelectorBase.Value"/> doesn't exist in the list of checkbox values, then the first checkbox will be checked by default
+    ///     and will raise the <see cref="SelectorBase.ValueChanging"/>/<see cref="SelectorBase.ValueChanged"/> events.
+    /// </remarks>
     public override void UpdateChecked ()
     {
         Dictionary<CheckBox, int> checkBoxValueMap = SubViews.OfType<CheckBox> ().ToDictionary (cb => cb, GetCheckBoxValue);

--- a/Terminal.Gui/Views/Selectors/OptionSelector.cs
+++ b/Terminal.Gui/Views/Selectors/OptionSelector.cs
@@ -165,6 +165,10 @@ public class OptionSelector : SelectorBase, IDesignable
 
                 break;
             }
+
+            // Sanity checks to verify the assumptions above
+            Debug.Assert (checkBoxValueMap.Values.First () != (int)SubViews.OfType<CheckBox> ().First ().Value);
+            Debug.Assert (checkBoxValueMap.Values.First () == Values! [0]);
         }
 
         // Verify at most one is checked

--- a/Terminal.Gui/Views/Selectors/OptionSelector.cs
+++ b/Terminal.Gui/Views/Selectors/OptionSelector.cs
@@ -137,11 +137,30 @@ public class OptionSelector : SelectorBase, IDesignable
     /// </summary>
     public override void UpdateChecked ()
     {
+        Dictionary<CheckBox, int> checkBoxValueMap = SubViews.OfType<CheckBox> ().ToDictionary (cb => cb, GetCheckBoxValue);
+
         foreach (CheckBox cb in SubViews.OfType<CheckBox> ())
         {
             int value = GetCheckBoxValue (cb);
 
             cb.Value = value == Value ? CheckState.Checked : CheckState.UnChecked;
+        }
+
+        // If Value doesn't exist in any checkbox, use the first checkbox's value
+        if (Value is not null && checkBoxValueMap.Count > 0 && Values!.All (v => v != Value) && checkBoxValueMap.Values.All (v => v != Value))
+        {
+            Value = checkBoxValueMap.Values.First ();
+
+            foreach (KeyValuePair<CheckBox, int> kvp in checkBoxValueMap)
+            {
+                if (kvp.Value != Value)
+                {
+                    continue;
+                }
+                kvp.Key.Value = CheckState.Checked;
+
+                break;
+            }
         }
 
         // Verify at most one is checked

--- a/Terminal.Gui/Views/Selectors/SelectorBase.cs
+++ b/Terminal.Gui/Views/Selectors/SelectorBase.cs
@@ -156,7 +156,6 @@ public abstract class SelectorBase : View, IOrientation, IValue<int?>
             field = value;
 
             CreateSubViews ();
-            UpdateChecked ();
         }
     }
 
@@ -316,7 +315,6 @@ public abstract class SelectorBase : View, IOrientation, IValue<int?>
             }
 
             CreateSubViews ();
-            UpdateChecked ();
         }
     }
 
@@ -331,7 +329,6 @@ public abstract class SelectorBase : View, IOrientation, IValue<int?>
             field = value;
 
             CreateSubViews ();
-            UpdateChecked ();
         }
     }
 
@@ -436,6 +433,9 @@ public abstract class SelectorBase : View, IOrientation, IValue<int?>
         // Note: Hotkey assignment is now handled automatically by the base class
         // when SubViews are added via Add(). No need to call AssignUniqueHotKeys() here.
         SetLayout ();
+
+        // Ensure the checked state of the checkboxes is correct after recreating subviews
+        UpdateChecked ();
     }
 
     /// <summary>

--- a/Tests/UnitTestsParallelizable/Views/SelectorBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/SelectorBaseTests.cs
@@ -617,6 +617,23 @@ public class SelectorBaseTests
         Assert.Equal (30, selector.Value);
     }
 
+    [Fact]
+    public void Setting_TabBehavior_AfterSubViewsAreCreated_DoesNotLoseCheckedState ()
+    {
+        OptionSelector selector = new ()
+        {
+            Labels = ["Option1", "Option2"], Values = [10, 20], Orientation = Orientation.Vertical, TabBehavior = TabBehavior.NoStop
+        };
+
+        List<CheckBox> checkBoxes = [.. selector.SubViews.OfType<CheckBox> ()];
+
+        Assert.Equal (2, checkBoxes.Count);
+        Assert.Equal (CheckState.Checked, checkBoxes [0].Value);
+        Assert.Equal (CheckState.UnChecked, checkBoxes [1].Value);
+        Assert.Equal (10, selector.Value);
+        Assert.Equal (TabBehavior.NoStop, selector.TabBehavior);
+    }
+
     #endregion
 
     #region HotKey Command Tests

--- a/Tests/UnitTestsParallelizable/Views/SelectorBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/SelectorBaseTests.cs
@@ -598,6 +598,25 @@ public class SelectorBaseTests
         Assert.True (checkBox.CanFocus);
     }
 
+    [Fact]
+    public void CreateSubViews_ResetsValueIfCurrentValueNotInNewValues_And_Call_UpdateChecked_Method ()
+    {
+        OptionSelector selector = new ();
+
+        selector.Labels = ["Option1", "Option2"];
+        selector.Values = [10, 20];
+
+        // Verify initial value is set to first value (10)
+        Assert.Equal (10, selector.Value);
+
+        // Change to new labels/values where current value (10) is not present
+        selector.Labels = ["New1", "New2"];
+        selector.Values = [30, 40];
+
+        // Value should reset to first value (30)
+        Assert.Equal (30, selector.Value);
+    }
+
     #endregion
 
     #region HotKey Command Tests

--- a/Tests/UnitTestsParallelizable/Views/SelectorBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/SelectorBaseTests.cs
@@ -599,7 +599,7 @@ public class SelectorBaseTests
     }
 
     [Fact]
-    public void CreateSubViews_ResetsValueIfCurrentValueNotInNewValues_And_Call_UpdateChecked_Method ()
+    public void CreateSubViews_ResetsValue_WhenCurrentValueNotInNewValues ()
     {
         OptionSelector selector = new ();
 

--- a/Tests/UnitTestsParallelizable/Views/SelectorBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/SelectorBaseTests.cs
@@ -634,6 +634,25 @@ public class SelectorBaseTests
         Assert.Equal (TabBehavior.NoStop, selector.TabBehavior);
     }
 
+    [Fact]
+    public void Setting_TabBehavior_AfterSubViewsAreCreated_DoesNotLoseCheckedState_With_Enum ()
+    {
+        OptionSelector<Side> selector = new ()
+        {
+            Orientation = Orientation.Vertical, TabBehavior = TabBehavior.NoStop
+        };
+
+        List<CheckBox> checkBoxes = [.. selector.SubViews.OfType<CheckBox> ()];
+
+        Assert.Equal (4, checkBoxes.Count);
+        Assert.Equal (CheckState.Checked, checkBoxes [0].Value);
+        Assert.Equal (CheckState.UnChecked, checkBoxes [1].Value);
+        Assert.Equal (CheckState.UnChecked, checkBoxes [2].Value);
+        Assert.Equal (CheckState.UnChecked, checkBoxes [3].Value);
+        Assert.Equal (Side.Left, selector.Value);
+        Assert.Equal (TabBehavior.NoStop, selector.TabBehavior);
+    }
+
     #endregion
 
     #region HotKey Command Tests


### PR DESCRIPTION
## Fixes

- Fixes #5040

## Proposed Changes/Todos

- [x] Call UpdateChecked inside the CreateSubViews method

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
