### PR TITLE
Fix stale test project references in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,21 @@ When in planning mode:
 ```bash
 dotnet restore
 dotnet build --no-restore
+
+# Preferred: parallelizable tests (no static state)
 dotnet test --project Tests/UnitTestsParallelizable --no-build
-dotnet test --project Tests/UnitTests --no-build
+
+# Tests that require process-wide static state (Application.Init, etc.)
+dotnet test --project Tests/UnitTests.NonParallelizable --no-build
+
+# Legacy tests — do NOT add new tests here; candidates for rewrite/deletion
+dotnet test --project Tests/UnitTests.Legacy --no-build
+
+# Run a single test by fully-qualified name
+dotnet test --project Tests/UnitTestsParallelizable --no-build --filter "FullyQualifiedName~MyTestClass.MyTestMethod"
 ```
+
+See `Tests/README.md` for the full list of test projects (including `IntegrationTests`, `StressTests`, `Benchmarks`) and the static-state classification that determines where a new test belongs.
 
 ## Key Concepts
 
@@ -118,7 +130,7 @@ dotnet test --project Tests/UnitTests --no-build
 
 ## Testing
 
-- Prefer `UnitTestsParallelizable` over `UnitTests`
+- Add new tests to `UnitTestsParallelizable`; use `UnitTests.NonParallelizable` only when static state is unavoidable. Never add to `UnitTests.Legacy`.
 - Add comment: `// Claude - Opus 4.5`
 - Never decrease coverage
 - Avoid `Application.Init` in tests


### PR DESCRIPTION
## Summary

The Build & Test section of `CLAUDE.md` referenced a `Tests/UnitTests` project that no longer exists. The actual test projects are `UnitTestsParallelizable`, `UnitTests.NonParallelizable`, and `UnitTests.Legacy` (per `Tests/README.md`). Copy-pasting the documented `dotnet test` command would fail.

- Replaced the stale `Tests/UnitTests` reference with the three current projects, each annotated with when to use it.
- Added a single-test `--filter` example.
- Added a pointer to `Tests/README.md` for the full list of test projects and the static-state classification that determines where a new test belongs.
- Updated the "Testing" summary bullet to reflect the three-project split and the rule that new tests never go in `UnitTests.Legacy`.

Docs-only change — no code, tests, or warnings affected.

## Test plan

- [x] `CLAUDE.md` renders correctly on GitHub
- [x] The `dotnet test --project Tests/UnitTestsParallelizable --no-build` command in the doc matches a real project path
- [x] No source files touched, so no new warnings possible

# To pull down this PR locally:
```
git remote add copilot https://github.com/harder/Terminal.Gui.git
git fetch copilot docs/claude-md-fix-test-projects
git checkout copilot/docs/claude-md-fix-test-projects
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)