### PR TITLE
Catch TypeLoadException in config property host scan

### DIFF
--- a/Terminal.Gui/Configuration/ConfigProperty.cs
+++ b/Terminal.Gui/Configuration/ConfigProperty.cs
@@ -554,6 +554,10 @@ public class ConfigProperty
             {
                 continue;
             }
+            catch (TypeLoadException)
+            {
+                continue;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- catch `TypeLoadException` while scanning loaded assemblies for configuration property hosts
- keep the existing behavior of skipping assemblies that cannot be reflected safely

## Why
`ConfigProperty.Initialize()` scans `AppDomain.CurrentDomain.GetAssemblies()` and calls `assembly.GetTypes()`.
Under some .NET 10 test and coverage runner combinations, that call can throw `TypeLoadException` instead of `ReflectionTypeLoadException`.
A real example is `Microsoft.TestPlatform.CoreUtilities`, where loading certain custom attributes can trip a `MemberNotNullWhenAttribute` conflict.

Today Terminal.Gui skips `ReflectionTypeLoadException` and `BadImageFormatException`, but not `TypeLoadException`, so module initialization can fail early with a `TypeInitializationException` before tests or headless apps even get moving.

This change makes the scan treat `TypeLoadException` the same way as the other assembly-load reflection failures it already tolerates.

## Validation
- `dotnet build --configuration Debug --no-restore`
- `dotnet test --project Tests/UnitTestsParallelizable --no-build --filter-class '*ConfigPropertyTests'`
- `dotnet test --project Tests/UnitTestsParallelizable --no-build --filter-class '*ConfigPropertyHostTypesTests'`
- `dotnet test --project Tests/UnitTests.NonParallelizable --no-build --filter-class '*ConfigurationMangerTests'`
