### PR TITLE
fix: Region.XOR computes correct symmetric difference (#5167)

### DIFF
--- a/Terminal.Gui/Drawing/Region.cs
+++ b/Terminal.Gui/Drawing/Region.cs
@@ -215,9 +215,24 @@ public class Region
                 break;
 
             case RegionOp.XOR:
-                Exclude (region);
-                region.Combine (this, RegionOp.Difference);
-                _rectangles.AddRange (region._rectangles);
+
+                // Snapshot both operands before mutating either, so the symmetric
+                // difference is computed as (thisOriginal \ regionOriginal) ∪
+                // (regionOriginal \ thisOriginal) rather than against a partially
+                // mutated `this`.
+                Region thisOriginal = Clone ();
+                Region regionOriginal = region.Clone ();
+
+                // Reuse `thisOriginal` to hold (thisOriginal \ regionOriginal).
+                thisOriginal.Combine (regionOriginal, RegionOp.Difference);
+
+                // Reuse a fresh clone of the unmodified `this` for (regionOriginal \ thisOriginal).
+                Region regionMinusThis = region.Clone ();
+                regionMinusThis.Combine (Clone (), RegionOp.Difference);
+
+                _rectangles.Clear ();
+                _rectangles.AddRange (thisOriginal._rectangles);
+                _rectangles.AddRange (regionMinusThis._rectangles);
 
                 break;
 

--- a/Tests/UnitTestsParallelizable/Drawing/Region/RegionClassTests.cs
+++ b/Tests/UnitTestsParallelizable/Drawing/Region/RegionClassTests.cs
@@ -1103,4 +1103,30 @@ public class RegionClassTests
         Assert.Null (exception);
     }
 
+    // Claude - Opus 4.7
+    [Fact]
+    public void Combine_XOR_ProducesSymmetricDifference ()
+    {
+        // Issue #5167: XOR mutated `this` before computing `region - this`,
+        // producing a non-symmetric result. With A=(0,0,2,2) and B=(1,1,2,2)
+        // the only intersecting cell is (1,1); XOR(A,B) must contain every
+        // other cell from A and B but NOT (1,1).
+        Region a = new (new (0, 0, 2, 2));
+        Region b = new (new (1, 1, 2, 2));
+
+        a.Combine (b, RegionOp.XOR);
+
+        // Cells exclusive to A
+        Assert.True (a.Contains (0, 0));
+        Assert.True (a.Contains (1, 0));
+        Assert.True (a.Contains (0, 1));
+
+        // Cells exclusive to B
+        Assert.True (a.Contains (2, 1));
+        Assert.True (a.Contains (1, 2));
+        Assert.True (a.Contains (2, 2));
+
+        // The intersecting cell must be excluded from a symmetric difference.
+        Assert.False (a.Contains (1, 1));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #5167. The `RegionOp.XOR` branch in `Region.Combine` mutated `this` via `Exclude (region)` and then computed `(region - this)` against the already-mutated `this`, producing a non-symmetric result. The fix snapshots both operands first and computes `(thisOriginal \ regionOriginal) ∪ (regionOriginal \ thisOriginal)` so the symmetric difference is correctly preserved.

A regression test in `Tests/UnitTestsParallelizable/Drawing/Region/RegionClassTests.cs` covers the canonical case where two unit-overlapping 2x2 rectangles XOR'd must exclude the single intersecting cell.

## Test plan

- [ ] `dotnet build --no-restore`
- [ ] `dotnet test --project Tests/UnitTestsParallelizable --no-build --filter "FullyQualifiedName~Region"`
- [ ] Verify `Combine_XOR_ProducesSymmetricDifference` fails on `develop` and passes with this change.

> Note: this environment does not have the .NET SDK installed, so the local `dotnet build`/`dotnet test` commands could not be run. The fix and test were verified by tracing `SubtractRectangle` over the test inputs by hand: for `A=(0,0,2,2)`, `B=(1,1,2,2)`, the buggy code includes cell `(1,1)` in the result while the fixed code excludes it (the load-bearing assertion). CI must confirm the build and test pass.

https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv)_