### PR TITLE
fix: AnsiOutput.Dispose parks cursor on last row of inline region (#5166)

### DIFF
--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -359,15 +359,35 @@ public class AnsiOutput : OutputBase, IOutput
         }
     }
 
+    /// <summary>
+    ///     Computes the 1-indexed terminal row of the last row of the inline application region.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="Rectangle.Height"/> is exclusive: <c>Y + Height</c> is the row immediately
+    ///         <em>after</em> the region. The last row inside the region is <c>Y + Height - 1</c>.
+    ///         ANSI cursor-positioning sequences are 1-indexed, but <see cref="Rectangle.Y"/> is already
+    ///         the 1-indexed terminal row offset for the inline region, so no additional adjustment is
+    ///         required.
+    ///     </para>
+    ///     <para>
+    ///         Used by <see cref="Dispose"/> to park the cursor on the final row of the inline region
+    ///         on shutdown. See issue #5166.
+    ///     </para>
+    /// </remarks>
+    /// <param name="appScreen">The inline application region rectangle.</param>
+    /// <returns>The 1-indexed terminal row of the last row of the region.</returns>
+    internal static int GetInlineLastRow (Rectangle appScreen) => appScreen.Y + appScreen.Height - 1;
+
     /// <inheritdoc/>
     public void Dispose ()
     {
         try
         {
-            if (_platform == AnsiPlatform.Degraded)
-            {
-                return;
-            }
+            // Note: each Write below short-circuits the platform-specific output path when
+            // <see cref="_platform"/> is <see cref="AnsiPlatform.Degraded"/>, but still
+            // appends to the buffered last-output (see <see cref="OutputBase.Write(StringBuilder)"/>),
+            // which keeps shutdown sequences observable to tests.
 
             // Restore terminal state: disable mouse, reset attributes, show cursor
             Write (EscSeqUtils.CSI_DisableMouseEvents);
@@ -380,7 +400,7 @@ public class AnsiOutput : OutputBase, IOutput
                 // Position to the last row of the inline region (guaranteed to exist),
                 // then write \n to scroll the terminal if at the bottom edge.
                 Rectangle appScreen = AppScreenGetter?.Invoke () ?? default;
-                int lastInlineRow = appScreen.Y + appScreen.Height; // 1-indexed last row
+                int lastInlineRow = GetInlineLastRow (appScreen);
                 Write (EscSeqUtils.CSI_SetCursorPosition (lastInlineRow, 1));
                 Write ("\n");
             }

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiDriver/AnsiOutputInlineDisposeTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiDriver/AnsiOutputInlineDisposeTests.cs
@@ -1,0 +1,67 @@
+// Claude - Opus 4.7
+
+namespace DriverTests.AnsiDriver;
+
+/// <summary>
+///     Tests for <see cref="AnsiOutput.Dispose"/> in <see cref="AppModel.Inline"/> mode.
+///     Verifies that the cursor is parked on the last row of the inline region (regression
+///     guard for issue #5166: <c>lastInlineRow</c> off-by-one parked cursor one row past
+///     the region, scrolling the host terminal on shutdown).
+/// </summary>
+[Collection ("Driver Tests")]
+public class AnsiOutputInlineDisposeTests
+{
+    [Theory]
+    [Trait ("Category", "LowLevelDriver")]
+    [InlineData (1, 1)]
+    [InlineData (1, 5)]
+    [InlineData (4, 6)]
+    [InlineData (10, 1)]
+    [InlineData (10, 24)]
+    public void GetInlineLastRow_ReturnsLastRowOfRegion_NotOnePast (int regionY, int regionHeight)
+    {
+        // Arrange
+        Rectangle appScreen = new (0, regionY, 80, regionHeight);
+        int expected = regionY + regionHeight - 1;
+        int forbidden = regionY + regionHeight;
+
+        // Act
+        int actual = AnsiOutput.GetInlineLastRow (appScreen);
+
+        // Assert
+        Assert.Equal (expected, actual);
+        Assert.NotEqual (forbidden, actual);
+    }
+
+    [Theory]
+    [Trait ("Category", "LowLevelDriver")]
+    [InlineData (1, 1)]
+    [InlineData (1, 5)]
+    [InlineData (4, 6)]
+    [InlineData (10, 1)]
+    [InlineData (10, 24)]
+    public void Dispose_Inline_ParksCursorOnLastRowOfRegion (int regionY, int regionHeight)
+    {
+        // Arrange
+        Rectangle appScreen = new (0, regionY, 80, regionHeight);
+        AnsiOutput output = new (AppModel.Inline)
+        {
+            AppScreenGetter = () => appScreen
+        };
+
+        // Act
+        output.Dispose ();
+        string written = output.GetLastOutput ();
+
+        // Assert
+        // ANSI cursor positioning is 1-indexed. appScreen.Y is already the 1-indexed
+        // terminal row offset for the inline region, so the last row is Y + Height - 1.
+        int expectedAnsiRow = regionY + regionHeight - 1;
+        int forbiddenAnsiRow = regionY + regionHeight;
+        string expectedSequence = EscSeqUtils.CSI_SetCursorPosition (expectedAnsiRow, 1);
+        string forbiddenSequence = EscSeqUtils.CSI_SetCursorPosition (forbiddenAnsiRow, 1);
+
+        Assert.Contains (expectedSequence, written);
+        Assert.DoesNotContain (forbiddenSequence, written);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5166.

In inline mode, `AnsiOutput.Dispose()` computed the final cursor row as `appScreen.Y + appScreen.Height` — one row *past* the inline region. The cursor was repositioned outside the region on shutdown, scrolling the host terminal and leaving stray content below the app.

`Rectangle.Height` is exclusive; the 1-indexed last row of the region is `Y + Height - 1`.

## Changes

- `Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs`
  - Extract the row calculation into an internal static helper `GetInlineLastRow(Rectangle)` that returns `appScreen.Y + appScreen.Height - 1` (the fix).
  - Remove the `_platform == AnsiPlatform.Degraded` early-return in `Dispose()`. Each `Write` call already short-circuits the platform-specific output path in degraded mode; the early-return only suppressed the buffered last-output that tests rely on to observe shutdown sequences. Real terminal behavior is unchanged.
- `Tests/UnitTestsParallelizable/Drivers/AnsiDriver/AnsiOutputInlineDisposeTests.cs` (new)
  - Theory test verifying `GetInlineLastRow` returns `Y + Height - 1` (and not `Y + Height`) across multiple region offsets/heights.
  - Theory test that drives `AnsiOutput.Dispose()` in inline mode with a known `appScreen` rectangle and asserts via `GetLastOutput()` that the emitted `CSI ... H` cursor-positioning sequence targets the 1-indexed last row of the region — and explicitly does not target one row past it.

## Test plan

- [x] `dotnet build Tests/UnitTestsParallelizable` succeeds.
- [x] `dotnet test --project Tests/UnitTestsParallelizable --filter-class "*AnsiOutputInlineDisposeTests*"` — all 10 cases pass with the fix applied.
- [x] Reverted the helper to the buggy `appScreen.Y + appScreen.Height` and re-ran: all 10 cases fail (`Assert.Equal()` mismatch on the row), confirming the test demonstrates the bug.
- [x] Restored the fix and re-ran: all 10 cases pass.
- [x] All other existing `*AnsiOutput*` tests in `UnitTestsParallelizable` still pass.

https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv)_