### PR TITLE
Fixes #5122. Visible popovers are always layout and redrawn in every iteration unnecessarily.

### DIFF
--- a/Terminal.Gui/App/ApplicationImpl.Screen.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Screen.cs
@@ -65,6 +65,11 @@ internal partial class ApplicationImpl
                 runnableView.SetNeedsLayout ();
             }
         }
+
+        if (Popovers?.GetActivePopover () is View { Visible: true } visiblePopover)
+        {
+            visiblePopover.SetNeedsLayout ();
+        }
     }
 
     private void Driver_SizeChanged (object? sender, SizeChangedEventArgs e)

--- a/Terminal.Gui/App/ApplicationImpl.Screen.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Screen.cs
@@ -117,16 +117,9 @@ internal partial class ApplicationImpl
 
         List<View?> views = [.. SessionStack.Select (r => r.Runnable! as View)!];
 
-        if (Popovers?.GetActivePopover () is { Visible: true } visiblePopover)
+        if (Popovers?.GetActivePopover () is View { Visible: true, NeedsLayout: true } visiblePopoverNeedingLayout)
         {
-            visiblePopover.SetNeedsDraw ();
-            visiblePopover.SetNeedsLayout ();
-
-            // Need View for views.Insert
-            if (visiblePopover is View popoverView)
-            {
-                views.Insert (0, popoverView);
-            }
+            views.Insert (0, visiblePopoverNeedingLayout);
         }
 
         // Layout
@@ -239,6 +232,30 @@ internal partial class ApplicationImpl
 
         // Draw
         bool needsDraw = forceRedraw || views.Any (v => v is { NeedsDraw: true } or { SubViewNeedsDraw: true });
+
+        if (Popovers?.GetActivePopover () is View { Visible: true } visiblePopover)
+        {
+            if (needsDraw)
+            {
+                visiblePopover.SetNeedsDraw ();
+
+                if (!views.Contains (visiblePopover))
+                {
+                    views.Insert (0, visiblePopover);
+                }
+            }
+            else if (visiblePopover.NeedsDraw || visiblePopover.SubViewNeedsDraw)
+            {
+                visiblePopover.SetNeedsDraw ();
+
+                if (!views.Contains (visiblePopover))
+                {
+                    views.Insert (0, visiblePopover);
+                }
+
+                needsDraw = true;
+            }
+        }
 
         if (Driver is { } && (neededLayout || needsDraw))
         {

--- a/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
@@ -286,11 +286,183 @@ public class ApplicationPopoverTests
         top.Dispose ();
     }
 
