### PR TITLE
Fixes #5075. TableView ShowVerticalCellLines renders incorrectly with custom ColorGetter

### DIFF
--- a/Terminal.Gui/Views/FileDialogs/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialogs/FileDialog.cs
@@ -200,7 +200,7 @@ public partial class FileDialog : Dialog, IDesignable
         _tableViewContainer.Add (_tableView);
 
         _tableView.Style.ShowHorizontalHeaderOverline = false;
-        _tableView.Style.ShowVerticalCellLines = true;
+        _tableView.Style.ShowVerticalCellLines = false;
         _tableView.Style.ShowVerticalHeaderLines = false;
         _tableView.Style.AlwaysShowHeaders = true;
         _tableView.Style.ShowHorizontalHeaderUnderline = false;

--- a/Terminal.Gui/Views/TableView/TableView.Drawing.cs
+++ b/Terminal.Gui/Views/TableView/TableView.Drawing.cs
@@ -434,6 +434,23 @@ public partial class TableView
             {
                 RenderSeparator (current.X + current.Width - 1, row, false);
             }
+
+            // When vertical cell lines are not rendered AND the separator symbol is the default
+            // invisible space, extend the cell's background color into the 1-char gap at the
+            // cell's right edge. The cell render itself only fills (Width - 1) chars (TruncateOrPad
+            // intentionally leaves 1 char for the cell boundary). Without this, the gap retains
+            // the row-clear's rowScheme color, producing visible "stripes" between cells when a
+            // custom ColumnStyle.ColorGetter is in use (e.g. FileDialog). See issue #5075.
+            if (!_style.ShowVerticalCellLines && SeparatorSymbol == ' ')
+            {
+                int gapX = current.X + current.Width - 1;
+
+                if (gapX >= Viewport.X && gapX < Viewport.X + Viewport.Width)
+                {
+                    SetAttribute (cellColor);
+                    AddRuneAt (gapX - Viewport.X, row, (Rune)' ');
+                }
+            }
         }
 
         if (!_style.ShowVerticalCellLines)
@@ -462,6 +479,16 @@ public partial class TableView
         }
 
         bool renderLines = isHeader ? _style.ShowVerticalHeaderLines : _style.ShowVerticalCellLines;
+
+        // When vertical lines are not rendered AND the separator symbol is the default space,
+        // skip drawing here. RenderRow handles the gap between cells separately by extending
+        // the cell's own background into the gap position (preserves custom ColorGetter colors).
+        // Drawing a space here with the row's normal scheme would overwrite that. See issue #5075.
+        if (!renderLines && SeparatorSymbol == ' ')
+        {
+            return;
+        }
+
         Rune symbol = renderLines ? Glyphs.VLine : (Rune)SeparatorSymbol;
         RenderRune (col, row, symbol);
     }

--- a/Tests/UnitTestsParallelizable/Views/TableViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TableViewTests.cs
@@ -508,6 +508,113 @@ public class TableViewTests : TestDriverBase
         Assert.True (result.GetColumns () <= 4, $"Truncated result '{result}' exceeds available space");
     }
 
