### PR TITLE
Fixes #5060. TextField in ReadOnly mode should not automatically scroll

### DIFF
--- a/Terminal.Gui/Views/TextInput/TextField/TextField.Commands.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.Commands.cs
@@ -522,6 +522,14 @@ public partial class TextField
 
         App?.Clipboard?.SetClipboardData (SelectedText);
 
+        if (!ReadOnly)
+        {
+            return true;
+        }
+        _insertionPoint = 0;
+        ScrollOffset = 0;
+        ClearAllSelection ();
+
         return true;
     }
 

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.cs
@@ -148,8 +148,8 @@ public partial class TextField : View, IDesignable, IValue<string>
             App.Mouse.UngrabMouse ();
         }
 
-        // If gaining focus via keyboard (not mouse), select all text
-        if (newHasFocus && !_focusSetByMouse && _text.Count > 0)
+        // If gaining focus via keyboard (not mouse), select all text if not ReadOnly
+        if (newHasFocus && !ReadOnly && !_focusSetByMouse && _text.Count > 0)
         {
             SelectAll ();
         }

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.cs
@@ -154,6 +154,16 @@ public partial class TextField : View, IDesignable, IValue<string>
             SelectAll ();
         }
 
+        if (ReadOnly && InsertionPoint > 0)
+        {
+            _insertionPoint = 0;
+        }
+
+        if (ReadOnly && ScrollOffset > 0)
+        {
+            ScrollOffset = 0;
+        }
+
         // Reset the flag after handling focus change
         _focusSetByMouse = false;
 

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.cs
@@ -112,9 +112,12 @@ public partial class TextField : View, IDesignable, IValue<string>
 
     private void TextField_Initialized (object? sender, EventArgs e)
     {
-        _insertionPoint = GraphemeHelper.GetGraphemeCount (Text);
+        if (!ReadOnly)
+        {
+            _insertionPoint = GraphemeHelper.GetGraphemeCount (Text);
+        }
 
-        if (Viewport.Width > 0)
+        if (!ReadOnly && Viewport.Width > 0)
         {
             int colsWidth = Text.GetColumns ();
             ScrollOffset = colsWidth > Viewport.Width + 1 ? colsWidth - Viewport.Width + 1 : 0;

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.cs
@@ -164,6 +164,11 @@ public partial class TextField : View, IDesignable, IValue<string>
             ScrollOffset = 0;
         }
 
+        if (ReadOnly && SelectedLength > 0)
+        {
+            ClearAllSelection ();
+        }
+
         // Reset the flag after handling focus change
         _focusSetByMouse = false;
 

--- a/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
@@ -1551,4 +1551,19 @@ public class TextFieldTests (ITestOutputHelper output) : TestDriverBase
         Assert.Equal (0, tf.ScrollOffset);
         Assert.Null (tf.SelectedText);
     }
+
+    [Fact]
+    public void ReadOnly_ShouldNotSelectAllText_OnFocus ()
+    {
+        TextField tf = new () { Width = 5, ReadOnly = true, Text = "hello world" };
+        tf.BeginInit ();
+        tf.EndInit ();
+
+        tf.SetFocus ();
+
+        Assert.Equal (0, tf.InsertionPoint);
+        Assert.Equal (0, tf.ScrollOffset);
+        Assert.Null (tf.SelectedText);
+    }
+
 }

--- a/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
@@ -1583,4 +1583,33 @@ public class TextFieldTests (ITestOutputHelper output) : TestDriverBase
          Assert.Equal (0, tf.InsertionPoint);
          Assert.Equal (0, tf.ScrollOffset);
      }
+
+     [Fact]
+     public void ReadOnly_ShouldSetInsertionPointAndScrollOffsetToZero_LeavingFocus ()
+     {
+         TextField tf = new () { Width = 5, ReadOnly = true, Text = "hello world" };
+
+         // Create another view to take focus away
+         View otherView = new () { CanFocus = true };
+
+         // Create a container to hold both views
+         Runnable container = new () { Id = "container", Width = 20, Height = 5 };
+         container.Add (tf, otherView);
+         container.BeginInit ();
+         container.EndInit ();
+
+         // Set focus to TextField and verify insertion point and scroll offset are at zero
+         tf.SetFocus ();
+         Assert.Equal (0, tf.InsertionPoint);
+         Assert.Equal (0, tf.ScrollOffset);
+
+         // Move insertion point to end of text and then move focus away to verify insertion point is still at zero
+         tf.InsertionPoint = tf.Text.Length;
+         Assert.Equal (11, tf.InsertionPoint);
+         Assert.Equal (7, tf.ScrollOffset);
+
+         otherView.SetFocus ();
+         Assert.Equal (0, tf.InsertionPoint);
+         Assert.Equal (0, tf.ScrollOffset);
+     }
 }

