### PR TITLE
fix: ConcurrentDictionaryJsonConverter rejects duplicate keys (#5173)

### DIFF
--- a/Terminal.Gui/Configuration/ConcurrentDictionaryJsonConverter.cs
+++ b/Terminal.Gui/Configuration/ConcurrentDictionaryJsonConverter.cs
@@ -35,7 +35,11 @@ internal class ConcurrentDictionaryJsonConverter<T> : JsonConverter<ConcurrentDi
                     string key = reader.GetString();
                     reader.Read();
                     object value = JsonSerializer.Deserialize(ref reader, typeof(T), ConfigurationManager.SerializerContext);
-                    dictionary.TryAdd(key, (T)value);
+
+                    if (!dictionary.TryAdd (key, (T)value))
+                    {
+                        throw new JsonException ($"Duplicate key '{key}' in dictionary.");
+                    }
                 }
             }
             else if (reader.TokenType == JsonTokenType.EndArray)

--- a/Terminal.Gui/Configuration/ConcurrentDictionaryJsonConverter.cs
+++ b/Terminal.Gui/Configuration/ConcurrentDictionaryJsonConverter.cs
@@ -7,7 +7,7 @@ namespace Terminal.Gui.Configuration;
 
 internal class ConcurrentDictionaryJsonConverter<T> : JsonConverter<ConcurrentDictionary<string, T>>
 {
-    public override ConcurrentDictionary<string, T> Read(
+    public override ConcurrentDictionary<string, T> Read (
         ref Utf8JsonReader reader,
         Type typeToConvert,
         JsonSerializerOptions options
@@ -15,7 +15,7 @@ internal class ConcurrentDictionaryJsonConverter<T> : JsonConverter<ConcurrentDi
     {
         if (reader.TokenType != JsonTokenType.StartArray)
         {
-            throw new JsonException($"Expected a JSON array (\"[ {{ ... }} ]\"), but got \"{reader.TokenType}\".");
+            throw new JsonException ($"Expected a JSON array (\"[ {{ ... }} ]\"), but got \"{reader.TokenType}\".");
         }
 
         // If the Json options indicate ignoring case, use the invariant culture ignore case comparer
@@ -24,17 +24,17 @@ internal class ConcurrentDictionaryJsonConverter<T> : JsonConverter<ConcurrentDi
                                                               ? StringComparer.InvariantCultureIgnoreCase
                                                               : StringComparer.InvariantCulture);
 
-        while (reader.Read())
+        while (reader.Read ())
         {
             if (reader.TokenType == JsonTokenType.StartObject)
             {
-                reader.Read();
+                reader.Read ();
 
                 if (reader.TokenType == JsonTokenType.PropertyName)
                 {
-                    string key = reader.GetString();
-                    reader.Read();
-                    object value = JsonSerializer.Deserialize(ref reader, typeof(T), ConfigurationManager.SerializerContext);
+                    string key = reader.GetString ();
+                    reader.Read ();
+                    object value = JsonSerializer.Deserialize (ref reader, typeof (T), ConfigurationManager.SerializerContext);
 
                     if (!dictionary.TryAdd (key, (T)value))
                     {

--- a/Tests/UnitTestsParallelizable/Configuration/ConcurrentDictionaryJsonConverterTests.cs
+++ b/Tests/UnitTestsParallelizable/Configuration/ConcurrentDictionaryJsonConverterTests.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Terminal.Gui.Configuration;
+
+namespace ConfigurationTests;
+
+public class ConcurrentDictionaryJsonConverterTests
+{
+    // Claude - Opus 4.7
+    [Fact]
+    public void Read_RejectsDuplicateKeys ()
+    {
+        const string json = """
+                            [
+                              { "alpha": "first" },
+                              { "alpha": "second" }
+                            ]
+                            """;
+
+        JsonSerializerOptions options = new ()
+        {
+            Converters = { new ConcurrentDictionaryJsonConverter<string> () }
+        };
+
+        Assert.Throws<JsonException> (
+                                      () => JsonSerializer.Deserialize<ConcurrentDictionary<string, string>> (json, options));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5173.

- `ConcurrentDictionaryJsonConverter<T>.Read` was calling `dictionary.TryAdd(key, (T)value)` and ignoring the return value, so duplicate keys in input JSON were silently dropped instead of producing an error.
- The companion `DictionaryJsonConverter<T>` was already corrected (it uses `dictionary.Add(...)` which throws on duplicate); this sibling was missed.
- Now throws `JsonException` on duplicate, matching the duplicate-rejection semantics of `DictionaryJsonConverter`.

## Test plan

- [x] Added `ConcurrentDictionaryJsonConverterTests.Read_RejectsDuplicateKeys` to `Tests/UnitTestsParallelizable/Configuration/`.
- [x] Verified the new test fails on `develop` (silently passes — no exception thrown).
- [x] Verified the new test passes after the fix.
- [x] Ran the full `Configuration` test suite in `UnitTests.Parallelizable` — all 215 tests pass, no regressions.

https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv)_