+    // CoPilot - ChatGPT v4
+    [Fact]
+    public void LayoutAndDraw_VisibleIdlePopover_DoesNotRaiseLayoutAndDrawComplete ()
+    {
+        // Arrange
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (80, 25);
+
+        Runnable top = new () { App = app };
+        SessionToken? token = app.Begin (top);
+
+        PopoverTestClass popover = new ()
+        {
+            App = app,
+            Width = 10,
+            Height = 5
+        };
+        app.Popovers!.Register (popover);
+        app.Popovers.Show (popover);
+
+        // Clear the initial invalidation caused by showing the popover.
+        app.LayoutAndDraw ();
+
+        int layoutAndDrawCompleteCount = 0;
+        app.LayoutAndDrawComplete += CountLayoutAndDrawComplete;
+
+        // Act
+        app.LayoutAndDraw ();
+
+        // Assert
+        Assert.Equal (0, layoutAndDrawCompleteCount);
+
+        app.LayoutAndDrawComplete -= CountLayoutAndDrawComplete;
+        app.End (token!);
+        top.Dispose ();
+
+        return;
+
+        void CountLayoutAndDrawComplete (object? _, EventArgs __) => layoutAndDrawCompleteCount++;
+    }
+
+    // CoPilot - ChatGPT v4
+    [Fact]
+    public void LayoutAndDraw_VisiblePopoverNeedingDraw_RaisesLayoutAndDrawComplete ()
+    {
+        // Arrange
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (80, 25);
+
+        Runnable top = new () { App = app };
+        SessionToken? token = app.Begin (top);
+
+        PopoverTestClass popover = new ()
+        {
+            App = app,
+            Width = 10,
+            Height = 5
+        };
+        app.Popovers!.Register (popover);
+        app.Popovers.Show (popover);
+        app.LayoutAndDraw ();
+
+        int layoutAndDrawCompleteCount = 0;
+        app.LayoutAndDrawComplete += CountLayoutAndDrawComplete;
+        popover.SetNeedsDraw ();
+
+        // Act
+        app.LayoutAndDraw ();
+
+        // Assert
+        Assert.Equal (1, layoutAndDrawCompleteCount);
+
+        app.LayoutAndDrawComplete -= CountLayoutAndDrawComplete;
+        app.End (token!);
+        top.Dispose ();
+
+        return;
+
+        void CountLayoutAndDrawComplete (object? _, EventArgs __) => layoutAndDrawCompleteCount++;
+    }
+
+    // CoPilot - ChatGPT v4
+    [Fact]
+    public void LayoutAndDraw_VisiblePopoverNeedingLayout_RaisesLayoutAndDrawComplete ()
+    {
+        // Arrange
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (80, 25);
+
+        Runnable top = new () { App = app };
+        SessionToken? token = app.Begin (top);
+
+        PopoverTestClass popover = new ()
+        {
+            App = app,
+            Width = 10,
+            Height = 5
+        };
+        app.Popovers!.Register (popover);
+        app.Popovers.Show (popover);
+        app.LayoutAndDraw ();
+
+        int layoutAndDrawCompleteCount = 0;
+        app.LayoutAndDrawComplete += CountLayoutAndDrawComplete;
+        popover.SetNeedsLayout ();
+
+        // Act
+        app.LayoutAndDraw ();
+
+        // Assert
+        Assert.Equal (1, layoutAndDrawCompleteCount);
+
+        app.LayoutAndDrawComplete -= CountLayoutAndDrawComplete;
+        app.End (token!);
+        top.Dispose ();
+
+        return;
+
+        void CountLayoutAndDrawComplete (object? _, EventArgs __) => layoutAndDrawCompleteCount++;
+    }
+
+    // CoPilot - ChatGPT v4
+    [Fact]
+    public void LayoutAndDraw_UnderlyingViewNeedsDraw_RedrawsPopoverWithoutLayout ()
+    {
+        // Arrange
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (80, 25);
+
+        Runnable top = new () { App = app };
+
+        View content = new ()
+        {
+            Width = 10,
+            Height = 5
+        };
+        top.Add (content);
+
+        SessionToken? token = app.Begin (top);
+
+        PopoverTestClass popover = new ()
+        {
+            App = app,
+            Width = 10,
+            Height = 5
+        };
+        app.Popovers!.Register (popover);
+        app.Popovers.Show (popover);
+
+        app.LayoutAndDraw ();
+        popover.DrawCompleteCount = 0;
+        popover.LayoutPassCount = 0;
+
+        content.SetNeedsDraw ();
+
+        // Act
+        app.LayoutAndDraw ();
+
+        // Assert
+        Assert.Equal (1, popover.DrawCompleteCount);
+        Assert.Equal (0, popover.LayoutPassCount);
+
+        app.End (token!);
+        top.Dispose ();
+    }
+
     public class PopoverTestClass : View, IPopoverView
     {
         public List<Key> HandledKeys { get; } = [];
 
         public int NewCommandInvokeCount { get; private set; }
+
+        public int DrawCompleteCount { get; set; }
 
         public int LayoutPassCount { get; set; }
 
@@ -378,6 +550,12 @@ public class ApplicationPopoverTests
             }
 
             return false;
+        }
+
+        protected override void OnDrawComplete (DrawContext? context)
+        {
+            DrawCompleteCount++;
+            base.OnDrawComplete (context);
         }
 
         protected override void OnSubViewLayout (LayoutEventArgs args)


### PR DESCRIPTION
## Fixes

- Fixes #5122

## Proposed Changes/Todos

- [x] Prevent with precondition to avoid redrawn unnecessarily.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
