### PR TITLE
Fixes #5065. Pressing Shift-Alt-T in a TextField causes a t to be entered

### DIFF
--- a/Terminal.Gui/Drivers/AnsiHandling/KittyKeyboardPattern.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/KittyKeyboardPattern.cs
@@ -201,10 +201,9 @@ public class KittyKeyboardPattern : AnsiKeyboardParserPattern
         }
 
         int explicitModifiers = encodedModifiers - 1;
-        int explicitKeyboardModifiers = explicitModifiers & 0b111;
         bool isRelease = parts.Length > 1 && parts [1] == "3";
 
-        if (explicitKeyboardModifiers != 0 || isRelease)
+        if (isRelease)
         {
             return modifierField;
         }

--- a/Terminal.Gui/Drivers/AnsiHandling/KittyKeyboardPattern.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/KittyKeyboardPattern.cs
@@ -193,6 +193,9 @@ public class KittyKeyboardPattern : AnsiKeyboardParserPattern
 
         string [] parts = modifierField.Split (':');
 
+        // Check for release event BEFORE parsing modifiers, to handle case where modifierField is just the event type
+        bool isRelease = parts.Length > 1 && parts [1] == "3";
+
         if (!int.TryParse (parts [0], CultureInfo.InvariantCulture, out int encodedModifiers) || encodedModifiers < 1)
         {
             parts [0] = implicitEncodedModifiers.ToString (CultureInfo.InvariantCulture);
@@ -200,16 +203,25 @@ public class KittyKeyboardPattern : AnsiKeyboardParserPattern
             return string.Join (':', parts);
         }
 
-        int explicitModifiers = encodedModifiers - 1;
-        bool isRelease = parts.Length > 1 && parts [1] == "3";
-
+        // If it's a release event, preserve the event type and don't try to merge implicit modifiers
         if (isRelease)
         {
-            return modifierField;
+            // For release events of modifier-only keys, ensure explicit modifiers are correct
+            int explicitModifiers = encodedModifiers - 1;
+            int implicitModifiers = implicitEncodedModifiers - 1;
+
+            // Only merge modifiers if the explicit modifiers don't already match the implicit ones
+            if (explicitModifiers != implicitModifiers)
+            {
+                parts [0] = ((explicitModifiers | implicitModifiers) + 1).ToString (CultureInfo.InvariantCulture);
+            }
+
+            return string.Join (':', parts);
         }
 
-        int implicitModifiers = implicitEncodedModifiers - 1;
-        parts [0] = ((explicitModifiers | implicitModifiers) + 1).ToString (CultureInfo.InvariantCulture);
+        int explicitModifiersPress = encodedModifiers - 1;
+        int implicitModifiersPress = implicitEncodedModifiers - 1;
+        parts [0] = ((explicitModifiersPress | implicitModifiersPress) + 1).ToString (CultureInfo.InvariantCulture);
 
         return string.Join (':', parts);
     }
@@ -266,6 +278,7 @@ public class KittyKeyboardPattern : AnsiKeyboardParserPattern
 
         Key printableKey = new (printableRune.Value)
         {
+            ModifierKey = key.ModifierKey,
             ShiftedKeyCode = key.ShiftedKeyCode,
             BaseLayoutKeyCode = key.BaseLayoutKeyCode,
             AssociatedText = key.AssociatedText

--- a/Terminal.Gui/Drivers/AnsiHandling/KittyKeyboardPattern.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/KittyKeyboardPattern.cs
@@ -122,6 +122,7 @@ public class KittyKeyboardPattern : AnsiKeyboardParserPattern
         }
 
         string modifierField = match.Groups [4].Value;
+        modifierField = ApplyImplicitModifierState (key, modifierField);
 
         if (!string.IsNullOrEmpty (modifierField))
         {
@@ -168,6 +169,50 @@ public class KittyKeyboardPattern : AnsiKeyboardParserPattern
         }
 
         return builder.ToString ();
