### PR TITLE
Fixes #5080. WindowsDriver isn't showing the cursor after exit

### DIFF
--- a/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
@@ -630,6 +630,9 @@ internal partial class WindowsOutput : OutputBase, IOutput
             {
                 //Disable alternative screen buffer.
                 Console.Out.Write (EscSeqUtils.CSI_RestoreCursorAndRestoreAltBufferWithBackscroll);
+
+                //Set cursor key to cursor.
+                Write (EscSeqUtils.CSI_ShowCursor);
             }
             else
             {


### PR DESCRIPTION
## Fixes

- Fixes #5080

## Proposed Changes/Todos

- [x] Restore the cursot at disposing

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
