### PR TITLE
Fixes #5043 - `View.ScrollBars` now only show if they fit - Fixes `View.Viewport` bug

### DIFF
--- a/Examples/UICatalog/Scenarios/Arrangement.cs
+++ b/Examples/UICatalog/Scenarios/Arrangement.cs
@@ -148,12 +148,9 @@ public class Arrangement : Scenario
             ShadowStyle = ShadowStyles.Transparent,
             BorderStyle = LineStyle.Double,
             TabStop = TabBehavior.TabGroup,
-            Arrangement = ViewArrangement.Movable | ViewArrangement.Overlapped
+            Arrangement = ViewArrangement.Movable | ViewArrangement.Overlapped,
+            SchemeName = SchemeManager.SchemesToSchemeName (Schemes.Error)
         };
-
-        datePicker.SetScheme (new Scheme (new Attribute (SchemeManager.GetScheme (Schemes.Accent).Normal.Foreground.GetBrighterColor (),
-                                                         SchemeManager.GetScheme (Schemes.Accent).Normal.Background.GetBrighterColor (),
-                                                         SchemeManager.GetScheme (Schemes.Accent).Normal.Style)));
 
         TransparentView transparentView = new ()
         {

--- a/Examples/UICatalog/Scenarios/PopoverMenus.cs
+++ b/Examples/UICatalog/Scenarios/PopoverMenus.cs
@@ -400,8 +400,7 @@ public class PopoverMenus : Scenario
 
                                   foreach (MenuItem item in cultures)
                                   {
-                                      ((CheckBox)item.CommandView).Value =
-                                          Thread.CurrentThread.CurrentUICulture.Name == item.HelpText ? CheckState.Checked : CheckState.UnChecked;
+                                      (item.CommandView as CheckBox)?.Value = Thread.CurrentThread.CurrentUICulture.Name == item.HelpText ? CheckState.Checked : CheckState.UnChecked;
                                   }
                               };
     }

--- a/Examples/UICatalog/Scenarios/Shortcuts.cs
+++ b/Examples/UICatalog/Scenarios/Shortcuts.cs
@@ -263,7 +263,7 @@ public class Shortcuts : Scenario
             Command = Command.New
         };
 
-        _window.CommandNotBound += (o, args) =>
+        _window.CommandNotBound += (_, args) =>
                                    {
                                        if (args.Context?.Command != Command.New)
                                        {
@@ -329,13 +329,10 @@ public class Shortcuts : Scenario
 
         //framedShortcut.Orientation = Orientation.Horizontal;
 
-        if (framedShortcut.Padding is { })
-        {
-            framedShortcut.Padding.Thickness = new Thickness (0, 1, 0, 0);
-            framedShortcut.Padding.Diagnostics = ViewDiagnosticFlags.Ruler;
-        }
+        framedShortcut.Padding.Thickness = new Thickness (0, 1, 0, 0);
+        framedShortcut.Padding.Diagnostics = ViewDiagnosticFlags.Ruler;
 
-        if (framedShortcut.CommandView.Margin is { })
+        if (framedShortcut.CommandView?.Margin is { })
         {
             framedShortcut.CommandView.SchemeName = SchemeManager.SchemesToSchemeName (Schemes.Dialog);
             framedShortcut.HelpView.SchemeName = SchemeManager.SchemesToSchemeName (Schemes.Error);
@@ -537,7 +534,7 @@ public class Shortcuts : Scenario
             {
                 if (peer.CanFocus)
                 {
-                    peer.CommandView.CanFocus = canFocus;
+                    peer.CommandView?.CanFocus = canFocus;
                 }
             }
             focused?.SetFocus ();

--- a/Examples/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/Examples/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -46,7 +46,7 @@ public class TreeViewFileSystem : Scenario
         // MenuBar
         MenuBar menu = new ();
 
-        _treeViewFiles = new TreeView<IFileSystemInfo> { X = 0, Y = Pos.Bottom (menu), Width = Dim.Percent (50), Height = Dim.Fill () };
+        _treeViewFiles = new TreeView<IFileSystemInfo> { X = 0, Y = Pos.Bottom (menu), Width = Dim.Percent (50), Height = Dim.Fill (), BorderStyle = LineStyle.Dotted};
         _treeViewFiles.DrawLine += TreeViewFiles_DrawLine;
 
         // Scrollbars are disabled by default (VisibilityMode.Manual)

--- a/Examples/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/Examples/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -38,25 +38,27 @@ public class TreeViewFileSystem : Scenario
         using IApplication app = Application.Create ();
         app.Init ();
 
-        using Window win = new ();
+        using Runnable win = new ();
         win.Title = GetName ();
-        win.Y = 1; // menu
-        win.Height = Dim.Fill ();
 
         // MenuBar
         MenuBar menu = new ();
 
-        _treeViewFiles = new TreeView<IFileSystemInfo> { X = 0, Y = Pos.Bottom (menu), Width = Dim.Percent (50), Height = Dim.Fill () };
+        _treeViewFiles = new TreeView<IFileSystemInfo>
+        {
+            Y = Pos.Bottom (menu),
+            Height = Dim.Fill (),
+        };
         _treeViewFiles.DrawLine += TreeViewFiles_DrawLine;
-
-        // Scrollbars are disabled by default (VisibilityMode.Manual)
 
         _detailsFrame = new DetailsFrame (_iconProvider)
         {
-            X = Pos.Right (_treeViewFiles), Y = Pos.Top (_treeViewFiles), Width = Dim.Fill (), Height = Dim.Fill ()
+            X = Pos.AnchorEnd (), Y = Pos.Bottom (menu), Width = 50, Height = Dim.Fill ()
         };
+        _treeViewFiles.Width = Dim.Fill (_detailsFrame);
 
-        win.Add (_detailsFrame);
+        win.Add (menu, _treeViewFiles, _detailsFrame);
+
         _treeViewFiles.Activating += TreeViewFiles_Activating;
         _treeViewFiles.KeyDown += TreeViewFiles_KeyPress;
         _treeViewFiles.SelectionChanged += TreeViewFiles_SelectionChanged;
@@ -70,8 +72,6 @@ public class TreeViewFileSystem : Scenario
         _miMultiSelectCheckBox = new CheckBox
         {
             Title = "_Multi Select"
-
-            //CheckedState = CheckState.Checked
         };
         _miMultiSelectCheckBox.ValueChanged += (_, _) => SetMultiSelect ();
 
@@ -140,10 +140,9 @@ public class TreeViewFileSystem : Scenario
                                    ]));
 
         SetNerdIcons ();
-        win.Add (menu, _treeViewFiles);
+
         _treeViewFiles.GoToFirst ();
         _treeViewFiles.Expand ();
-
         _treeViewFiles.SetFocus ();
 
         UpdateIconCheckState ();
@@ -205,20 +204,20 @@ public class TreeViewFileSystem : Scenario
         if (_miCustomColorsCheckBox.Value == CheckState.Checked)
         {
             _treeViewFiles.ColorGetter = m =>
-                                         {
-                                             if ((m is IDirectoryInfo && m.Attributes.HasFlag (FileAttributes.Hidden)) || (m is IFileInfo && m.Attributes.HasFlag (FileAttributes.Hidden)))
-                                             {
-                                                 return new Scheme
-                                                 {
-                                                     Focus = new Attribute (Color.BrightRed,
-                                                                            _treeViewFiles.GetAttributeForRole (VisualRole.Focus).Background),
-                                                     Normal = new Attribute (Color.BrightYellow,
-                                                                             _treeViewFiles.GetAttributeForRole (VisualRole.Normal).Background)
-                                                 };
-                                             }
+            {
+                if ((m is IDirectoryInfo && m.Attributes.HasFlag (FileAttributes.Hidden)) || (m is IFileInfo && m.Attributes.HasFlag (FileAttributes.Hidden)))
+                {
+                    return new Scheme
+                    {
+                        Focus = new Attribute (Color.BrightRed,
+                                               _treeViewFiles.GetAttributeForRole (VisualRole.Focus).Background),
+                        Normal = new Attribute (Color.BrightYellow,
+                                                _treeViewFiles.GetAttributeForRole (VisualRole.Normal).Background)
+                    };
+                }
 
-                                             return null;
-                                         };
+                return null;
+            };
         }
         else
         {
@@ -393,13 +392,13 @@ public class TreeViewFileSystem : Scenario
                 return;
 
             case { }:
-            {
-                Cell cell = e.Cells [e.IndexOfModelText];
+                {
+                    Cell cell = e.Cells [e.IndexOfModelText];
 
-                cell.Attribute = new Attribute (Color.BrightYellow, cell.Attribute!.Value.Background, cell.Attribute!.Value.Style);
+                    cell.Attribute = new Attribute (Color.BrightYellow, cell.Attribute!.Value.Background, cell.Attribute!.Value.Style);
 
-                break;
-            }
+                    break;
+                }
         }
     }
 
