### PR TITLE
fix: Key.Equals honors GetHashCode contract; drops Handled from identity (#5170)

### DIFF
--- a/Terminal.Gui/Input/Keyboard/Key.cs
+++ b/Terminal.Gui/Input/Keyboard/Key.cs
@@ -692,11 +692,16 @@ public class Key : EventArgs, IEquatable<Key>
     public static implicit operator string (Key key) => key.ToString ();
 
     /// <inheritdoc/>
+    /// <remarks>
+    ///     Two <see cref="Key"/> instances are considered equal when their <see cref="KeyCode"/> values match.
+    ///     <see cref="Handled"/> is per-event state and is intentionally excluded from identity so that
+    ///     <see cref="Equals(object?)"/> remains consistent with <see cref="GetHashCode"/>.
+    /// </remarks>
     public override bool Equals (object? obj)
     {
         if (obj is Key other)
         {
-            return other._keyCode == _keyCode && other.Handled == Handled;
+            return other._keyCode == _keyCode;
         }
 
         return false;

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/KeyEqualityTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/KeyEqualityTests.cs
@@ -1,0 +1,39 @@
+// Claude - Opus 4.7
+using System.Collections.Concurrent;
+
+namespace InputTests;
+
+public class KeyEqualityTests
+{
+    [Fact]
+    public void Equals_ReturnsTrue_WhenHandledDiffers ()
+    {
+        Key a = new (KeyCode.F1) { Handled = false };
+        Key b = new (KeyCode.F1) { Handled = true };
+
+        Assert.True (a.Equals (b));
+    }
+
+    [Fact]
+    public void GetHashCode_IsEqual_WhenHandledDiffers ()
+    {
+        Key a = new (KeyCode.F1) { Handled = false };
+        Key b = new (KeyCode.F1) { Handled = true };
+
+        Assert.Equal (a.GetHashCode (), b.GetHashCode ());
+    }
+
+    [Fact]
+    public void ConcurrentDictionary_Lookup_Succeeds_WhenHandledDiffers ()
+    {
+        // Regression test for issue #5170: KeyBindings is a ConcurrentDictionary<Key, KeyBinding>
+        // and lookup must succeed when the lookup Key has a different Handled value than the stored Key.
+        ConcurrentDictionary<Key, string> bindings = new ();
+        Key a = new (KeyCode.F1) { Handled = false };
+        Key b = new (KeyCode.F1) { Handled = true };
+        bindings [a] = "binding-A";
+
+        Assert.True (bindings.TryGetValue (b, out string? found));
+        Assert.Equal ("binding-A", found);
+    }
+}

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/KeyTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/KeyTests.cs
@@ -618,9 +618,9 @@ public class KeyTests
         Key b = Key.A;
         Assert.True (a.Equals (b));
 
+        // Handled is per-event state and not part of Key identity (see issue #5170).
         b.Handled = true;
-        Assert.False (a.Equals (b));
-
+        Assert.True (a.Equals (b));
     }
 
     [Fact]
@@ -634,12 +634,13 @@ public class KeyTests
     }
 
     [Fact]
-    public void Equals_Handled_Changed_ShouldReturnFalse_WhenNotEqual ()
+    public void Equals_Handled_Changed_ShouldReturnTrue_WhenHandledDiffers ()
     {
+        // Handled is per-event state and is intentionally excluded from Key identity (see issue #5170).
         Key a = Key.A;
         a.Handled = true;
         Key b = Key.A;
-        Assert.False (a.Equals (b));
+        Assert.True (a.Equals (b));
     }
 
 


### PR DESCRIPTION
## Summary

Fixes #5170.

- `Key.Equals(object?)` previously compared `_keyCode` **and** `Handled`, while `GetHashCode()` returned only `_keyCode.GetHashCode()`. This violated the .NET contract that equal objects must have equal hash codes, and broke `KeyBindings` (a `ConcurrentDictionary<Key, KeyBinding>`) when `Handled` flipped between storage and lookup.
- `Handled` is per-event state, not part of binding identity, so it is removed from the equality comparison. `IEquatable<Key>.Equals(Key?)` delegates to the same `Equals(object?)` logic and is now consistent. `KeyEqualityComparer` already used `KeyCode`-only equality and required no change.
- Added a regression test class `KeyEqualityTests` that exercises the load-bearing dictionary lookup case plus direct `Equals`/`GetHashCode` assertions across differing `Handled` values.

### Tests updated to match the corrected contract

Two existing tests in `Tests/UnitTestsParallelizable/Input/Keyboard/KeyTests.cs` encoded the buggy behavior and have been updated. The original assertions were wrong because they required `Equals` to return `false` for two `Key` instances with the same `KeyCode` but differing `Handled`, while `GetHashCode` returned the same value for both — a direct violation of `object.Equals`/`GetHashCode` consistency requirements:

- `Equals_ShouldReturnTrue_WhenEqual` — removed the assertion that flipping `Handled` makes two otherwise-equal keys unequal.
- `Equals_Handled_Changed_ShouldReturnFalse_WhenNotEqual` → renamed to `Equals_Handled_Changed_ShouldReturnTrue_WhenHandledDiffers` and inverted to assert the correct behavior.

## Test plan

- [ ] `dotnet build` succeeds with no new warnings
- [ ] `dotnet test --project Tests/UnitTestsParallelizable --filter "FullyQualifiedName~Key"` — all Key tests pass, including the three new `KeyEqualityTests`
- [ ] Confirm the new `ConcurrentDictionary_Lookup_Succeeds_WhenHandledDiffers` test fails on `develop` without the fix (demonstrates the regression coverage)
- [ ] Verify `KeyBindings` lookup behavior is unaffected for keys with matching `Handled` state

> Note: dotnet was unavailable in the worktree where this PR was assembled, so local `dotnet build` / `dotnet test` could not be run. The change is small and well-scoped (one method body, plus tests). Please verify CI passes before merging.

https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv)_