### PR TITLE
Fixes #5119. Popover isn't recalculating it's position when terminal is resizing

### DIFF
--- a/Terminal.Gui/App/Popovers/Popover.cs
+++ b/Terminal.Gui/App/Popovers/Popover.cs
@@ -350,6 +350,19 @@ public class Popover<TView, TResult> : PopoverImpl, IDesignable where TView : Vi
         base.OnVisibleChanged (); // PopoverImpl handles Hide
     }
 
+    /// <inheritdoc />
+    protected override void OnFrameChanged (in Rectangle frame)
+    {
+        base.OnFrameChanged (in frame);
+
+        if (!Visible || Anchor is null || ContentView is null)
+        {
+            return;
+        }
+
+        SetPosition (anchor: Anchor ());
+    }
+
     /// <summary>
     ///     Extracts the result from the content view using <see cref="ResultExtractor"/> or <see cref="IValue{TResult}"/>.
     /// </summary>

--- a/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
@@ -250,6 +250,42 @@ public class ApplicationPopoverTests
         Assert.Equal (initialVisibleState, popover2.Visible);
     }
 
+    // CoPilot - ChatGPT v4
+    [Fact]
+    public void LayoutAndDraw_ScreenResize_LayoutsVisiblePopover ()
+    {
+        // Arrange
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (80, 25);
+
+        Runnable top = new () { App = app };
+        SessionToken? token = app.Begin (top);
+
+        PopoverTestClass popover = new ()
+        {
+            App = app,
+            Width = 10,
+            Height = 5
+        };
+        app.Popovers!.Register (popover);
+        app.Popovers.Show (popover);
+
+        app.LayoutAndDraw ();
+        popover.LayoutPassCount = 0;
+
+        app.Driver.SetScreenSize (100, 30);
+
+        // Act
+        app.LayoutAndDraw ();
+
+        // Assert
+        Assert.True (popover.LayoutPassCount > 0);
+
+        app.End (token!);
+        top.Dispose ();
+    }
+
     public class PopoverTestClass : View, IPopoverView
     {
         public List<Key> HandledKeys { get; } = [];

--- a/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
@@ -292,6 +292,8 @@ public class ApplicationPopoverTests
 
         public int NewCommandInvokeCount { get; private set; }
 
+        public int LayoutPassCount { get; set; }
+
         public bool HandleNewCommand { get; set; }
 
         /// <summary>
@@ -376,6 +378,12 @@ public class ApplicationPopoverTests
             }
 
             return false;
+        }
+
+        protected override void OnSubViewLayout (LayoutEventArgs args)
+        {
+            LayoutPassCount++;
+            base.OnSubViewLayout (args);
         }
 
         /// <inheritdoc/>

--- a/Tests/UnitTestsParallelizable/Views/DropDownListTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/DropDownListTests.cs
@@ -900,6 +900,120 @@ public class DropDownListTests (ITestOutputHelper output)
         app.End (token!);
     }
 
+    // CoPilot - ChatGPT v4
+    [Fact]
+    public void VisiblePopover_Repositions_WhenTerminalIsResized ()
+    {
+        // Arrange
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (40, 15);
+
+        using Runnable top = new ();
+        SessionToken? token = app.Begin (top);
+
+        ObservableCollection<string> items = ["Alpha", "Beta", "Gamma"];
+
+        DropDownList dropdown = new ()
+        {
+            X = Pos.Center (),
+            Y = Pos.Center (),
+            Width = 12,
+            Source = new ListWrapper<string> (items),
+            ReadOnly = true
+        };
+
+        top.Add (dropdown);
+        app.LayoutAndDraw ();
+
+        dropdown.SetFocus ();
+        app.InjectKey (Key.F4);
+        app.LayoutAndDraw ();
+
+        Popover<ListView, string?>? popover = FindDropDownPopover (app) as Popover<ListView, string?>;
+        Assert.NotNull (popover);
+        Assert.True (popover.Visible);
+
+        Rectangle initialListFrame = popover.ContentView!.FrameToScreen ();
+        Rectangle initialDropDownFrame = dropdown.FrameToScreen ();
+
+        // Act
+        app.Driver.SetScreenSize (60, 25);
+        app.LayoutAndDraw ();
+
+        // Assert
+        Rectangle resizedListFrame = popover.ContentView.FrameToScreen ();
+        Rectangle resizedDropDownFrame = dropdown.FrameToScreen ();
+
+        Assert.NotEqual (initialDropDownFrame.Location, resizedDropDownFrame.Location);
+        Assert.Equal (resizedDropDownFrame.X, resizedListFrame.X);
+        Assert.Equal (resizedDropDownFrame.Bottom, resizedListFrame.Y);
+        Assert.NotEqual (initialListFrame.Location, resizedListFrame.Location);
+
+        app.End (token!);
+    }
+
+    // CoPilot - ChatGPT v4
+    [Fact]
+    public void VisiblePopover_LayoutsHeight_WhenTerminalIsResized ()
+    {
+        // Arrange
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (30, 10);
+
+        using Runnable top = new ();
+        SessionToken? token = app.Begin (top);
+
+        ObservableCollection<string> items =
+        [
+            "Item_00",
+            "Item_01",
+            "Item_02",
+            "Item_03",
+            "Item_04",
+            "Item_05",
+            "Item_06",
+            "Item_07",
+            "Item_08",
+            "Item_09"
+        ];
+
+        DropDownList dropdown = new ()
+        {
+            X = 0,
+            Y = 0,
+            Width = 12,
+            Source = new ListWrapper<string> (items),
+            ReadOnly = true
+        };
+
+        top.Add (dropdown);
+        app.LayoutAndDraw ();
+
+        dropdown.SetFocus ();
+        app.InjectKey (Key.F4);
+        app.LayoutAndDraw ();
+
+        Popover<ListView, string?>? popover = FindDropDownPopover (app) as Popover<ListView, string?>;
+        Assert.NotNull (popover);
+        Assert.True (popover.Visible);
+
+        int initialHeight = popover.ContentView!.Frame.Height;
+        Assert.Equal (9, initialHeight);
+
+        // Act
+        app.Driver.SetScreenSize (30, 5);
+        app.LayoutAndDraw ();
+
+        // Assert
+        int resizedHeight = popover.ContentView.Frame.Height;
+        Assert.Equal (4, resizedHeight);
+        Assert.NotEqual (initialHeight, resizedHeight);
+
+        app.End (token!);
+    }
+
     // Helper to find the DropDownList popover (excludes the context menu popover)
     private static IPopoverView? FindDropDownPopover (IApplication app) => app.Popovers?.Popovers.OfType<Popover<ListView, string?>> ().FirstOrDefault ();
 }


### PR DESCRIPTION
## Fixes

- Fixes #5119

## Proposed Changes/Todos

- [ ] Recalculate position when frame changes

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