--- a/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
@@ -1566,4 +1566,21 @@ public class TextFieldTests (ITestOutputHelper output) : TestDriverBase
         Assert.Null (tf.SelectedText);
     }
 
+     [Fact]
+     public void ReadOnly_ShouldSetInsertionPointAndScrollOffsetToZero_OnFocus ()
+     {
+         TextField tf = new () { Width = 5, ReadOnly = true, Text = "hello world" };
+         tf.BeginInit ();
+         tf.EndInit ();
+
+         // Move insertion point to end of text
+         tf.InsertionPoint = tf.Text.Length;
+         Assert.Equal (11, tf.InsertionPoint);
+         Assert.Equal (7, tf.ScrollOffset);
+
+         // Set focus and verify insertion point is still at zero
+         tf.SetFocus ();
+         Assert.Equal (0, tf.InsertionPoint);
+         Assert.Equal (0, tf.ScrollOffset);
+     }
 }

--- a/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
@@ -1612,4 +1612,24 @@ public class TextFieldTests (ITestOutputHelper output) : TestDriverBase
          Assert.Equal (0, tf.InsertionPoint);
          Assert.Equal (0, tf.ScrollOffset);
      }
+
+     [Fact]
+     public void ReadOnly_ShouldSetInsertionPointAndScrollOffsetToZero_AfterCopyingText ()
+     {
+         TextField tf = new () { Width = 5, ReadOnly = true, Text = "hello world" };
+         tf.BeginInit ();
+         tf.EndInit ();
+
+         // Select all text
+         tf.SelectAll ();
+         Assert.Equal (11, tf.InsertionPoint);
+         Assert.Equal (7, tf.ScrollOffset);
+         Assert.Equal ("hello world", tf.SelectedText);
+
+         // Copy text and verify insertion point and scroll offset are still at zero
+         tf.Copy ();
+         Assert.Equal (0, tf.InsertionPoint);
+         Assert.Equal (0, tf.ScrollOffset);
+         Assert.Null (tf.SelectedText);
+     }
 }

--- a/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
@@ -1539,4 +1539,16 @@ public class TextFieldTests (ITestOutputHelper output) : TestDriverBase
 
         Assert.Equal ("", tf.Text);
     }
+
+    [Fact]
+    public void ReadOnly_ShouldNotAllowAutomaticallyScrolling_AndMustSetInsertionPointToZeroAtInitialization ()
+    {
+        TextField tf = new () { Width = 5, ReadOnly = true, Text = "hello world" };
+        tf.BeginInit ();
+        tf.EndInit ();
+
+        Assert.Equal (0, tf.InsertionPoint);
+        Assert.Equal (0, tf.ScrollOffset);
+        Assert.Null (tf.SelectedText);
+    }
 }

--- a/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
@@ -1632,4 +1632,32 @@ public class TextFieldTests (ITestOutputHelper output) : TestDriverBase
          Assert.Equal (0, tf.ScrollOffset);
          Assert.Null (tf.SelectedText);
      }
+
+     [Fact]
+     public void ReadOnly_ShouldSetInsertionPointAndScrollOffsetToZeroAndClearAllSelection_OnLeavingFocus ()
+     {
+         TextField tf = new () { Width = 5, ReadOnly = true, Text = "hello world" };
+
+         // Create another view to take focus away
+         View otherView = new () { CanFocus = true };
+
+         // Create a container to hold both views
+         Runnable container = new () { Id = "container", Width = 20, Height = 5 };
+         container.Add (tf, otherView);
+         container.BeginInit ();
+         container.EndInit ();
+
+         // Set focus to TextField and select all text
+         tf.SetFocus ();
+         tf.SelectAll ();
+         Assert.Equal (11, tf.InsertionPoint);
+         Assert.Equal (7, tf.ScrollOffset);
+         Assert.Equal ("hello world", tf.SelectedText);
+
+         // Move focus away and verify insertion point and scroll offset are at zero and selection is cleared
+         otherView.SetFocus ();
+         Assert.Equal (0, tf.InsertionPoint);
+         Assert.Equal (0, tf.ScrollOffset);
+         Assert.Null (tf.SelectedText);
+     }
 }


### PR DESCRIPTION
## Fixes

- Fixes #5060

## Proposed Changes/Todos

- [x] Ensuring ScrollOffset and InsertionPoint set to zero and clear all selected text on enter/leaving focus

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
