### PR TITLE
Fixes #5145. ReadOnly TextView mouse selection still cannot include final character

### DIFF
--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Mouse.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Mouse.cs
@@ -274,7 +274,7 @@ public partial class TextView
             if (newInsertionIndex >= r.Count || (IsSelecting && p.X >= Math.Max (Viewport.Width - 1, 0)))
             {
                 Viewport = Viewport with { X = Math.Max (0, colsWidth - Viewport.Width + 1) };
-                CurrentColumn = Math.Max (r.Count - (ReadOnly ? 1 : 0), 0);
+                CurrentColumn = r.Count;
             }
             else if (Viewport.X + p.X == 0 || (IsSelecting && p.X == 0))
             {

--- a/Tests/UnitTestsParallelizable/Views/TextView.SelectionTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextView.SelectionTests.cs
@@ -302,4 +302,45 @@ public class TextViewSelectionTests
         Assert.Equal (28, tv.SelectionStartColumn);
         Assert.Equal (2, tv.SelectionStartRow);
     }
+
+    [Fact]
+    public void Mouse_Selection_ToTheEndOfLine_With_ReadOnly_FalseOrTrue_Works_Correctly ()
+    {
+        // // Test that mouse selection to the end of line works correctly with ReadOnly false or true
+        TextView tv = new ()
+        {
+            Width = 10,
+            Height = 2,
+            Text = "This is the first line.\nThis is the second line.\nThis is the third line.first"
+        };
+
+        tv.BeginInit ();
+        tv.EndInit ();
+
+        Assert.False (tv.ReadOnly);
+
+        // Simulate mouse selection from (0,0) to end of first line
+        tv.NewMouseEvent (new Mouse () { Position = new Point (0, 0), Flags = MouseFlags.LeftButtonPressed });
+        tv.NewMouseEvent (new Mouse () { Position = new Point (23, 0), Flags = MouseFlags.LeftButtonPressed | MouseFlags.PositionReport });
+        tv.NewMouseEvent (new Mouse () { Position = new Point (23, 0), Flags = MouseFlags.LeftButtonReleased });
+
+        Assert.Equal (new Point (23, 0), tv.InsertionPoint);
+        Assert.Equal (23, tv.SelectedLength);
+        Assert.Equal ("This is the first line.", tv.SelectedText);
+        Assert.True (tv.IsSelecting);
+
+        // Now set ReadOnly to true, reset position and repeat
+        tv.ReadOnly = true;
+        tv.InsertionPoint = Point.Empty;
+
+        // Simulate mouse selection from (0,0) to end of first line again
+        tv.NewMouseEvent (new Mouse () { Position = new Point (0, 0), Flags = MouseFlags.LeftButtonPressed });
+        tv.NewMouseEvent (new Mouse () { Position = new Point (23, 0), Flags = MouseFlags.LeftButtonPressed | MouseFlags.PositionReport });
+        tv.NewMouseEvent (new Mouse () { Position = new Point (23, 0), Flags = MouseFlags.LeftButtonReleased });
+
+        Assert.Equal (new Point (23, 0), tv.InsertionPoint);
+        Assert.Equal (23, tv.SelectedLength);
+        Assert.Equal ("This is the first line.", tv.SelectedText);
+        Assert.True (tv.IsSelecting);
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #5145

## Proposed Changes/Todos

- [x] Handle ReadOnly selection the same way as false or true

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