+    }
+
+    private static string ApplyImplicitModifierState (Key key, string modifierField)
+    {
+        if (!key.IsModifierOnly)
+        {
+            return modifierField;
+        }
+
+        int implicitEncodedModifiers = key.ModifierKey switch
+        {
+            ModifierKey.Shift or ModifierKey.LeftShift or ModifierKey.RightShift => 2,
+            ModifierKey.Ctrl or ModifierKey.LeftCtrl or ModifierKey.RightCtrl => 5,
+            ModifierKey.Alt or ModifierKey.LeftAlt or ModifierKey.RightAlt or ModifierKey.AltGr => 3,
+            _ => 1
+        };
+
+        if (string.IsNullOrEmpty (modifierField))
+        {
+            return implicitEncodedModifiers.ToString (CultureInfo.InvariantCulture);
+        }
+
+        string [] parts = modifierField.Split (':');
+
+        if (!int.TryParse (parts [0], CultureInfo.InvariantCulture, out int encodedModifiers) || encodedModifiers < 1)
+        {
+            parts [0] = implicitEncodedModifiers.ToString (CultureInfo.InvariantCulture);
+
+            return string.Join (':', parts);
+        }
+
+        int explicitModifiers = encodedModifiers - 1;
+        int explicitKeyboardModifiers = explicitModifiers & 0b111;
+        bool isRelease = parts.Length > 1 && parts [1] == "3";
+
+        if (explicitKeyboardModifiers != 0 || isRelease)
+        {
+            return modifierField;
+        }
+
+        int implicitModifiers = implicitEncodedModifiers - 1;
+        parts [0] = ((explicitModifiers | implicitModifiers) + 1).ToString (CultureInfo.InvariantCulture);
+
+        return string.Join (':', parts);
     }
 
     private static (Key Key, string ModifierField) NormalizeShiftedPrintableKey (Key key, string modifierField)

--- a/Terminal.Gui/Input/Keyboard/Key.cs
+++ b/Terminal.Gui/Input/Keyboard/Key.cs
@@ -210,6 +210,11 @@ public class Key : EventArgs, IEquatable<Key>
                 return GetSingleGraphemeOrEmpty (AssociatedText);
             }
 
+            if (IsAlt || IsCtrl)
+            {
+                return string.Empty;
+            }
+
             if (IsShift && ShiftedKeyCode != KeyCode.Null)
             {
                 Rune shiftedRune = ToRune (ShiftedKeyCode);
@@ -264,6 +269,11 @@ public class Key : EventArgs, IEquatable<Key>
                 Rune associatedRune = enumerator.Current;
 
                 return enumerator.MoveNext () ? default (Rune) : associatedRune;
+            }
+
+            if (IsAlt || IsCtrl)
+            {
+                return default (Rune);
             }
 
             if (IsShift && ShiftedKeyCode != KeyCode.Null)

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
@@ -516,6 +516,24 @@ public class KittyKeyboardParsingTests
     }
 
     [Fact]
+    public void KittyPattern_AssociatedText_ShiftAltModifiedPrintableKey_IsSuppressed ()
+    {
+        // ESC[116:84;4;84u = Shift+Alt+T with shifted key 'T' and associated text 'T'
+        Key? key = _pattern.GetKey ("\u001b[116:84;4;84u");
+
+        Assert.NotNull (key);
+        Assert.True (key.IsShift);
+        Assert.True (key.IsAlt);
+        Assert.Equal (Key.T.WithShift.WithAlt, key);
+        Assert.Equal (Key.T.WithShift.WithAlt.KeyCode, key.KeyCode);
+        Assert.Equal ((KeyCode)'T', key.ShiftedKeyCode);
+        Assert.Equal (string.Empty, key.AssociatedText);
+        Assert.Equal (string.Empty, key.GetPrintableText ());
+        Assert.Equal (string.Empty, key.AsGrapheme);
+        Assert.Equal (0, key.AsRune.Value);
+    }
+
+    [Fact]
     public void KittyPattern_AssociatedText_MultipleCodePoints ()
     {
         // ESC[97;1;769:97u = associated text composed of combining acute accent + 'a'

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
@@ -507,9 +507,12 @@ public class KittyKeyboardParsingTests
 
         Assert.NotNull (key);
         Assert.True (key.IsAlt);
+        Assert.Equal (Key.T.WithAlt, key);
         Assert.Equal (Key.T.WithAlt.KeyCode, key.KeyCode);
         Assert.Equal (string.Empty, key.AssociatedText);
         Assert.Equal (string.Empty, key.GetPrintableText ());
+        Assert.Equal (string.Empty, key.AsGrapheme);
+        Assert.Equal (0, key.AsRune.Value);
     }
 
     [Fact]

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
@@ -133,6 +133,7 @@ public class KittyKeyboardParsingTests
         Assert.NotNull (key);
         Assert.True (key.IsModifierOnly);
         Assert.Equal (ModifierKey.LeftShift, key.ModifierKey);
