### PR TITLE
Fix XML comment has cref attribute 'Buttons' that could not be resolved CS1574

### DIFF
--- a/Terminal.Gui/Views/FileDialogs/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialogs/FileDialog.cs
@@ -33,7 +33,7 @@ public partial class FileDialog : Dialog, IDesignable
     /// <summary>
     ///     Gets the index of the cancel button for the dialog. This is useful for checking if the user canceled the dialog by
     ///     comparing
-    ///     the <see cref="Dialog.Result"/> to the index of this button in the <see cref="Dialog.Buttons"/> array.
+    ///     the <see cref="Dialog.Result"/> to the index of this button in the <see cref="Dialog{TResult}.Buttons"/> array.
     /// </summary>
     public int CancelButtonIndex => Buttons.IndexOf (_btnCancel);
 


### PR DESCRIPTION
## Fixes

- Fixes #_____

## Proposed Changes/Todos

- [x] Fix FileDialog warning

## Pull Request checklist:

- [ ] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