@@ -482,8 +481,7 @@ public class TreeViewFileSystem : Scenario
         public DetailsFrame (FileSystemIconProvider iconProvider)
         {
             Title = "Details";
-            base.Visible = true;
-            CanFocus = true;
+            SchemeName = SchemeManager.SchemesToSchemeName (Schemes.Dialog);
             _iconProvider = iconProvider;
         }
 

--- a/Examples/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/Examples/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -46,7 +46,7 @@ public class TreeViewFileSystem : Scenario
         // MenuBar
         MenuBar menu = new ();
 
-        _treeViewFiles = new TreeView<IFileSystemInfo> { X = 0, Y = Pos.Bottom (menu), Width = Dim.Percent (50), Height = Dim.Fill (), BorderStyle = LineStyle.Dotted};
+        _treeViewFiles = new TreeView<IFileSystemInfo> { X = 0, Y = Pos.Bottom (menu), Width = Dim.Percent (50), Height = Dim.Fill () };
         _treeViewFiles.DrawLine += TreeViewFiles_DrawLine;
 
         // Scrollbars are disabled by default (VisibilityMode.Manual)

--- a/Terminal.Gui/ViewBase/Adornment/AdornmentImpl.cs
+++ b/Terminal.Gui/ViewBase/Adornment/AdornmentImpl.cs
@@ -48,23 +48,6 @@ public abstract class AdornmentImpl : IAdornment
                 return;
             }
 
-            // this is a useful assert to enable to find places where Thickness is being set to an unreasonably
-            // large value that will cause layout issues, but it is noisy in debug since some adornments (e.g. Border)
-            // intentionally allow large thicknesses and assert would need to be disabled for those cases.
-            //#if DEBUG
-            //            // If the new thickness is larger than the Parent.Frame, throw as this is likely a mistake and will cause layout issues.
-            //            if (Parent is { } p)
-            //            {
-            //                int width = p.Frame.Size.Width - value.Horizontal;
-            //                int height = p.Frame.Size.Height - value.Vertical;
-            //
-            //                if (width < 0 || height < 0)
-            //                {
-            //                    throw new ArgumentException (@$"Thickness {value} is too large for the parent frame {p.Frame}.", nameof (value));
-            //                }
-            //            }
-            //#endif
-
             field = value;
 
             OnThicknessChanged ();