+        Assert.True (key.IsShift);
     }
 
     [Fact]
@@ -144,6 +145,7 @@ public class KittyKeyboardParsingTests
         Assert.NotNull (key);
         Assert.True (key.IsModifierOnly);
         Assert.Equal (ModifierKey.LeftCtrl, key.ModifierKey);
+        Assert.True (key.IsCtrl);
     }
 
     [Fact]
@@ -155,6 +157,7 @@ public class KittyKeyboardParsingTests
         Assert.NotNull (key);
         Assert.True (key.IsModifierOnly);
         Assert.Equal (ModifierKey.LeftAlt, key.ModifierKey);
+        Assert.True (key.IsAlt);
     }
 
     [Fact]
@@ -287,6 +290,34 @@ public class KittyKeyboardParsingTests
     }
 
     [Fact]
+    public void KittyPattern_LeftCtrl_WithCapsLockModifier_PreservesCtrlState ()
+    {
+        Key? key = _pattern.GetKey ("\u001b[57442;65u");
+
+        Assert.NotNull (key);
+        Assert.True (key.IsModifierOnly);
+        Assert.Equal (ModifierKey.LeftCtrl, key.ModifierKey);
+        Assert.True (key.IsCtrl);
+        Assert.False (key.IsAlt);
+        Assert.False (key.IsShift);
+        Assert.Equal (KeyEventType.Press, key.EventType);
+    }
+
+    [Fact]
+    public void KittyPattern_LeftShift_WithCapsLockModifier_PreservesShiftState ()
+    {
+        Key? key = _pattern.GetKey ("\u001b[57441;65u");
+
+        Assert.NotNull (key);
+        Assert.True (key.IsModifierOnly);
+        Assert.Equal (ModifierKey.LeftShift, key.ModifierKey);
+        Assert.True (key.IsShift);
+        Assert.False (key.IsAlt);
+        Assert.False (key.IsCtrl);
+        Assert.Equal (KeyEventType.Press, key.EventType);
+    }
+
+    [Fact]
     public void KittyPattern_NonModifierKey_IsNotModifierOnly ()
     {
         // ESC[97u = 'a'
@@ -306,6 +337,40 @@ public class KittyKeyboardParsingTests
         Assert.NotNull (key);
         Assert.True (key.IsModifierOnly);
         Assert.Equal (ModifierKey.LeftSuper, key.ModifierKey);
+    }
+
+    [Theory]
+    [InlineData ("\u001b[57358u", ModifierKey.CapsLock, false, false, false)]
+    [InlineData ("\u001b[57359u", ModifierKey.ScrollLock, false, false, false)]
+    [InlineData ("\u001b[57360u", ModifierKey.NumLock, false, false, false)]
+    [InlineData ("\u001b[57441u", ModifierKey.LeftShift, true, false, false)]
+    [InlineData ("\u001b[57442u", ModifierKey.LeftCtrl, false, false, true)]
+    [InlineData ("\u001b[57443u", ModifierKey.LeftAlt, false, true, false)]
+    [InlineData ("\u001b[57444u", ModifierKey.LeftSuper, false, false, false)]
+    [InlineData ("\u001b[57445u", ModifierKey.LeftHyper, false, false, false)]
+    [InlineData ("\u001b[57447u", ModifierKey.RightShift, true, false, false)]
+    [InlineData ("\u001b[57448u", ModifierKey.RightCtrl, false, false, true)]
+    [InlineData ("\u001b[57449u", ModifierKey.RightAlt, false, true, false)]
+    [InlineData ("\u001b[57450u", ModifierKey.RightSuper, false, false, false)]
+    [InlineData ("\u001b[57451u", ModifierKey.RightHyper, false, false, false)]
+    [InlineData ("\u001b[57453u", ModifierKey.AltGr, false, true, false)]
+    public void KittyPattern_AllMappedModifierPresses_ParseWithExpectedImplicitState (
+        string sequence,
+        ModifierKey expectedModifier,
+        bool expectedShift,
+        bool expectedAlt,
+        bool expectedCtrl
+    )
+    {
+        Key? key = _pattern.GetKey (sequence);
+
+        Assert.NotNull (key);
+        Assert.True (key.IsModifierOnly);
+        Assert.Equal (expectedModifier, key.ModifierKey);
+        Assert.Equal (expectedShift, key.IsShift);
+        Assert.Equal (expectedAlt, key.IsAlt);
+        Assert.Equal (expectedCtrl, key.IsCtrl);
+        Assert.Equal (KeyEventType.Press, key.EventType);
     }
 
     #endregion

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardParsingTests.cs
@@ -253,13 +253,15 @@ public class KittyKeyboardParsingTests
     [Fact]
     public void KittyPattern_LeftAlt_WithCtrlModifier_PreservesBothStates ()
     {
+        // ESC[57443;5u = LeftAlt (implicit Alt) with Ctrl held (explicit Ctrl=5)
+        // After the fix, implicit Alt is combined with explicit Ctrl
         Key? key = _pattern.GetKey ("\u001b[57443;5u");
 
         Assert.NotNull (key);
         Assert.True (key.IsModifierOnly);
         Assert.Equal (ModifierKey.LeftAlt, key.ModifierKey);
         Assert.True (key.IsCtrl);
-        Assert.False (key.IsAlt);
+        Assert.True (key.IsAlt);
         Assert.Equal (KeyEventType.Press, key.EventType);
     }
 
