### PR TITLE
fix: TextFormatter vertical-text height uses display columns (#5172)

### DIFF
--- a/Terminal.Gui/Text/TextFormatter.cs
+++ b/Terminal.Gui/Text/TextFormatter.cs
@@ -553,7 +553,7 @@ public class TextFormatter
         if (IsVerticalDirection (Direction))
         {
             width = GetColumnsRequiredForVerticalText (lines, 0, lines.Count, TabWidth);
-            height = lines.Max (static line => line.Length);
+            height = lines.Max (static line => line.GetColumns ());
         }
         else
         {

--- a/Tests/UnitTestsParallelizable/Text/TextFormatterTests.cs
+++ b/Tests/UnitTestsParallelizable/Text/TextFormatterTests.cs
@@ -1989,6 +1989,24 @@ public class TextFormatterTests (ITestOutputHelper output) : TestDriverBase
         Assert.Equal (new (expectedWidth, expectedHeight), tf.FormatAndGetSize ());
     }
 
+    // Claude - Opus 4.7
+    [Theory]
+    [InlineData ("ABC", 3)] // ASCII sanity
+    [InlineData ("中文字", 6)] // CJK: 3 ideographs x 2 columns each
+    [InlineData ("🙂", 2)] // emoji surrogate pair
+    public void FormatAndGetSize_VerticalHeight_UsesDisplayColumns (string line, int expectedHeight)
+    {
+        TextFormatter tf = new ()
+        {
+            Direction = TextDirection.TopBottom_LeftRight,
+            Text = line
+        };
+
+        Size size = tf.FormatAndGetSize ();
+
+        Assert.Equal (expectedHeight, size.Height);
+    }
+
     [Fact]
     public void WordWrap_BigWidth ()
     {


### PR DESCRIPTION
## Summary

Fixes #5172.

In `TextFormatter.FormatAndGetSize()`, the vertical-direction branch computed height via `lines.Max(line => line.Length)`, which counts UTF-16 code units rather than terminal display columns. CJK ideographs, emoji surrogate pairs, and combining-mark sequences therefore returned an incorrect height.

- Replace `line.Length` with `line.GetColumns()` so the vertical branch uses the same grapheme-aware measurement as the horizontal branch (and as required by `.claude/rules/unicode-graphemes.md`).
- Add a `[Theory]` to `Tests/UnitTestsParallelizable/Text/TextFormatterTests.cs` covering ASCII, CJK, and emoji vertical-height cases.

## Test plan

- [ ] `dotnet build` passes with no new warnings.
- [ ] `dotnet test --project Tests/UnitTestsParallelizable --filter "FullyQualifiedName~TextFormatter"` passes (including the new `FormatAndGetSize_VerticalHeight_UsesDisplayColumns` theory).
- [ ] New test fails on `develop` prior to the fix (e.g. `中文字` returns height 3 instead of 6) and passes after.

https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv)_