### PR TITLE
Fixes #5057. Pressing `Alt-T` in a `TextField` causes a `t` to be entered

### DIFF
--- a/Terminal.Gui/Drivers/AnsiHandling/KittyKeyboardPattern.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/KittyKeyboardPattern.cs
@@ -128,7 +128,17 @@ public class KittyKeyboardPattern : AnsiKeyboardParserPattern
             (key, modifierField) = NormalizeShiftedPrintableKey (key, modifierField);
         }
 
-        return string.IsNullOrEmpty (modifierField) ? key : ApplyModifiersAndEventType (modifierField, key);
+        if (!string.IsNullOrEmpty (modifierField))
+        {
+            key = ApplyModifiersAndEventType (modifierField, key);
+        }
+
+        if ((key.IsAlt || key.IsCtrl) && !string.IsNullOrEmpty (key.AssociatedText))
+        {
+            key = new Key (key) { AssociatedText = string.Empty };
+        }
+
+        return key;
     }
 
     private static string ParseAssociatedText (string textField)

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
@@ -500,6 +500,19 @@ public class KittyKeyboardParsingTests
     }
 
     [Fact]
+    public void KittyPattern_AssociatedText_AltModifiedPrintableKey_IsSuppressed ()
+    {
+        // ESC[116;3;116u = Alt+t with associated text 't'
+        Key? key = _pattern.GetKey ("\u001b[116;3;116u");
+
+        Assert.NotNull (key);
+        Assert.True (key.IsAlt);
+        Assert.Equal (Key.T.WithAlt.KeyCode, key.KeyCode);
+        Assert.Equal (string.Empty, key.AssociatedText);
+        Assert.Equal (string.Empty, key.GetPrintableText ());
+    }
+
+    [Fact]
     public void KittyPattern_AssociatedText_MultipleCodePoints ()
     {
         // ESC[97;1;769:97u = associated text composed of combining acute accent + 'a'

--- a/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
@@ -356,6 +356,25 @@ public class TextFieldTests (ITestOutputHelper output) : TestDriverBase
     }
 
     [Fact]
+    public void KittyAltModifiedPrintableKey_DoesNotInsertAssociatedText ()
+    {
+        Runnable top = new ();
+        TextField tf = new () { Width = 10 };
+        top.Add (tf);
+        tf.SetFocus ();
+        tf.ClearAllSelection ();
+        tf.InsertionPoint = 0;
+
+        Key? key = new KittyKeyboardPattern ().GetKey ("\u001b[116;3;116u");
+
+        Assert.NotNull (key);
+        Assert.False (top.NewKeyDownEvent (key));
+        Assert.Equal (string.Empty, tf.Text);
+
+        top.Dispose ();
+    }
+
+    [Fact]
     public void ShiftedDigitKey_WithoutKittyMetadata_InsertsBaseDigit ()
     {
         Runnable top = new ();


### PR DESCRIPTION
## Fixes

- Fixes #5057

## Proposed Changes/Todos

- [x] Invalidade AssociatedKey if Ctrl or Alt exist

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