@@ -314,6 +316,40 @@ public class KittyKeyboardParsingTests
         Assert.True (key.IsShift);
         Assert.False (key.IsAlt);
         Assert.False (key.IsCtrl);
+        Assert.Equal (KeyEventType.Press, key.EventType);
+    }
+
+    // Regression test for issue where modifier combinations weren't being combined correctly
+    [Fact]
+    public void KittyPattern_LeftCtrl_WithShiftModifier_CombinesImplicitAndExplicit ()
+    {
+        // ESC[57442;2u = LeftCtrl (implicit Ctrl) with Shift held (explicit Shift=2)
+        // Should combine to Ctrl+Shift, not just Shift
+        Key? key = _pattern.GetKey ("\u001b[57442;2u");
+
+        Assert.NotNull (key);
+        Assert.True (key.IsModifierOnly);
+        Assert.Equal (ModifierKey.LeftCtrl, key.ModifierKey);
+        Assert.True (key.IsCtrl);
+        Assert.True (key.IsShift);
+        Assert.False (key.IsAlt);
+        Assert.Equal (KeyEventType.Press, key.EventType);
+    }
+
+    // Regression test for issue where modifier combinations weren't being combined correctly
+    [Fact]
+    public void KittyPattern_LeftAlt_WithShiftAndCtrlModifiers_CombinesAllModifiers ()
+    {
+        // ESC[57443;6u = LeftAlt (implicit Alt) with Shift+Ctrl held (explicit Shift+Ctrl=6)
+        // Should combine to Alt+Shift+Ctrl, not just Shift+Ctrl
+        Key? key = _pattern.GetKey ("\u001b[57443;6u");
+
+        Assert.NotNull (key);
+        Assert.True (key.IsModifierOnly);
+        Assert.Equal (ModifierKey.LeftAlt, key.ModifierKey);
+        Assert.True (key.IsAlt);
+        Assert.True (key.IsShift);
+        Assert.True (key.IsCtrl);
         Assert.Equal (KeyEventType.Press, key.EventType);
     }
 

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -325,6 +325,7 @@ public class KittyKeyboardPipelineTests
         Assert.Single (down);
         Assert.True (down [0].IsModifierOnly);
         Assert.Equal (ModifierKey.LeftShift, down [0].ModifierKey);