+    // Claude - Opus 4.5 — regression for issue #5075
+    // When ShowVerticalCellLines is false AND a custom ColorGetter is used, the position between cells
+    // (the separator column, current.X - 1) was being overdrawn with a space using the row's normal
+    // scheme. This punched a 1-cell hole in the cell's custom color. The fix skips the separator draw
+    // when the symbol would be the default space and lines are off — the cell padding has already
+    // filled that position with the cell's color.
+    [Fact]
+    public void ShowVerticalCellLines_False_WithCustomColorGetter_PreservesCellColorAtSeparator ()
+    {
+        IDriver driver = CreateTestDriver (40, 5);
+
+        TableView tableView = new () { Driver = driver };
+        tableView.BeginInit ();
+        tableView.EndInit ();
+        tableView.SchemeName = SchemeManager.SchemesToSchemeName (Schemes.Base);
+        tableView.Viewport = new Rectangle (0, 0, 40, 5);
+
+        tableView.Style.ShowHeaders = true;
+        tableView.Style.ShowHorizontalHeaderUnderline = false;
+        tableView.Style.ShowHorizontalHeaderOverline = false;
+        tableView.Style.AlwaysShowHeaders = true;
+        tableView.Style.ShowVerticalCellLines = false;
+        tableView.Style.ShowVerticalHeaderLines = false;
+        tableView.Style.ExpandLastColumn = false;
+        tableView.FullRowSelect = false;
+
+        // A custom scheme that is visibly distinct from the row scheme.
+        Scheme customScheme = new ()
+        {
+            Normal = new Attribute (Color.White, Color.Red),
+            Focus = new Attribute (Color.Red, Color.White),
+            HotNormal = new Attribute (Color.White, Color.Red),
+            HotFocus = new Attribute (Color.Red, Color.White),
+            Disabled = new Attribute (Color.White, Color.Red),
+            Active = new Attribute (Color.White, Color.Red)
+        };
+
+        tableView.Style.GetOrCreateColumnStyle (0).ColorGetter = _ => customScheme;
+        tableView.Style.GetOrCreateColumnStyle (1).ColorGetter = _ => customScheme;
+
+        DataTable dt = new ();
+        dt.Columns.Add ("A");
+        dt.Columns.Add ("B");
+        dt.Rows.Add ("aa", "bb");
+        tableView.Table = new DataTableSource (dt);
+
+        tableView.Layout ();
+        tableView.SetClipToScreen ();
+        tableView.Draw ();
+
+        // Find the row that contains the data ("aa" then "bb").
+        Cell [,] contents = driver.Contents!;
+        var dataRow = -1;
+
+        for (var r = 0; r < 5; r++)
+        {
+            var rowText = string.Empty;
+
+            for (var c = 0; c < 10; c++)
+            {
+                rowText += contents [r, c].Grapheme;
+            }
+
+            if (rowText.Contains ("aa") && rowText.Contains ("bb"))
+            {
+                dataRow = r;
+
+                break;
+            }
+        }
+
+        Assert.True (dataRow >= 0, "Expected a rendered data row containing 'aa' and 'bb'");
+
+        // Locate the columns for "aa" and "bb".
+        var aaCol = -1;
+        var bbCol = -1;
+
+        for (var c = 0; c < 39; c++)
+        {
+            if (aaCol < 0 && contents [dataRow, c].Grapheme == "a" && contents [dataRow, c + 1].Grapheme == "a")
+            {
+                aaCol = c;
+            }
+
+            if (bbCol < 0 && contents [dataRow, c].Grapheme == "b" && contents [dataRow, c + 1].Grapheme == "b")
+            {
+                bbCol = c;
+            }
+        }
+
+        Assert.True (aaCol >= 0 && bbCol > aaCol + 1, $"Expected 'aa' before 'bb'. aaCol={aaCol}, bbCol={bbCol}");
+
+        // The cells "aa" and "bb" must use the custom red background.
+        Assert.Equal (customScheme.Normal, contents [dataRow, aaCol].Attribute);
+        Assert.Equal (customScheme.Normal, contents [dataRow, bbCol].Attribute);
+
+        // The separator position is the gap between the end of "aa" and the start of "bb".
+        // Before the fix, this position was overdrawn with the row scheme attribute.
+        // After the fix, the cell padding's custom red attribute remains.
+        for (int c = aaCol + 2; c < bbCol; c++)
+        {
+            Assert.Equal (customScheme.Normal, contents [dataRow, c].Attribute);
+        }
+
+        tableView.Dispose ();
+    }
+
     [Fact]
     public void Test_CalculateMaxCellWidth_UsesGraphemeWidth ()
     {


### PR DESCRIPTION
- Fixes #5075

## Summary

When `Style.ShowVerticalCellLines` is `false` and a `ColumnStyle.ColorGetter` is in use (as in `FileDialog`), the 1-char gap between cells retained the row scheme's attribute. This produced visible "stripes" of the row scheme color cutting through custom-colored cells.

## Root cause

`TruncateOrPad` intentionally renders each cell to `(Width - 1)` chars, leaving 1 char "for cell boundary". With `ShowVerticalCellLines = true` that gap is filled by the VLine glyph in `RenderSeparator`. With `ShowVerticalCellLines = false`, `RenderSeparator` was overdrawing it with a space using `rowScheme.Normal/Disabled` — so cells with a custom `ColorGetter` had a `rowScheme`-colored stripe between them.

## Fix

Two coordinated changes in `Terminal.Gui/Views/TableView/TableView.Drawing.cs`:

1. **`RenderRow`** — after drawing each cell, when `!ShowVerticalCellLines && SeparatorSymbol == ' '`, explicitly fill the 1-char right-edge gap with the cell's own `cellColor`. Viewport-clipped to handle horizontal scroll.
2. **`RenderSeparator`** — skip drawing when the separator would be an invisible space and lines are off (`RenderRow` now owns the gap).

No behavior change for `ShowVerticalCellLines = true` (VLines still drawn), non-default `SeparatorSymbol`, `FullRowSelect`, or cells without a custom `ColorGetter`.

Also flips `FileDialog`'s `TableView` to `ShowVerticalCellLines = false` so it now uses the repaired rendering path — its custom file-type colors paint cleanly across the row.

## Tests

Added `ShowVerticalCellLines_False_WithCustomColorGetter_PreservesCellColorAtSeparator` in `Tests/UnitTestsParallelizable/Views/TableViewTests.cs` — sets up a 2-column table with a custom red `ColorGetter`, draws, and asserts both the cells and the separator gap between them carry the custom red attribute. Test fails on the unfixed code and passes after the fix.

## Test plan

- [x] New regression test passes
- [x] All 102 existing TableView tests pass
- [x] Full `UnitTestsParallelizable` suite passes (16,529 tests)
- [x] `UnitTests.NonParallelizable` suite passes (63 tests)

## To pull down this PR locally

```bash
git remote add copilot https://github.com/harder/Terminal.Gui.git
git fetch copilot fix-5075-table-vertical-cell-lines-color
git checkout copilot/fix-5075-table-vertical-cell-lines-color
```