### PR TITLE
fix: ApplicationImpl.Begin raises SessionBegun after state changes (#5162)

### DIFF
--- a/Terminal.Gui/App/ApplicationImpl.Run.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Run.cs
@@ -151,7 +151,7 @@ internal partial class ApplicationImpl
             TopRunnable = runnable;
 
             // Update cached state atomically - IsRunning and IsModal are now consistent
-            SessionBegun?.Invoke (this, new SessionTokenEventArgs (token));
+            // (CWP: state mutations happen BEFORE the SessionBegun notification below)
             runnable.SetIsRunning (true);
             runnable.SetIsModal (true);
 
@@ -160,6 +160,10 @@ internal partial class ApplicationImpl
         }
 
         // END CRITICAL SECTION - IsRunning/IsModal now thread-safe
+
+        // CWP: Raise SessionBegun AFTER all state mutations so subscribers
+        // observe a fully-consistent session token (IsRunning/IsModal == true).
+        SessionBegun?.Invoke (this, new SessionTokenEventArgs (token));
 
         // Fire events AFTER lock released (avoid deadlocks in event handlers)
         previousTop?.RaiseIsModalChangedEvent (false);

--- a/Tests/UnitTests.NonParallelizable/Application/SessionBegunCwpTests.cs
+++ b/Tests/UnitTests.NonParallelizable/Application/SessionBegunCwpTests.cs
@@ -1,0 +1,58 @@
+#nullable enable
+namespace UnitTests.NonParallelizable.ApplicationTests;
+
+/// <summary>
+///     Regression tests for issue #5162. Ensures that <see cref="IApplication.SessionBegun"/>
+///     is raised AFTER all session state mutations, per the Cancellable Workflow Pattern (CWP):
+///     subscribers must observe a fully-consistent <see cref="SessionToken"/> with
+///     <see cref="IRunnable.IsRunning"/> and <see cref="IRunnable.IsModal"/> already set to
+///     <see langword="true"/>.
+/// </summary>
+public class SessionBegunCwpTests
+{
+    // Claude - Opus 4.7
+    [Fact]
+    public void SessionBegun_Raised_After_IsRunning_And_IsModal_Set_True ()
+    {
+        ApplicationImpl.ResetModelUsageTracking ();
+
+        IApplication app = Application.Create ();
+        Runnable? runnable = null;
+
+        bool? observedIsRunning = null;
+        bool? observedIsModal = null;
+
+        try
+        {
+            runnable = new ();
+
+            EventHandler<SessionTokenEventArgs> handler = (_, e) =>
+                                                          {
+                                                              IRunnable? r = e.State.Runnable;
+
+                                                              if (r is null) { return; }
+
+                                                              observedIsRunning = r.IsRunning;
+                                                              observedIsModal = r.IsModal;
+                                                          };
+
+            app.SessionBegun += handler;
+
+            SessionToken? token = app.Begin (runnable);
+
+            app.SessionBegun -= handler;
+
+            Assert.NotNull (token);
+            Assert.True (observedIsRunning, "SessionBegun fired before SetIsRunning(true).");
+            Assert.True (observedIsModal, "SessionBegun fired before SetIsModal(true).");
+
+            app.End (token);
+        }
+        finally
+        {
+            runnable?.Dispose ();
+            app.Dispose ();
+            ApplicationImpl.ResetModelUsageTracking ();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5162.

## Summary

- `ApplicationImpl.Begin` violated the Cancellable Workflow Pattern (CWP): it invoked the `SessionBegun` event inside the session-stack lock and **before** calling `SetIsRunning(true)` / `SetIsModal(true)` on the runnable. Subscribers observed a `SessionToken` whose `Runnable.IsRunning` and `IsModal` were still `false`.
- Move the state mutations (`SetIsRunning(true)`, `SetIsModal(true)`, `previousTop?.SetIsModal(false)`) inside the lock, and raise `SessionBegun` **after** the lock is released. This mirrors the existing symmetric `End()` / `SessionEnded` pattern.
- Add a regression test in `Tests/UnitTests.NonParallelizable` that subscribes to `SessionBegun` and asserts `IsRunning == true` and `IsModal == true` on the event's `SessionToken.Runnable`.

The test was empirically verified to FAIL on `develop` (with the original ordering) and PASS after the fix. All 14 existing `BeginEnd` tests and the broader `ApplicationTests` suite (548 tests) continue to pass.

## Test plan

- [x] New test `SessionBegunCwpTests.SessionBegun_Raised_After_IsRunning_And_IsModal_Set_True` fails on unfixed code (observed `IsRunning == false`)
- [x] New test passes after the fix
- [x] `dotnet build` succeeds
- [x] Existing `BeginEndTests` (14 tests) pass
- [x] Broader `ApplicationTests` namespace in `UnitTestsParallelizable` passes (548/548 + 2 pre-existing skips)

https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv)_