+        Assert.True (down [0].IsShift);
         Assert.Equal (KeyEventType.Press, down [0].EventType);
 
         Assert.Single (up);
@@ -382,6 +383,55 @@ public class KittyKeyboardPipelineTests
         Assert.Empty (up);
     }
 
+    [Fact]
+    public void Pipeline_ModifierPress_SetsImplicitModifierState ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[57441u",
+                                                            "\x1b[57442u",
+                                                            "\x1b[57443u");
+
+        Assert.Equal (3, down.Count);
+        Assert.True (down [0].IsShift);
+        Assert.True (down [1].IsCtrl);
+        Assert.True (down [2].IsAlt);
+        Assert.Empty (up);
+    }
+
+    [Theory]
+    [InlineData ("\x1b[57358u", ModifierKey.CapsLock, false, false, false)]
+    [InlineData ("\x1b[57359u", ModifierKey.ScrollLock, false, false, false)]
+    [InlineData ("\x1b[57360u", ModifierKey.NumLock, false, false, false)]
+    [InlineData ("\x1b[57441u", ModifierKey.LeftShift, true, false, false)]
+    [InlineData ("\x1b[57442u", ModifierKey.LeftCtrl, false, false, true)]
+    [InlineData ("\x1b[57443u", ModifierKey.LeftAlt, false, true, false)]
+    [InlineData ("\x1b[57444u", ModifierKey.LeftSuper, false, false, false)]
+    [InlineData ("\x1b[57445u", ModifierKey.LeftHyper, false, false, false)]
+    [InlineData ("\x1b[57447u", ModifierKey.RightShift, true, false, false)]
+    [InlineData ("\x1b[57448u", ModifierKey.RightCtrl, false, false, true)]
+    [InlineData ("\x1b[57449u", ModifierKey.RightAlt, false, true, false)]
+    [InlineData ("\x1b[57450u", ModifierKey.RightSuper, false, false, false)]
+    [InlineData ("\x1b[57451u", ModifierKey.RightHyper, false, false, false)]
+    [InlineData ("\x1b[57453u", ModifierKey.AltGr, false, true, false)]
+    public void Pipeline_AllMappedModifierPresses_RaiseExpectedImplicitState (
+        string sequence,
+        ModifierKey expectedModifier,
+        bool expectedShift,
+        bool expectedAlt,
+        bool expectedCtrl
+    )
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence (sequence);
+
+        Assert.Single (down);
+        Assert.True (down [0].IsModifierOnly);
+        Assert.Equal (expectedModifier, down [0].ModifierKey);
+        Assert.Equal (expectedShift, down [0].IsShift);
+        Assert.Equal (expectedAlt, down [0].IsAlt);
+        Assert.Equal (expectedCtrl, down [0].IsCtrl);
+        Assert.Equal (KeyEventType.Press, down [0].EventType);
+        Assert.Empty (up);
+    }
+
     // Copilot - Opus 4.6
     [Theory]
     [InlineData ("\x1b[57441;1:3u", ModifierKey.LeftShift)]
@@ -403,6 +453,7 @@ public class KittyKeyboardPipelineTests
         Assert.Equal (KeyEventType.Release, up [0].EventType);
     }
 
