### PR TITLE
fix: ApplicationImpl.Invoke throws NotInitializedException after Dispose (#5163)

### DIFF
--- a/Terminal.Gui/App/ApplicationImpl.Run.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Run.cs
@@ -57,7 +57,7 @@ internal partial class ApplicationImpl
     {
         if (!Initialized)
         {
-            throw new NotInitializedException (@"Init must be called before Invoke.");
+            throw new NotInitializedException (nameof (Invoke));
         }
 
         // If we are already on the main UI thread
@@ -80,9 +80,11 @@ internal partial class ApplicationImpl
     /// <inheritdoc/>
     public void Invoke (Action action)
     {
+        ArgumentNullException.ThrowIfNull (action);
+
         if (!Initialized)
         {
-            throw new NotInitializedException (@"Init must be called before Invoke.");
+            throw new NotInitializedException (nameof (Invoke));
         }
 
         // If we are already on the main UI thread

--- a/Terminal.Gui/App/ApplicationImpl.Run.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Run.cs
@@ -55,6 +55,11 @@ internal partial class ApplicationImpl
     /// <inheritdoc/>
     public void Invoke (Action<IApplication>? action)
     {
+        if (!Initialized)
+        {
+            throw new NotInitializedException (@"Init must be called before Invoke.");
+        }
+
         // If we are already on the main UI thread
         if (TopRunnableView is IRunnable { IsRunning: true } && MainThreadId == Thread.CurrentThread.ManagedThreadId)
         {
@@ -75,6 +80,11 @@ internal partial class ApplicationImpl
     /// <inheritdoc/>
     public void Invoke (Action action)
     {
+        if (!Initialized)
+        {
+            throw new NotInitializedException (@"Init must be called before Invoke.");
+        }
+
         // If we are already on the main UI thread
         if (TopRunnableView is IRunnable { IsRunning: true } && MainThreadId == Thread.CurrentThread.ManagedThreadId)
         {

--- a/Terminal.Gui/App/IApplication.cs
+++ b/Terminal.Gui/App/IApplication.cs
@@ -354,6 +354,9 @@ public interface IApplication : IDisposable
     ///         iteration.
     ///     </para>
     /// </remarks>
+    /// <exception cref="NotInitializedException">
+    ///     Thrown when <see cref="Init"/> has not been called or after <see cref="IDisposable.Dispose"/> has been called.
+    /// </exception>
     void Invoke (Action<IApplication>? action);
 
     /// <summary>Runs <paramref name="action"/> on the main UI loop thread.</summary>
@@ -365,6 +368,9 @@ public interface IApplication : IDisposable
     ///         iteration.
     ///     </para>
     /// </remarks>
+    /// <exception cref="NotInitializedException">
+    ///     Thrown when <see cref="Init"/> has not been called or after <see cref="IDisposable.Dispose"/> has been called.
+    /// </exception>
     void Invoke (Action action);
 
     #endregion Iteration & Invoke

--- a/Tests/UnitTests.NonParallelizable/Application/ApplicationInvokeLifecycleTests.cs
+++ b/Tests/UnitTests.NonParallelizable/Application/ApplicationInvokeLifecycleTests.cs
@@ -1,0 +1,63 @@
+// Claude - Opus 4.7
+#nullable enable
+
+namespace UnitTests.NonParallelizable.ApplicationTests;
+
+/// <summary>
+///     Tests asserting <see cref="IApplication.Invoke(Action)"/> and
+///     <see cref="IApplication.Invoke(System.Action{IApplication})"/> contract relative to the
+///     <see cref="IApplication.Init"/> / <see cref="IDisposable.Dispose"/> lifecycle.
+///     Regression coverage for issue #5163.
+/// </summary>
+public class ApplicationInvokeLifecycleTests
+{
+    [Fact]
+    public void Invoke_Action_BeforeInit_Throws_NotInitializedException ()
+    {
+        IApplication app = Application.Create ();
+
+        try
+        {
+            Assert.Throws<NotInitializedException> (() => app.Invoke (() => { }));
+        }
+        finally
+        {
+            app.Dispose ();
+        }
+    }
+
+    [Fact]
+    public void Invoke_ActionOfApplication_BeforeInit_Throws_NotInitializedException ()
+    {
+        IApplication app = Application.Create ();
+
+        try
+        {
+            Assert.Throws<NotInitializedException> (() => app.Invoke (static _ => { }));
+        }
+        finally
+        {
+            app.Dispose ();
+        }
+    }
+
+    [Fact]
+    public void Invoke_Action_AfterDispose_Throws_NotInitializedException ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Dispose ();
+
+        Assert.Throws<NotInitializedException> (() => app.Invoke (() => { }));
+    }
+
+    [Fact]
+    public void Invoke_ActionOfApplication_AfterDispose_Throws_NotInitializedException ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Dispose ();
+
+        Assert.Throws<NotInitializedException> (() => app.Invoke (static _ => { }));
+    }
+}

--- a/Tests/UnitTests.NonParallelizable/Application/ApplicationInvokeLifecycleTests.cs
+++ b/Tests/UnitTests.NonParallelizable/Application/ApplicationInvokeLifecycleTests.cs
@@ -45,8 +45,15 @@ public class ApplicationInvokeLifecycleTests
     public void Invoke_Action_AfterDispose_Throws_NotInitializedException ()
     {
         IApplication app = Application.Create ();
-        app.Init (DriverRegistry.Names.ANSI);
-        app.Dispose ();
+
+        try
+        {
+            app.Init (DriverRegistry.Names.ANSI);
+        }
+        finally
+        {
+            app.Dispose ();
+        }
 
         Assert.Throws<NotInitializedException> (() => app.Invoke (() => { }));
     }
@@ -55,8 +62,15 @@ public class ApplicationInvokeLifecycleTests
     public void Invoke_ActionOfApplication_AfterDispose_Throws_NotInitializedException ()
     {
         IApplication app = Application.Create ();
-        app.Init (DriverRegistry.Names.ANSI);
-        app.Dispose ();
+
+        try
+        {
+            app.Init (DriverRegistry.Names.ANSI);
+        }
+        finally
+        {
+            app.Dispose ();
+        }
 
         Assert.Throws<NotInitializedException> (() => app.Invoke (static _ => { }));
     }


### PR DESCRIPTION
Fixes #5163.

## Summary

- Both `IApplication.Invoke(Action)` and `IApplication.Invoke(Action<IApplication>)` overloads previously dropped the action silently when called before `Init()` or after `Dispose()`: the thread-affinity fast path skips (`MainThreadId` is null and there is no top runnable) and the `TimedEvents.Add` fallback queues onto a stopped timer queue.
- Add an `Initialized` guard at the top of both overloads so the pre-Init / post-Dispose case fails loudly with `NotInitializedException`. This matches the existing guard already used by `Run(IRunnable, …)` in the same partial.
- Add `<exception>` documentation to the `IApplication.Invoke` interface contracts so the new behavior is part of the spec.
- Add four regression tests in `Tests/UnitTests.NonParallelizable/Application/ApplicationInvokeLifecycleTests.cs` (one per overload, before-Init and after-Dispose).

## Out of scope

The deeper thread-affinity race in the fast-path between reads of `TopRunnableView` / `MainThreadId` and concurrent shutdown is **intentionally not addressed** here. Issue #5163 calls that out as a redesign; this PR ships only the narrow, testable contract change (loud failure post-Dispose).

## Test plan

- [x] Added `ApplicationInvokeLifecycleTests` (4 tests) covering both overloads, pre-Init and post-Dispose.
- [x] Confirmed the new tests **fail on `develop`** (production fix stashed) — current code drops the action silently.
- [x] Confirmed the new tests **pass with the fix**.
- [x] Ran all `*Invoke*` and `ApplicationImplTests` tests in both `UnitTests.NonParallelizable` and `UnitTestsParallelizable` — no regressions (16 + 103 + 13 passing).
- [x] No new build warnings.

https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv)_