--- a/Terminal.Gui/ViewBase/Adornment/AdornmentImpl.cs
+++ b/Terminal.Gui/ViewBase/Adornment/AdornmentImpl.cs
@@ -43,13 +43,29 @@ public abstract class AdornmentImpl : IAdornment
         get;
         set
         {
-            Thickness current = field;
-            field = value;
-
-            if (current == field)
+            if (value == field)
             {
                 return;
             }
+
+            // this is a useful assert to enable to find places where Thickness is being set to an unreasonably
+            // large value that will cause layout issues, but it is noisy in debug since some adornments (e.g. Border)
+            // intentionally allow large thicknesses and assert would need to be disabled for those cases.
+            //#if DEBUG
+            //            // If the new thickness is larger than the Parent.Frame, throw as this is likely a mistake and will cause layout issues.
+            //            if (Parent is { } p)
+            //            {
+            //                int width = p.Frame.Size.Width - value.Horizontal;
+            //                int height = p.Frame.Size.Height - value.Vertical;
+            //
+            //                if (width < 0 || height < 0)
+            //                {
+            //                    throw new ArgumentException (@$"Thickness {value} is too large for the parent frame {p.Frame}.", nameof (value));
+            //                }
+            //            }
+            //#endif
+
+            field = value;
 
             OnThicknessChanged ();
             ThicknessChanged?.Invoke (this, EventArgs.Empty);

--- a/Terminal.Gui/ViewBase/Layout/DimAuto.cs
+++ b/Terminal.Gui/ViewBase/Layout/DimAuto.cs
@@ -166,8 +166,7 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
         // 2048 x 2048 supports unit testing where no App is running.
         Size screenSize = us.App?.Screen.Size ?? new Size (2048, 2048);
         int autoMin = MinimumContentDim?.GetAnchor (superviewContentSize) ?? 0;
-        int screenX4 = dimension == Dimension.Width ? screenSize.Width * 4 : screenSize.Height * 4;
-        int autoMax = MaximumContentDim?.GetAnchor (superviewContentSize) ?? screenX4;
+        int autoMax = MaximumContentDim?.GetAnchor (superviewContentSize) ?? int.MaxValue;
 
         if (Style.FastHasFlags (DimAutoStyle.Text))
         {
@@ -177,7 +176,7 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
                 {
                     // Set BOTH width and height (by setting Size). We do this because we will be called again, next
                     // for Dimension.Height. We need to know the width to calculate the height.
-                    us.TextFormatter.ConstrainToSize = us.TextFormatter.FormatAndGetSize (new Size (int.Min (autoMax, screenX4), screenX4));
+                    us.TextFormatter.ConstrainToSize = us.TextFormatter.FormatAndGetSize (new Size (int.Min (autoMax, int.MaxValue), int.MaxValue));
                 }
 
                 textSize = us.TextFormatter.ConstrainToWidth ?? 0;
@@ -187,7 +186,7 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
                 // For height, we need to make sure width has been calculated.
                 if (us.TextFormatter.ConstrainToHeight is null)
                 {
-                    int width = int.Min (MaximumContentDim?.GetAnchor (superviewContentSize) ?? screenX4, screenSize.Width * 4);
+                    int width = int.Min (MaximumContentDim?.GetAnchor (superviewContentSize) ?? int.MaxValue, screenSize.Width * 4);
 
                     if (us.TextFormatter.ConstrainToWidth is null)
                     {
@@ -195,10 +194,10 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
                         // the view hasn't been laid out yet (Viewport.Width == 0) to avoid
                         // constraining the text to zero width which produces height = 0.
                         int constrainWidth = us.Viewport.Width > 0 ? us.Viewport.Width : width;
-                        width = us.TextFormatter.FormatAndGetSize (new Size (constrainWidth, screenX4)).Width;
+                        width = us.TextFormatter.FormatAndGetSize (new Size (constrainWidth, int.MaxValue)).Width;
                     }
 
-                    textSize = us.TextFormatter.FormatAndGetSize (new Size (us.TextFormatter.ConstrainToWidth ?? width, screenX4)).Height;
+                    textSize = us.TextFormatter.FormatAndGetSize (new Size (us.TextFormatter.ConstrainToWidth ?? width, int.MaxValue)).Height;
                     us.TextFormatter.ConstrainToHeight = textSize;
                 }
                 else
@@ -248,8 +247,8 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
                 foreach (View v in categories.Centered)
                 {
                     maxCentered = dimension == Dimension.Width
-                                      ? v.X.GetAnchor (0) + v.Width.Calculate (0, screenX4, v, dimension)
-                                      : v.Y.GetAnchor (0) + v.Height.Calculate (0, screenX4, v, dimension);
+                                      ? v.X.GetAnchor (0) + v.Width.Calculate (0, int.MaxValue, v, dimension)
+                                      : v.Y.GetAnchor (0) + v.Height.Calculate (0, int.MaxValue, v, dimension);
                 }
 
                 maxCalculatedSize = int.Max (maxCalculatedSize, maxCentered);
@@ -272,8 +271,8 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
                 {
                     // Need to set the relative layout for PosAnchorEnd subviews to calculate the size
                     anchoredSubView.SetRelativeLayout (dimension == Dimension.Width
-                                                           ? new Size (maxCalculatedSize, screenX4)
-                                                           : new Size (screenX4, maxCalculatedSize));
+                                                           ? new Size (maxCalculatedSize, int.MaxValue)
+                                                           : new Size (int.MaxValue, maxCalculatedSize));
 
                     maxAnchorEnd = dimension == Dimension.Width
                                        ? anchoredSubView.X.GetAnchor (maxCalculatedSize + anchoredSubView.Frame.Width)

--- a/Terminal.Gui/ViewBase/Layout/DimAuto.cs
+++ b/Terminal.Gui/ViewBase/Layout/DimAuto.cs
@@ -176,7 +176,7 @@ public record DimAuto (Dim? MaximumContentDim, Dim? MinimumContentDim, DimAutoSt
                 {
                     // Set BOTH width and height (by setting Size). We do this because we will be called again, next
                     // for Dimension.Height. We need to know the width to calculate the height.
-                    us.TextFormatter.ConstrainToSize = us.TextFormatter.FormatAndGetSize (new Size (int.Min (autoMax, int.MaxValue), int.MaxValue));
+                    us.TextFormatter.ConstrainToSize = us.TextFormatter.FormatAndGetSize (new Size (autoMax, int.MaxValue));
                 }
 
                 textSize = us.TextFormatter.ConstrainToWidth ?? 0;

--- a/Terminal.Gui/ViewBase/View.Content.cs
+++ b/Terminal.Gui/ViewBase/View.Content.cs
@@ -523,9 +523,12 @@ public partial class View
 
         Size newSize = new (viewport.Size.Width + thickness.Horizontal, viewport.Size.Height + thickness.Vertical);
 
-        if (newSize == Frame.Size || viewport.Size.Width - thickness.Horizontal < 0 || viewport.Size.Height - thickness.Vertical < 0)
+        // Detect the "adornments consume entire viewport" no-op: when the requested viewport size equals
+        // the current Viewport size (which may already be clamped to zero when Frame is smaller than adornments).
+        // In this case updating Frame would incorrectly grow it, so treat it as a no-op.
+        if (newSize == Frame.Size || viewport.Size == Viewport.Size)
         {
-            // The change is not changing the Frame, or it is invalid, so we don't need to update it.
+            // The change is not changing the Frame, or the adornments consume the entire Frame, so we don't need to update it.
             // Just call SetNeedsLayout to update the layout.
             if (_viewportLocation != viewport.Location)
             {

--- a/Terminal.Gui/ViewBase/View.Content.cs
+++ b/Terminal.Gui/ViewBase/View.Content.cs
@@ -521,11 +521,13 @@ public partial class View
 
         Thickness thickness = GetAdornmentsThickness ();
 
+        Rectangle inside = thickness.GetInside (Viewport);
+
         Size newSize = new (viewport.Size.Width + thickness.Horizontal, viewport.Size.Height + thickness.Vertical);
 
-        if (newSize == Frame.Size)
+        if (newSize == Frame.Size || inside.Width < 0 || inside.Height < 0)
         {
-            // The change is not changing the Frame, so we don't need to update it.
+            // The change is not changing the Frame, or it is invalid, so we don't need to update it.
             // Just call SetNeedsLayout to update the layout.
             if (_viewportLocation != viewport.Location)
             {

--- a/Terminal.Gui/ViewBase/View.Content.cs
+++ b/Terminal.Gui/ViewBase/View.Content.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-
-namespace Terminal.Gui.ViewBase;
+﻿namespace Terminal.Gui.ViewBase;
 
 public partial class View
 {

--- a/Terminal.Gui/ViewBase/View.Content.cs
+++ b/Terminal.Gui/ViewBase/View.Content.cs
@@ -1,4 +1,6 @@
-﻿namespace Terminal.Gui.ViewBase;
+﻿using System.Diagnostics;
+
+namespace Terminal.Gui.ViewBase;
 
 public partial class View
 {
@@ -521,11 +523,9 @@ public partial class View
 
         Thickness thickness = GetAdornmentsThickness ();
 
-        Rectangle inside = thickness.GetInside (Viewport);
-
         Size newSize = new (viewport.Size.Width + thickness.Horizontal, viewport.Size.Height + thickness.Vertical);
 
-        if (newSize == Frame.Size || inside.Width < 0 || inside.Height < 0)
+        if (newSize == Frame.Size || viewport.Size.Width - thickness.Horizontal < 0 || viewport.Size.Height - thickness.Vertical < 0)
         {
             // The change is not changing the Frame, or it is invalid, so we don't need to update it.
             // Just call SetNeedsLayout to update the layout.

--- a/Terminal.Gui/ViewBase/View.Drawing.Scheme.cs
+++ b/Terminal.Gui/ViewBase/View.Drawing.Scheme.cs
@@ -152,7 +152,15 @@ public partial class View
                     return namedScheme;
                 }
 
-                return SchemeManager.TryGetScheme ("Base", out Scheme? baseScheme) ? Scheme.DeriveAccent (baseScheme, Driver?.DefaultAttribute) : namedScheme;
+                // If the "Accent" scheme is requested but the theme's definition has no normal background color,
+                // derive it from the base scheme to ensure it has a valid background.
+                // There may be cases where a Theme defines an Accent like this; that should be a rare case.
+                if (namedScheme.Normal.Background == Color.None)
+                {
+                    return SchemeManager.TryGetScheme ("Base", out Scheme? baseScheme) ? Scheme.DeriveAccent (baseScheme, Driver?.DefaultAttribute) : namedScheme;
+                }
+
+                return namedScheme;
             }
 
             Logging.Warning ($"SchemeName '{SchemeName}' not found in current theme. Falling back.");

--- a/Terminal.Gui/ViewBase/View.Drawing.Scheme.cs
+++ b/Terminal.Gui/ViewBase/View.Drawing.Scheme.cs
@@ -147,7 +147,12 @@ public partial class View
 
             if (SchemeManager.TryGetScheme (SchemeName, out Scheme? namedScheme))
             {
-                return namedScheme;
+                if (SchemeName != "Accent")
+                {
+                    return namedScheme;
+                }
+
+                return SchemeManager.TryGetScheme ("Base", out Scheme? baseScheme) ? Scheme.DeriveAccent (baseScheme, Driver?.DefaultAttribute) : namedScheme;
             }
 
             Logging.Warning ($"SchemeName '{SchemeName}' not found in current theme. Falling back.");

--- a/Terminal.Gui/ViewBase/View.ScrollBars.cs
+++ b/Terminal.Gui/ViewBase/View.ScrollBars.cs
@@ -144,6 +144,25 @@ public partial class View
                                       Viewport = Viewport with { Y = Math.Min (args.NewValue, scrollBar.ScrollableContentSize - scrollBar.VisibleContentSize) };
                                   };
 
+
+        scrollBar.VisibleChanging += (_, args) =>
+                                     {
+                                         if (!args.NewValue)
+                                         {
+                                             return;
+                                         }
+                                         int width = Frame.Size.Width - Padding.Thickness.Horizontal;
+                                         int height = Frame.Size.Height - Padding.Thickness.Vertical;
+
+                                         if (width < 2 || height < 3)
+                                         {
+                                             // Prevent scrollbar from becoming visible if it would cause negative available space for content
+                                             args.Cancel = true;
+
+                                             return;
+                                         }
+                                     };
+
         scrollBar.VisibleChanged += (_, _) =>
                                     {
                                         // Reset scrolling
@@ -165,6 +184,25 @@ public partial class View
                                   {
                                       Viewport = Viewport with { X = Math.Min (args.NewValue, scrollBar.ScrollableContentSize - scrollBar.VisibleContentSize) };
                                   };
+
+
+        scrollBar.VisibleChanging += (_, args) =>
+                                     {
+                                         if (!args.NewValue)
+                                         {
+                                             return;
+                                         }
+                                         int width = Frame.Size.Width - Padding.Thickness.Horizontal;
+                                         int height = Frame.Size.Height - Padding.Thickness.Vertical;
+
+                                         if (width < 3 || height < 2)
+                                         {
+                                             // Prevent scrollbar from becoming visible if it would cause negative available space for content
+                                             args.Cancel = true;
+
+                                             return;
+                                         }
+                                     };
 
         scrollBar.VisibleChanged += (_, _) =>
                                     {

--- a/Terminal.Gui/ViewBase/View.ScrollBars.cs
+++ b/Terminal.Gui/ViewBase/View.ScrollBars.cs
@@ -144,22 +144,18 @@ public partial class View
                                       Viewport = Viewport with { Y = Math.Min (args.NewValue, scrollBar.ScrollableContentSize - scrollBar.VisibleContentSize) };
                                   };
 
-
         scrollBar.VisibleChanging += (_, args) =>
                                      {
                                          if (!args.NewValue)
                                          {
                                              return;
                                          }
-                                         int width = Frame.Size.Width - Padding.Thickness.Horizontal;
-                                         int height = Frame.Size.Height - Padding.Thickness.Vertical;
+                                         int width = Frame.Size.Width - GetAdornmentsThickness ().Horizontal;
 
-                                         if (width < 2 || height < 3)
+                                         if (width < 1 || Viewport.Height < 2)
                                          {
                                              // Prevent scrollbar from becoming visible if it would cause negative available space for content
                                              args.Cancel = true;
-
-                                             return;
                                          }
                                      };
 
@@ -185,22 +181,18 @@ public partial class View
                                       Viewport = Viewport with { X = Math.Min (args.NewValue, scrollBar.ScrollableContentSize - scrollBar.VisibleContentSize) };
                                   };
 
-
         scrollBar.VisibleChanging += (_, args) =>
                                      {
                                          if (!args.NewValue)
                                          {
                                              return;
                                          }
-                                         int width = Frame.Size.Width - Padding.Thickness.Horizontal;
-                                         int height = Frame.Size.Height - Padding.Thickness.Vertical;
+                                         int height = Frame.Size.Height - GetAdornmentsThickness ().Vertical;
 
-                                         if (width < 3 || height < 2)
+                                         if (Viewport.Width < 2 || height < 1)
                                          {
                                              // Prevent scrollbar from becoming visible if it would cause negative available space for content
                                              args.Cancel = true;
-
-                                             return;
                                          }
                                      };
 

--- a/Terminal.Gui/Views/DropDownList.cs
+++ b/Terminal.Gui/Views/DropDownList.cs
@@ -201,6 +201,19 @@ public class DropDownList : TextField
     }
 
     /// <inheritdoc/>
+    protected override bool OnMouseEvent (Mouse ev)
+    {
+        if (!ReadOnly || !ev.Flags.FastHasFlags (MouseFlags.LeftButtonPressed))
+        {
+            return base.OnMouseEvent (ev);
+        }
+
+        App?.Popovers?.Register (_listPopover);
+
+        return InvokeCommand (Command.Activate) is true;
+    }
+
+    /// <inheritdoc/>
     protected override bool OnHasFocusChanging (bool currentHasFocus, bool newHasFocus, View? currentFocused, View? newFocused)
     {
         if (base.OnHasFocusChanging (currentHasFocus, newHasFocus, currentFocused, newFocused))
@@ -304,18 +317,18 @@ public class DropDownList : TextField
             case VisualRole.ReadOnly when ReadOnly:
 
             case VisualRole.Active when ReadOnly:
-                {
-                    currentAttribute = GetAttributeForRole (HasFocus ? VisualRole.Focus : VisualRole.Normal);
+            {
+                currentAttribute = GetAttributeForRole (HasFocus ? VisualRole.Focus : VisualRole.Normal);
 
-                    return true;
-                }
+                return true;
+            }
 
             case VisualRole.Editable when ReadOnly:
-                {
-                    currentAttribute = GetAttributeForRole (HasFocus ? VisualRole.Focus : VisualRole.Normal);
+            {
+                currentAttribute = GetAttributeForRole (HasFocus ? VisualRole.Focus : VisualRole.Normal);
 
-                    break;
-                }
+                break;
+            }
         }
 
         return false;

--- a/Terminal.Gui/Views/Menu/MenuBar.cs
+++ b/Terminal.Gui/Views/Menu/MenuBar.cs
@@ -309,7 +309,7 @@ public class MenuBar : Menu, IDesignable
                                                           ]) { Id = "Preferences" }
                                   },
                                   new Line (),
-                                  new MenuItem { TargetView = targetView as View, Key = Application.GetDefaultKey (Command.Quit), Command = Command.Quit }
+                                  new MenuItem { TargetView = targetView as View, Command = Command.Quit }
                               ]));
 
         Add (new MenuBarItem ("_Edit",

--- a/Terminal.Gui/Views/ScrollBar/ScrollBar.cs
+++ b/Terminal.Gui/Views/ScrollBar/ScrollBar.cs
@@ -90,6 +90,14 @@ public class ScrollBar : View, IOrientation, IDesignable, IValue<int>
         switch (VisibilityMode)
         {
             case ScrollBarVisibilityMode.Auto:
+                if (VisibleContentSize < 2)
+                {
+                    // Not enough room to show both buttons, so hide the scrollbar
+                    Visible = false;
+
+                    break;
+                }
+
                 // VisibilityMode is the authority. ViewportSettings flags are a
                 // convenience that *sets* VisibilityMode via SyncOneScrollBar; they
                 // should not be re-checked here. When the flag is later removed,

--- a/Terminal.Gui/Views/Shortcut.cs
+++ b/Terminal.Gui/Views/Shortcut.cs
@@ -486,8 +486,6 @@ public class Shortcut : View, IOrientation, IDesignable
         get => _commandView;
         set
         {
-            ArgumentNullException.ThrowIfNull (value);
-
             // Clean up old
             _commandView?.GettingAttributeForRole -= SubViewOnGettingAttributeForRole;
             Remove (_commandView);
@@ -497,15 +495,15 @@ public class Shortcut : View, IOrientation, IDesignable
             _commandView = value;
 
 #if DEBUG
-            if (string.IsNullOrEmpty (_commandView.Id))
+            if (string.IsNullOrEmpty (_commandView?.Id))
             {
-                _commandView.Id = "_commandView";
+                _commandView?.Id = "_commandView";
             }
 #endif
-            _commandView.GettingAttributeForRole += SubViewOnGettingAttributeForRole;
+            _commandView?.GettingAttributeForRole += SubViewOnGettingAttributeForRole;
 
             // If the CommandView has a hotkey, we use that. Otherwise, we use '_' to indicate the hotkey is in the Title.
-            if (_commandView.HotKey != Key.Empty)
+            if (_commandView?.HotKey != Key.Empty)
             {
                 HotKeySpecifier = (Rune)'\xffff';
             }
@@ -513,7 +511,7 @@ public class Shortcut : View, IOrientation, IDesignable
             {
                 HotKeySpecifier = (Rune)'_';
             }
-            Title = _commandView.Text;
+            Title = _commandView?.Text ?? string.Empty;
 
             UpdateKeyBindings (Key.Empty);
             UpdateMouseBindings ();

--- a/Terminal.Gui/Views/Shortcut.cs
+++ b/Terminal.Gui/Views/Shortcut.cs
@@ -129,6 +129,7 @@ public class Shortcut : View, IOrientation, IDesignable
 #if DEBUG
             Id = "CommandView",
 #endif
+            Frame = new (0, 0, 2, 1),
             Width = Dim.Auto (),
             Height = Dim.Fill ()
         };
@@ -208,30 +209,30 @@ public class Shortcut : View, IOrientation, IDesignable
         ShowHide ();
         ForceCalculateNaturalWidth ();
 
-        if (Width.Has<DimAuto> (out _) || HelpView.Margin is null)
+        if (Width.Has<DimAuto> (out _))
         {
             return;
         }
 
         // Frame.Width is smaller than the natural width. Reduce width of HelpView.
-        _maxHelpWidth = int.Max (0, GetContentWidth () - CommandView.Frame.Width - KeyView.Frame.Width);
+        _maxHelpWidth = int.Max (0, GetContentWidth () - (CommandView?.Frame.Width ?? 0) - KeyView.Frame.Width);
 
         if (_maxHelpWidth < 3)
         {
             Thickness t = GetMarginThickness ();
 
             HelpView.Margin.Thickness = _maxHelpWidth switch
-                                         {
-                                             0 or 1 =>
+            {
+                0 or 1 =>
 
-                                                 // Scrunch it by removing both margins
-                                                 new Thickness (t.Right - 1, t.Top, t.Left - 1, t.Bottom),
-                                             2 =>
+                    // Scrunch it by removing both margins
+                    new Thickness (t.Right - 1, t.Top, t.Left - 1, t.Bottom),
+                2 =>
 
-                                                 // Scrunch just the right margin
-                                                 new Thickness (t.Right, t.Top, t.Left - 1, t.Bottom),
-                                             _ => HelpView.Margin.Thickness
-                                         };
+                    // Scrunch just the right margin
+                    new Thickness (t.Right, t.Top, t.Left - 1, t.Bottom),
+                _ => HelpView.Margin.Thickness
+            };
         }
         else
         {
@@ -251,7 +252,7 @@ public class Shortcut : View, IOrientation, IDesignable
     // so Pos.Align works correctly.
     internal void ShowHide ()
     {
-        if (CommandView.Visible)
+        if (CommandView?.Visible == true)
         {
             if (CommandView.SuperView is null)
             {
@@ -261,7 +262,7 @@ public class Shortcut : View, IOrientation, IDesignable
         }
         else
         {
-            if (CommandView.SuperView is { })
+            if (CommandView?.SuperView is { })
             {
                 Remove (CommandView);
             }
@@ -301,7 +302,11 @@ public class Shortcut : View, IOrientation, IDesignable
 
         MoveSubViewToStart (KeyView);
         MoveSubViewToStart (HelpView);
-        MoveSubViewToStart (CommandView);
+
+        if (CommandView is { })
+        {
+            MoveSubViewToStart (CommandView);
+        }
     }
 
     // Force Width to DimAuto to calculate natural width and then set it back
@@ -309,7 +314,7 @@ public class Shortcut : View, IOrientation, IDesignable
     {
         // Get the natural size of each subview
         Size screenSize = App?.Screen.Size ?? new Size (2048, 2048);
-        CommandView.SetRelativeLayout (screenSize);
+        CommandView?.SetRelativeLayout (screenSize);
         HelpView.SetRelativeLayout (screenSize);
         KeyView.SetRelativeLayout (screenSize);
 
@@ -331,7 +336,7 @@ public class Shortcut : View, IOrientation, IDesignable
     ///         <item>Programmatic guard (skip if no binding)</item>
     ///     </list>
     /// </summary>
-    protected override View GetDispatchTarget (ICommandContext? ctx) => CommandView;
+    protected override View? GetDispatchTarget (ICommandContext? ctx) => CommandView;
 
     // ConsumeDispatch defaults to false — CommandView completes its own activation
     // (e.g., CheckBox.OnActivated calls AdvanceCheckState).
@@ -432,7 +437,7 @@ public class Shortcut : View, IOrientation, IDesignable
 
     #region Command
 
-    private View _commandView = new ();
+    private View? _commandView;
 
     /// <summary>
     ///     Gets or sets the View that displays the command text and hotkey.
@@ -476,7 +481,7 @@ public class Shortcut : View, IOrientation, IDesignable
     ///     StatusBar.Add(force16ColorsShortcut);
     /// </code>
     /// </example>
-    public View CommandView
+    public View? CommandView
     {
         get => _commandView;
         set
@@ -484,9 +489,9 @@ public class Shortcut : View, IOrientation, IDesignable
             ArgumentNullException.ThrowIfNull (value);
 
             // Clean up old
-            _commandView.GettingAttributeForRole -= SubViewOnGettingAttributeForRole;
+            _commandView?.GettingAttributeForRole -= SubViewOnGettingAttributeForRole;
             Remove (_commandView);
-            _commandView.Dispose ();
+            _commandView?.Dispose ();
 
             // Set new
             _commandView = value;
@@ -527,7 +532,7 @@ public class Shortcut : View, IOrientation, IDesignable
 
         MouseBindings.Clear ();
 
-        foreach (KeyValuePair<MouseFlags, MouseBinding> mb in CommandView.MouseBindings.GetBindings ())
+        foreach (KeyValuePair<MouseFlags, MouseBinding> mb in CommandView?.MouseBindings.GetBindings () ?? [])
         {
             MouseBindings.Add (mb.Key, mb.Value);
         }
@@ -535,22 +540,19 @@ public class Shortcut : View, IOrientation, IDesignable
 
     private void SetCommandViewDefaultLayout ()
     {
-        if (CommandView.Margin is { })
-        {
-            CommandView.Margin.Thickness = GetMarginThickness ();
+        CommandView?.Margin.Thickness = GetMarginThickness ();
 
-            // Margin must be transparent to mouse, so clicks pass through to Shortcut
-            CommandView.Margin.ViewportSettings |= ViewportSettingsFlags.TransparentMouse;
-        }
+        // Margin must be transparent to mouse, so clicks pass through to Shortcut
+        CommandView?.Margin.ViewportSettings |= ViewportSettingsFlags.TransparentMouse;
 
-        CommandView.X = Pos.Align (Alignment.End, AlignmentModes);
+        CommandView?.X = Pos.Align (Alignment.End, AlignmentModes);
 
-        CommandView.VerticalTextAlignment = Alignment.Center;
-        CommandView.TextAlignment = Alignment.Start;
-        CommandView.TextFormatter.WordWrap = false;
+        CommandView?.VerticalTextAlignment = Alignment.Center;
+        CommandView?.TextAlignment = Alignment.Start;
+        CommandView?.TextFormatter.WordWrap = false;
 
-        CommandView.MouseHighlightStates = MouseState.None;
-        CommandView.GettingAttributeForRole += SubViewOnGettingAttributeForRole;
+        CommandView?.MouseHighlightStates = MouseState.None;
+        CommandView?.GettingAttributeForRole += SubViewOnGettingAttributeForRole;
     }
 
     private void SubViewOnGettingAttributeForRole (object? sender, VisualRoleEventArgs e)
@@ -607,7 +609,7 @@ public class Shortcut : View, IOrientation, IDesignable
         // If the Title changes, update the CommandView Text.
         // This is a helper to make it easier to set the CommandView text.
         // CommandView is public and replaceable, but this is a convenience.
-        _commandView.Text = Title;
+        _commandView?.Text = Title;
 
     /// <summary>
     ///     Gets or sets the target <see cref="View"/> that the <see cref="Command"/> will be invoked on
@@ -654,17 +656,14 @@ public class Shortcut : View, IOrientation, IDesignable
     /// <summary>
     ///     The subview that displays the help text for the command. Internal for unit testing.
     /// </summary>
-    public View HelpView { get; } = new () { /*ViewportSettings = ViewportSettingsFlags.TransparentMouse*/ };
+    public View HelpView { get; } = new () { Frame = new Rectangle (0, 0, 2, 1) };
 
     private void SetHelpViewDefaultLayout ()
     {
-        if (HelpView.Margin is { })
-        {
-            HelpView.Margin.Thickness = GetMarginThickness ();
+        HelpView.Margin.Thickness = GetMarginThickness ();
 
-            // Margin must be transparent to mouse, so clicks pass through to Shortcut
-            HelpView.Margin.ViewportSettings |= ViewportSettingsFlags.TransparentMouse;
-        }
+        // Margin must be transparent to mouse, so clicks pass through to Shortcut
+        HelpView.Margin.ViewportSettings |= ViewportSettingsFlags.TransparentMouse;
 
         HelpView.X = Pos.Align (Alignment.End, AlignmentModes);
         _maxHelpWidth = HelpView.Text.GetColumns ();
@@ -760,7 +759,7 @@ public class Shortcut : View, IOrientation, IDesignable
     ///     Gets the subview that displays the key. Is drawn with Normal and HotNormal colors reversed.
     /// </summary>
 
-    public View KeyView { get; } = new () { /*ViewportSettings = ViewportSettingsFlags.TransparentMouse*/ };
+    public View KeyView { get; } = new () { Frame = new Rectangle (0, 0, 2, 1) };
 
     /// <summary>
     ///     Gets or sets the minimum size of the key text. Useful for aligning the key text with other <see cref="Shortcut"/>s.
@@ -782,13 +781,10 @@ public class Shortcut : View, IOrientation, IDesignable
 
     private void SetKeyViewDefaultLayout ()
     {
-        if (KeyView.Margin is { })
-        {
-            KeyView.Margin.Thickness = GetMarginThickness ();
+        KeyView.Margin.Thickness = GetMarginThickness ();
 
-            // Margin must be transparent to mouse, so clicks pass through to Shortcut
-            KeyView.Margin.ViewportSettings |= ViewportSettingsFlags.TransparentMouse;
-        }
+        // Margin must be transparent to mouse, so clicks pass through to Shortcut
+        KeyView.Margin.ViewportSettings |= ViewportSettingsFlags.TransparentMouse;
 
         KeyView.X = Pos.Align (Alignment.End, AlignmentModes);
         KeyView.Width = Dim.Auto (DimAutoStyle.Text, Dim.Func (_ => MinimumKeyTextSize));
@@ -883,9 +879,10 @@ public class Shortcut : View, IOrientation, IDesignable
         {
             TitleChanged -= Shortcut_TitleChanged;
 
-            if (CommandView.SuperView is null)
+            if (CommandView?.SuperView is null)
             {
-                CommandView.Dispose ();
+                CommandView?.Dispose ();
+                CommandView = null;
             }
 
             if (HelpView.SuperView is null)

--- a/Terminal.Gui/Views/Shortcut.cs
+++ b/Terminal.Gui/Views/Shortcut.cs
@@ -877,10 +877,10 @@ public class Shortcut : View, IOrientation, IDesignable
         {
             TitleChanged -= Shortcut_TitleChanged;
 
-            if (CommandView?.SuperView is null)
+            if (_commandView?.SuperView is null)
             {
-                CommandView?.Dispose ();
-                CommandView = null;
+                _commandView?.Dispose ();
+                _commandView = null;
             }
 
             if (HelpView.SuperView is null)

--- a/Tests/UnitTestsParallelizable/ViewBase/Layout/ViewportTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/Layout/ViewportTests.cs
@@ -227,7 +227,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         // Arrange
         var view = new View ();
-        view.SetContentSize (new (100, 100));
+        view.SetContentSize (new Size (100, 100));
         var newViewport = new Rectangle (0, 0, 200, 200);
         view.ViewportSettings = ViewportSettingsFlags.AllowLocationGreaterThanContentSize;
 
@@ -276,7 +276,7 @@ public class ViewportTests (ITestOutputHelper output)
         View view = new () { X = 1, Y = 1, Width = 10, Height = 10 };
         view.BeginInit ();
         view.EndInit ();
-        view.Margin.Thickness = new (adornmentThickness);
+        view.Margin.Thickness = new Thickness (adornmentThickness);
 
         Assert.Equal (expectedOffset, view.GetViewportOffsetFromFrame ().X);
     }
@@ -303,7 +303,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         View view = new () { Width = 1, Height = 1 };
         view.SetContentSize (new Size (5, 5));
-        view.Viewport = new (0, 0, 10, 10);
+        view.Viewport = new Rectangle (0, 0, 10, 10);
         view.ContentSizeTracksViewport = true;
         Assert.Equal (view.Viewport.Size, view.GetContentSize ());
     }
@@ -313,7 +313,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         View view = new () { Width = 1, Height = 1 };
         view.SetContentSize (new Size (5, 5));
-        view.Viewport = new (0, 0, 10, 10);
+        view.Viewport = new Rectangle (0, 0, 10, 10);
         view.ContentSizeTracksViewport = false;
         Assert.NotEqual (view.Viewport.Size, view.GetContentSize ());
     }
@@ -323,7 +323,7 @@ public class ViewportTests (ITestOutputHelper output)
         public int OnViewportChangedCallCount { get; private set; }
         public int ViewportChangedEventCallCount { get; private set; }
 
-        public TestViewportEventsView () => ViewportChanged += (sender, args) => ViewportChangedEventCallCount++;
+        public TestViewportEventsView () => ViewportChanged += (_, _) => ViewportChangedEventCallCount++;
 
         protected override void OnViewportChanged (DrawEventArgs e)
         {
@@ -409,7 +409,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         // Arrange - View with content that fits exactly in viewport
         var view = new View { Width = 10, Height = 10 };
-        view.SetContentSize (new (20, 20)); // Content larger than viewport
+        view.SetContentSize (new Size (20, 20)); // Content larger than viewport
         view.Layout ();
 
         // Act - Try to set viewport X such that X + Width > ContentSize.Width
@@ -425,7 +425,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         // Arrange - View with content that fits exactly in viewport
         var view = new View { Width = 10, Height = 10 };
-        view.SetContentSize (new (20, 20)); // Content larger than viewport
+        view.SetContentSize (new Size (20, 20)); // Content larger than viewport
         view.Layout ();
 
         // Act - Try to set viewport Y such that Y + Height > ContentSize.Height
@@ -441,7 +441,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         // Arrange
         var view = new View { Width = 10, Height = 10, ViewportSettings = ViewportSettingsFlags.AllowXPlusWidthGreaterThanContentWidth };
-        view.SetContentSize (new (20, 20));
+        view.SetContentSize (new Size (20, 20));
         view.Layout ();
 
         // Act - Set viewport X such that X + Width > ContentSize.Width
@@ -456,7 +456,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         // Arrange
         var view = new View { Width = 10, Height = 10, ViewportSettings = ViewportSettingsFlags.AllowYPlusHeightGreaterThanContentHeight };
-        view.SetContentSize (new (20, 20));
+        view.SetContentSize (new Size (20, 20));
         view.Layout ();
 
         // Act - Set viewport Y such that Y + Height > ContentSize.Height
@@ -471,7 +471,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         // Arrange
         var view = new View { Width = 10, Height = 10, ViewportSettings = ViewportSettingsFlags.AllowLocationPlusSizeGreaterThanContentSize };
-        view.SetContentSize (new (20, 20));
+        view.SetContentSize (new Size (20, 20));
         view.Layout ();
 
         // Act - Set viewport location such that X + Width and Y + Height exceed content size
@@ -491,7 +491,7 @@ public class ViewportTests (ITestOutputHelper output)
 
         // ContentSize = Viewport.Size = 10x10
 
-        // Act - Try to set positive viewport X 
+        // Act - Try to set positive viewport X
         // X=1, Width=10, ContentSize.Width=10 -> 1+10=11 > 10, should clamp to X=0
         view.Viewport = view.Viewport with { X = 1 };
 
@@ -525,7 +525,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         // Arrange - ContentSize larger than Viewport
         var view = new View { Width = 10, Height = 10 };
-        view.SetContentSize (new (20, 20)); // ContentSize.Width = 20, Viewport.Width = 10
+        view.SetContentSize (new Size (20, 20)); // ContentSize.Width = 20, Viewport.Width = 10
         view.Layout ();
 
         // Act
@@ -544,7 +544,7 @@ public class ViewportTests (ITestOutputHelper output)
     {
         // Arrange - ContentSize larger than Viewport
         var view = new View { Width = 10, Height = 10 };
-        view.SetContentSize (new (20, 20)); // ContentSize.Height = 20, Viewport.Height = 10
+        view.SetContentSize (new Size (20, 20)); // ContentSize.Height = 20, Viewport.Height = 10
         view.Layout ();
 
         // Act
@@ -552,6 +552,141 @@ public class ViewportTests (ITestOutputHelper output)
 
         // Assert - Max valid Y is ContentSize.Height - Viewport.Height = 20 - 10 = 10
         Assert.Equal (expectedY, view.Viewport.Y);
+    }
+
+    #endregion
+
+    #region SetViewport should not grow Frame when adornments consume entire Viewport (Issue #5043)
+
+    [Theory]
+    [InlineData (0, 1, 0)] // Padding right=1 → Horizontal=1, Frame.Width=0, Viewport.Width=0
+    [InlineData (1, 1, 0)] // Padding right=1 → Horizontal=1, Frame.Width=1, Viewport.Width=0
+    [InlineData (2, 1, 1)] // Padding right=1 → Horizontal=1, Frame.Width=2, Viewport.Width=1
+    [InlineData (2, 2, 0)] // Padding right=2 → Horizontal=2, Frame.Width=2, Viewport.Width=0
+    [InlineData (3, 2, 1)] // Padding right=2 → Horizontal=2, Frame.Width=3, Viewport.Width=1
+    [InlineData (2, 3, 0)] // Padding right=3 → Horizontal=3, Frame.Width=2, Viewport.Width=0
+    public void Set_Viewport_DoesNotGrowFrame_WhenPaddingThicknessConsumesViewport (int frameSize, int paddingRight, int expectedViewportWidth)
+    {
+        // Arrange - simulate scrollbar adding padding (right/bottom) that consumes the Viewport
+        var view = new View { Frame = new Rectangle (0, 0, frameSize, frameSize) };
+        view.Padding.Thickness = new Thickness (0, 0, paddingRight, paddingRight);
+
+        Rectangle originalFrame = view.Frame;
+
+        // Sanity: verify Viewport is as expected
+        Assert.Equal (expectedViewportWidth, view.Viewport.Width);
+        Assert.Equal (expectedViewportWidth, view.Viewport.Height);
+
+        // Act - setting Viewport to its current value should be a no-op
+        view.Viewport = view.Viewport;
+
+        // Assert - Frame must not have grown
+        Assert.Equal (originalFrame, view.Frame);
+    }
+
+    [Theory]
+    [InlineData (0, 1)] // Border=1 → Horizontal=2, Frame.Width=0, Viewport.Width=0
+    [InlineData (1, 1)] // Border=1 → Horizontal=2, Frame.Width=1, Viewport.Width=0
+    [InlineData (2, 1)] // Border=1 → Horizontal=2, Frame.Width=2, Viewport.Width=0
+    [InlineData (3, 1)] // Border=1 → Horizontal=2, Frame.Width=3, Viewport.Width=1
+    [InlineData (4, 2)] // Border=2 → Horizontal=4, Frame.Width=4, Viewport.Width=0
+    public void Set_Viewport_DoesNotGrowFrame_WhenBorderThicknessConsumesViewport (int frameSize, int borderThickness)
+    {
+        // Arrange
+        var view = new View { Frame = new Rectangle (0, 0, frameSize, frameSize) };
+        view.Border.Thickness = new Thickness (borderThickness);
+
+        Rectangle originalFrame = view.Frame;
+        int expectedViewportW = Math.Max (0, frameSize - borderThickness * 2);
+
+        // Sanity
+        Assert.Equal (expectedViewportW, view.Viewport.Width);
+
+        // Act
+        view.Viewport = view.Viewport;
+
+        // Assert
+        Assert.Equal (originalFrame, view.Frame);
+    }
+
+    [Theory]
+    [InlineData (0, 1)] // Margin=1 → Horizontal=2, Frame.Width=0, Viewport.Width=0
+    [InlineData (1, 1)] // Margin=1 → Horizontal=2, Frame.Width=1, Viewport.Width=0
+    [InlineData (2, 1)] // Margin=1 → Horizontal=2, Frame.Width=2, Viewport.Width=0
+    [InlineData (3, 1)] // Margin=1 → Horizontal=2, Frame.Width=3, Viewport.Width=1
+    public void Set_Viewport_DoesNotGrowFrame_WhenMarginThicknessConsumesViewport (int frameSize, int marginThickness)
+    {
+        // Arrange
+        var view = new View { Frame = new Rectangle (0, 0, frameSize, frameSize) };
+        view.Margin.Thickness = new Thickness (marginThickness);
+
+        Rectangle originalFrame = view.Frame;
+        int expectedViewportW = Math.Max (0, frameSize - marginThickness * 2);
+
+        // Sanity
+        Assert.Equal (expectedViewportW, view.Viewport.Width);
+
+        // Act
+        view.Viewport = view.Viewport;
+
+        // Assert
+        Assert.Equal (originalFrame, view.Frame);
+    }
+
+    [Theory]
+    [InlineData (4, 1, 1, 1)] // All adornments = 1 → total Horizontal=6 > Frame.Width=4 → Viewport.Width=0
+    [InlineData (6, 1, 1, 1)] // All = 1 → Horizontal=6, Frame.Width=6, Viewport.Width=0
+    [InlineData (7, 1, 1, 1)] // All = 1 → Horizontal=6, Frame.Width=7, Viewport.Width=1
+    [InlineData (3, 1, 0, 1)] // Margin=1, Padding=1 → Horizontal=4 > Frame.Width=3 → Viewport.Width=0
+    [InlineData (4, 1, 0, 1)] // Margin=1, Padding=1 → Horizontal=4, Frame.Width=4, Viewport.Width=0
+    [InlineData (5, 1, 0, 1)] // Margin=1, Padding=1 → Horizontal=4, Frame.Width=5, Viewport.Width=1
+    public void Set_Viewport_DoesNotGrowFrame_WhenCombinedAdornmentsConsumeViewport (int frameSize,
+                                                                                     int marginThickness,
+                                                                                     int borderThickness,
+                                                                                     int paddingThickness)
+    {
+        // Arrange
+        var view = new View { Frame = new Rectangle (0, 0, frameSize, frameSize) };
+        view.Margin.Thickness = new Thickness (marginThickness);
+        view.Border.Thickness = new Thickness (borderThickness);
+        view.Padding.Thickness = new Thickness (paddingThickness);
+
+        Rectangle originalFrame = view.Frame;
+        int totalThickness = (marginThickness + borderThickness + paddingThickness) * 2;
+        int expectedViewportW = Math.Max (0, frameSize - totalThickness);
+
+        // Sanity
+        Assert.Equal (expectedViewportW, view.Viewport.Width);
+
+        // Act
+        view.Viewport = view.Viewport;
+
+        // Assert
+        Assert.Equal (originalFrame, view.Frame);
+    }
+
+    [Theory]
+    [InlineData (2, 0, 0, 1, 0)] // Padding bottom=1, Frame.Height=2 → Viewport.Height=1, Viewport.Width=2 (only vertical affected)
+    [InlineData (2, 0, 0, 0, 1)] // Padding right=1, Frame.Width=2 → Viewport.Width=1, Viewport.Height=2 (only horizontal affected)
+    [InlineData (1, 0, 0, 1, 0)] // Padding bottom=1, Frame.Height=1 → Viewport.Height=0 (vertical consumed)
+    [InlineData (1, 0, 0, 0, 1)] // Padding right=1, Frame.Width=1 → Viewport.Width=0 (horizontal consumed)
+    public void Set_Viewport_DoesNotGrowFrame_WhenAsymmetricPaddingConsumesOneDimension (int frameSize,
+                                                                                         int paddingLeft,
+                                                                                         int paddingTop,
+                                                                                         int paddingBottom,
+                                                                                         int paddingRight)
+    {
+        // Arrange - simulates scrollbar adding thickness in only one direction
+        var view = new View { Frame = new Rectangle (0, 0, frameSize, frameSize) };
+        view.Padding.Thickness = new Thickness (paddingLeft, paddingTop, paddingRight, paddingBottom);
+
+        Rectangle originalFrame = view.Frame;
+
+        // Act
+        view.Viewport = view.Viewport;
+
+        // Assert
+        Assert.Equal (originalFrame, view.Frame);
     }
 
     #endregion

--- a/Tests/UnitTestsParallelizable/Views/EnableForDesignEventTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/EnableForDesignEventTests.cs
@@ -77,7 +77,7 @@ public class EnableForDesignEventTests
         // Find the Shortcut that has a CheckBox CommandView
         Shortcut checkBoxShortcut = bar.SubViews.OfType<Shortcut> ()
                                        .First (s => s.CommandView is CheckBox);
-        CheckBox checkBox = (CheckBox)checkBoxShortcut.CommandView;
+        CheckBox checkBox = (CheckBox)checkBoxShortcut.CommandView!;
 
         Assert.Equal (CheckState.UnChecked, checkBox.Value);
 

--- a/Tests/UnitTestsParallelizable/Views/ShortcutTests.KeyDown.cs
+++ b/Tests/UnitTestsParallelizable/Views/ShortcutTests.KeyDown.cs
@@ -245,7 +245,7 @@ public partial class ShortcutTests
         // The default CommandView does not have a HotKey, so only the Shortcut's Key should trigger activation, not the CommandView's HotKey
         Assert.Equal (Key.A, shortcut.Key);
         Assert.Equal (Key.C, shortcut.HotKey);
-        Assert.Equal (Key.Empty, shortcut.CommandView.HotKey);
+        Assert.Equal (Key.Empty, shortcut.CommandView?.HotKey);
 
         runnable.Add (shortcut);
 
@@ -290,7 +290,7 @@ public partial class ShortcutTests
 
         // Verify layout created gaps
         Assert.True (shortcut.Frame.Width >= 40, "Shortcut should be wide enough for gaps");
-        Assert.True (shortcut.CommandView.Frame.Width > 0, "CommandView should be visible");
+        Assert.True (shortcut.CommandView?.Frame.Width > 0, "CommandView should be visible");
         Assert.True (shortcut.HelpView.Frame.Width > 0, "HelpView should be visible");
         Assert.True (shortcut.KeyView.Frame.Width > 0, "KeyView should be visible");
 
@@ -334,7 +334,7 @@ public partial class ShortcutTests
 
         // Verify layout created gaps
         Assert.True (shortcut.Frame.Width >= 40, "Shortcut should be wide enough for gaps");
-        Assert.True (shortcut.CommandView.Frame.Width > 0, "CommandView should be visible");
+        Assert.True (shortcut.CommandView?.Frame.Width > 0, "CommandView should be visible");
         Assert.True (shortcut.HelpView.Frame.Width > 0, "HelpView should be visible");
         Assert.True (shortcut.KeyView.Frame.Width > 0, "KeyView should be visible");
 
@@ -378,7 +378,7 @@ public partial class ShortcutTests
 
         // Verify layout created gaps
         Assert.True (shortcut.Frame.Width >= 40, "Shortcut should be wide enough for gaps");
-        Assert.True (shortcut.CommandView.Frame.Width > 0, "CommandView should be visible");
+        Assert.True (shortcut.CommandView?.Frame.Width > 0, "CommandView should be visible");
         Assert.True (shortcut.HelpView.Frame.Width > 0, "HelpView should be visible");
         Assert.True (shortcut.KeyView.Frame.Width > 0, "KeyView should be visible");
 
@@ -426,7 +426,7 @@ public partial class ShortcutTests
 
         // Verify layout created gaps
         Assert.True (shortcut.Frame.Width >= 40, "Shortcut should be wide enough for gaps");
-        Assert.True (shortcut.CommandView.Frame.Width > 0, "CommandView should be visible");
+        Assert.True (shortcut.CommandView?.Frame.Width > 0, "CommandView should be visible");
         Assert.True (shortcut.HelpView.Frame.Width > 0, "HelpView should be visible");
         Assert.True (shortcut.KeyView.Frame.Width > 0, "KeyView should be visible");
 

--- a/Tests/UnitTestsParallelizable/Views/ShortcutTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ShortcutTests.cs
@@ -54,7 +54,7 @@ public partial class ShortcutTests (ITestOutputHelper output)
 
         // CanFocus defaults
         Assert.True (shortcut.CanFocus);
-        Assert.False (shortcut.CommandView.CanFocus);
+        Assert.False (shortcut.CommandView?.CanFocus);
 
         // Dimension defaults
         Assert.IsType<DimAuto> (shortcut.Width);
@@ -77,7 +77,7 @@ public partial class ShortcutTests (ITestOutputHelper output)
         // CommandView defaults
         Assert.NotNull (shortcut.CommandView);
 #if DEBUG
-        Assert.Equal ("CommandView", shortcut.CommandView.Id);
+        Assert.Equal ("CommandView", shortcut.CommandView?.Id);
 #endif
 
         // HelpView defaults
@@ -122,7 +122,7 @@ public partial class ShortcutTests (ITestOutputHelper output)
         Assert.False (shortcut1.BindKeyToApplication);
         Assert.Equal (Orientation.Horizontal, shortcut1.Orientation);
         Assert.Equal (AlignmentModes.StartToEnd | AlignmentModes.IgnoreFirstOrLast, shortcut1.AlignmentModes);
-        Assert.Equal ("_CommandText", shortcut1.CommandView.Text); // Title syncs to CommandView.Text
+        Assert.Equal ("_CommandText", shortcut1.CommandView?.Text); // Title syncs to CommandView?.Text
         Assert.Equal (MouseState.In, shortcut1.MouseHighlightStates);
 
         // SubViews - All three should be present with values set
@@ -145,14 +145,14 @@ public partial class ShortcutTests (ITestOutputHelper output)
         Assert.Equal (2, shortcut.Viewport.Width);
         Assert.Equal (1, shortcut.Viewport.Height);
 
-        Assert.Equal (0, shortcut.CommandView.Viewport.Width);
-        Assert.Equal (1, shortcut.CommandView.Viewport.Height);
+        Assert.Equal (0, shortcut.CommandView?.Viewport.Width);
+        Assert.Equal (1, shortcut.CommandView?.Viewport.Height);
 
-        Assert.Equal (0, shortcut.HelpView.Viewport.Width);
-        Assert.Equal (0, shortcut.HelpView.Viewport.Height);
+        Assert.Equal (2, shortcut.HelpView.Viewport.Width);
+        Assert.Equal (1, shortcut.HelpView.Viewport.Height);
 
-        Assert.Equal (0, shortcut.KeyView.Viewport.Width);
-        Assert.Equal (0, shortcut.KeyView.Viewport.Height);
+        Assert.Equal (2, shortcut.KeyView.Viewport.Width);
+        Assert.Equal (1, shortcut.KeyView.Viewport.Height);
 
         //  0123456789
         // "   0  A "
@@ -163,8 +163,8 @@ public partial class ShortcutTests (ITestOutputHelper output)
         Assert.Equal (8, shortcut.Viewport.Width);
         Assert.Equal (1, shortcut.Viewport.Height);
 
-        Assert.Equal (0, shortcut.CommandView.Viewport.Width);
-        Assert.Equal (1, shortcut.CommandView.Viewport.Height);
+        Assert.Equal (0, shortcut.CommandView?.Viewport.Width);
+        Assert.Equal (1, shortcut.CommandView?.Viewport.Height);
 
         Assert.Equal (1, shortcut.HelpView.Viewport.Width);
         Assert.Equal (1, shortcut.HelpView.Viewport.Height);
@@ -181,8 +181,8 @@ public partial class ShortcutTests (ITestOutputHelper output)
         Assert.Equal (9, shortcut.Viewport.Width);
         Assert.Equal (1, shortcut.Viewport.Height);
 
-        Assert.Equal (1, shortcut.CommandView.Viewport.Width);
-        Assert.Equal (1, shortcut.CommandView.Viewport.Height);
+        Assert.Equal (1, shortcut.CommandView?.Viewport.Width);
+        Assert.Equal (1, shortcut.CommandView?.Viewport.Height);
 
         Assert.Equal (1, shortcut.HelpView.Viewport.Width);
         Assert.Equal (1, shortcut.HelpView.Viewport.Height);
@@ -261,7 +261,7 @@ public partial class ShortcutTests (ITestOutputHelper output)
 
         // 0123456789
         // -C--H--K-
-        Assert.Equal (expectedCmdX, shortcut.CommandView.Frame.X);
+        Assert.Equal (expectedCmdX, shortcut.CommandView?.Frame.X);
         Assert.Equal (expectedHelpX, shortcut.HelpView.Frame.X);
         Assert.Equal (expectedKeyX, shortcut.KeyView.Frame.X);
     }
@@ -271,19 +271,19 @@ public partial class ShortcutTests (ITestOutputHelper output)
     {
         var shortcut = new Shortcut { Title = "T" };
 
-        Assert.Equal (shortcut.Title, shortcut.CommandView.Text);
+        Assert.Equal (shortcut.Title, shortcut.CommandView?.Text);
 
         shortcut = new Shortcut ();
 
         shortcut.CommandView = new View { Text = "T" };
-        Assert.Equal (shortcut.Title, shortcut.CommandView.Text);
+        Assert.Equal (shortcut.Title, shortcut.CommandView?.Text);
     }
 
     [Fact]
     public void HotKey_Title_Initializer_SetsCorrectly ()
     {
         Shortcut shortcut = new () { Title = "_C" };
-        Assert.Equal (Key.Empty, shortcut.CommandView.HotKey);
+        Assert.Equal (Key.Empty, shortcut.CommandView?.HotKey);
         Assert.Equal (Key.C, shortcut.HotKey);
     }
 
@@ -293,15 +293,15 @@ public partial class ShortcutTests (ITestOutputHelper output)
         Shortcut shortcut = new () { Title = "_C" };
 
         shortcut.CommandView = new View { HotKeySpecifier = (Rune)'_', Text = "_D" };
-        Assert.Equal (Key.Empty, shortcut.CommandView.HotKey);
+        Assert.Equal (Key.Empty, shortcut.CommandView?.HotKey);
         Assert.Equal (Key.D, shortcut.HotKey);
 
         shortcut = new Shortcut { Title = "_C", CommandView = new View { HotKeySpecifier = (Rune)'_', Text = "_D" } };
-        Assert.Equal (Key.Empty, shortcut.CommandView.HotKey);
+        Assert.Equal (Key.Empty, shortcut.CommandView?.HotKey);
         Assert.Equal (Key.D, shortcut.HotKey);
 
         shortcut = new Shortcut { CommandView = new View { HotKeySpecifier = (Rune)'_', Text = "_D" }, Title = "_C" };
-        Assert.Equal (Key.Empty, shortcut.CommandView.HotKey);
+        Assert.Equal (Key.Empty, shortcut.CommandView?.HotKey);
         Assert.Equal (Key.C, shortcut.HotKey);
     }
 
@@ -456,7 +456,7 @@ public partial class ShortcutTests (ITestOutputHelper output)
     {
         Shortcut shortcut = new ();
 
-        Assert.True (shortcut.CommandView.Visible);
+        Assert.True (shortcut.CommandView?.Visible);
         Assert.Contains (shortcut.CommandView, shortcut.SubViews);
         Assert.True (shortcut.HelpView.Visible);
         Assert.DoesNotContain (shortcut.HelpView, shortcut.SubViews);
@@ -498,7 +498,7 @@ public partial class ShortcutTests (ITestOutputHelper output)
         shortcut.Text = "Help";
         shortcut.Title = "Command";
         Assert.True (shortcut.CanFocus);
-        Assert.False (shortcut.CommandView.CanFocus);
+        Assert.False (shortcut.CommandView?.CanFocus);
     }
 
     [Fact]
@@ -506,25 +506,25 @@ public partial class ShortcutTests (ITestOutputHelper output)
     {
         Shortcut shortcut = new ();
         Assert.True (shortcut.CanFocus);
-        Assert.False (shortcut.CommandView.CanFocus);
+        Assert.False (shortcut.CommandView?.CanFocus);
 
         shortcut.CommandView = new View { CanFocus = true };
-        Assert.True (shortcut.CommandView.CanFocus);
+        Assert.True (shortcut.CommandView?.CanFocus);
 
-        shortcut.CommandView.CanFocus = true;
-        Assert.True (shortcut.CommandView.CanFocus);
+        shortcut.CommandView?.CanFocus = true;
+        Assert.True (shortcut.CommandView?.CanFocus);
 
         shortcut.CanFocus = false;
         Assert.False (shortcut.CanFocus);
-        Assert.True (shortcut.CommandView.CanFocus);
+        Assert.True (shortcut.CommandView?.CanFocus);
 
-        shortcut.CommandView.CanFocus = false;
+        shortcut.CommandView?.CanFocus = false;
         Assert.False (shortcut.CanFocus);
-        Assert.False (shortcut.CommandView.CanFocus);
+        Assert.False (shortcut.CommandView?.CanFocus);
 
-        shortcut.CommandView.CanFocus = true;
+        shortcut.CommandView?.CanFocus = true;
         Assert.False (shortcut.CanFocus);
-        Assert.True (shortcut.CommandView.CanFocus);
+        Assert.True (shortcut.CommandView?.CanFocus);
     }
 
     // Claude - Opus 4.5


### PR DESCRIPTION
## Fixes

- Fixes #5043
- Fixes #5046 

## Pull request overview

This PR targets issue #5043 by preventing built-in scrollbars from becoming visible when there isn’t enough space to render them without consuming the entire content area, and by addressing a `Viewport`/adornment interaction that could incorrectly grow `Frame` when re-applying the current `Viewport`.

**Changes:**
- Add scrollbar visibility guards (and a minimum-size rule) so scrollbars only show when they can fit.
- Adjust `View.SetViewport` behavior and add viewport/adornment regression tests for the “adornments consume viewport” scenario.
- Update `Shortcut`/Menu example and unit test code to accommodate the behavior changes.