+
     [Fact]
     public void Pipeline_LeftAltPress_WithCtrlModifier_PreservesBothStates ()
     {
@@ -413,6 +464,36 @@ public class KittyKeyboardPipelineTests
         Assert.Equal (ModifierKey.LeftAlt, down [0].ModifierKey);
         Assert.True (down [0].IsCtrl);
         Assert.False (down [0].IsAlt);
+        Assert.Empty (up);
+    }
+
+    [Fact]
+    public void Pipeline_LeftCtrlPress_WithCapsLockModifier_PreservesCtrlState ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[57442;65u");
+
+        Assert.Single (down);
+        Assert.True (down [0].IsModifierOnly);
+        Assert.Equal (ModifierKey.LeftCtrl, down [0].ModifierKey);
+        Assert.True (down [0].IsCtrl);
+        Assert.False (down [0].IsAlt);
+        Assert.False (down [0].IsShift);
+        Assert.Equal (KeyEventType.Press, down [0].EventType);
+        Assert.Empty (up);
+    }
+
+    [Fact]
+    public void Pipeline_LeftShiftPress_WithCapsLockModifier_PreservesShiftState ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[57441;65u");
+
+        Assert.Single (down);
+        Assert.True (down [0].IsModifierOnly);
+        Assert.Equal (ModifierKey.LeftShift, down [0].ModifierKey);
+        Assert.True (down [0].IsShift);
+        Assert.False (down [0].IsAlt);
+        Assert.False (down [0].IsCtrl);
+        Assert.Equal (KeyEventType.Press, down [0].EventType);
         Assert.Empty (up);
     }
 

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -463,7 +463,7 @@ public class KittyKeyboardPipelineTests
         Assert.True (down [0].IsModifierOnly);
         Assert.Equal (ModifierKey.LeftAlt, down [0].ModifierKey);
         Assert.True (down [0].IsCtrl);
-        Assert.False (down [0].IsAlt);
+        Assert.True (down [0].IsAlt);
         Assert.Empty (up);
     }
 

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -811,5 +811,110 @@ public class KittyKeyboardPipelineTests
         Assert.Equal (expectedKey.KeyCode, down [0].KeyCode);
         Assert.Empty (up);
     }
+
+    #endregion
+
+    #region Regression tests for modifier key release events in Kitty keyboard protocol.
+
+    [Fact]
+    public void ModifierKeyRelease_PreservesModifierKey ()
+    {
+        // ESC[57441;1:3u = LeftShift release
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[57441;1:3u");
+
+        Assert.Empty (down);
+        Assert.Single (up);
+
+        // The bug: ModifierKey should be LeftShift, not None
+        Assert.True (up [0].IsModifierOnly, "Release event should be marked as modifier-only");
+        Assert.Equal (ModifierKey.LeftShift, up [0].ModifierKey);
+        Assert.Equal (KeyEventType.Release, up [0].EventType);
+        Assert.Equal (KeyCode.ShiftMask, up [0].KeyCode);
+    }
+
+    [Fact]
+    public void ModifierKeyRelease_LeftCtrl_PreservesModifierKey ()
+    {
+        // ESC[57442;1:3u = LeftCtrl release
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[57442;1:3u");
+
+        Assert.Empty (down);
+        Assert.Single (up);
+
+        Assert.True (up [0].IsModifierOnly);
+        Assert.Equal (ModifierKey.LeftCtrl, up [0].ModifierKey);
+        Assert.Equal (KeyEventType.Release, up [0].EventType);
+    }
+
+    [Fact]
+    public void ModifierKeyRelease_RightAlt_PreservesModifierKey ()
+    {
+        // ESC[57449;1:3u = RightAlt release
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[57449;1:3u");
+
+        Assert.Empty (down);
+        Assert.Single (up);
+
+        Assert.True (up [0].IsModifierOnly);
+        Assert.Equal (ModifierKey.RightAlt, up [0].ModifierKey);
+        Assert.Equal (KeyEventType.Release, up [0].EventType);
+    }
+
+    [Fact]
+    public void ModifierKeyRelease_AltGr_PreservesModifierKey ()
+    {
+        // ESC[57453;1:3u = AltGr release
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[57453;1:3u");
+
+        Assert.Empty (down);
+        Assert.Single (up);
+
+        Assert.True (up [0].IsModifierOnly);
+        Assert.Equal (ModifierKey.AltGr, up [0].ModifierKey);
+        Assert.Equal (KeyEventType.Release, up [0].EventType);
+    }
+
+    [Theory]
+    [InlineData ("\x1b[57441;1:3u", ModifierKey.LeftShift, KeyCode.ShiftMask)]
+    [InlineData ("\x1b[57442;1:3u", ModifierKey.LeftCtrl, KeyCode.CtrlMask)]
+    [InlineData ("\x1b[57443;1:3u", ModifierKey.LeftAlt, KeyCode.AltMask)]
+    [InlineData ("\x1b[57447;1:3u", ModifierKey.RightShift, KeyCode.ShiftMask)]
+    [InlineData ("\x1b[57448;1:3u", ModifierKey.RightCtrl, KeyCode.CtrlMask)]
+    [InlineData ("\x1b[57449;1:3u", ModifierKey.RightAlt, KeyCode.AltMask)]
+    [InlineData ("\x1b[57453;1:3u", ModifierKey.AltGr, KeyCode.AltMask)]
+    public void ModifierKeyRelease_AllModifiers_PreserveModifierKey (string sequence, ModifierKey expectedModifier, KeyCode keyCode)
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence (sequence);
+
+        Assert.Empty (down);
+        Assert.Single (up);
+        Assert.True (up [0].IsModifierOnly, $"Release event for {expectedModifier} should be modifier-only");
+        Assert.Equal (expectedModifier, up [0].ModifierKey);
+        Assert.Equal (KeyEventType.Release, up [0].EventType);
+        Assert.Equal (keyCode, up [0].KeyCode);
+    }
+
+    [Fact]
+    public void ModifierKeyRelease_PressAndRelease_Sequence ()
+    {
+        // Press LeftShift, then release it
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[57441u", // LeftShift press
+                                                            "\x1b[57441;1:3u" // LeftShift release
+                                                           );
+
+        Assert.Single (down);
+        Assert.Single (up);
+
+        // Press event
+        Assert.True (down [0].IsModifierOnly);
+        Assert.Equal (ModifierKey.LeftShift, down [0].ModifierKey);
+        Assert.Equal (KeyEventType.Press, down [0].EventType);
+
+        // Release event - should preserve ModifierKey
+        Assert.True (up [0].IsModifierOnly);
+        Assert.Equal (ModifierKey.LeftShift, up [0].ModifierKey);
+        Assert.Equal (KeyEventType.Release, up [0].EventType);
+    }
+
+    #endregion
 }
-#endregion

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/KeyTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/KeyTests.cs
@@ -290,6 +290,18 @@ public class KeyTests
         Assert.Equal (default (Rune), key.AsRune);
     }
 
+    [Fact]
+    public void AsGrapheme_And_AsRune_Suppress_ModifiedPrintableFallback_WithoutAssociatedText ()
+    {
+        Key key = new (Key.T.WithShift.WithAlt) { ShiftedKeyCode = (KeyCode)'T' };
+
+        Assert.Equal (string.Empty, key.AsGrapheme);
+        Assert.Equal (default (Rune), key.AsRune);
+        Assert.Equal (string.Empty, key.GetPrintableText ());
+        Assert.False (key.TryGetPrintableRune (out Rune rune));
+        Assert.Equal (default (Rune), rune);
+    }
+
     [Theory]
     [InlineData ("Barf")]
     public void Constructor_String_Invalid_Throws (string keyString) { Assert.Throws<ArgumentException> (() => new Key (keyString)); }


### PR DESCRIPTION
## Fixes

- Fixes #5065

## Proposed Changes/Todos

- [x] I would like to add the kitty addition test lines to reinforce the Key values. Thanks

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
