### PR TITLE
fix: AnsiOutput.Dispose flushes cleanup ANSI sequences (#5165)

### DIFF
--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -411,6 +411,14 @@ public class AnsiOutput : OutputBase, IOutput
             }
 
             Write (EscSeqUtils.CSI_ShowCursor);
+
+            // Flush the native stdout to ensure all cleanup sequences (mouse-off, SGR reset,
+            // alt-buffer restore, cursor show, etc.) reach the terminal before we return.
+            // Mirrors the FlushNative call in the constructor after init sequences are written.
+            // Without this, buffered cleanup bytes may be discarded when the process exits or
+            // when the underlying handle is closed by <see cref="WindowsVTOutputHelper.Dispose"/>.
+            // See issue #5165.
+            AnsiTerminalHelper.FlushNative (_platform);
         }
         catch
         {

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -359,15 +359,35 @@ public class AnsiOutput : OutputBase, IOutput
         }
     }
 
+    /// <summary>
+    ///     Computes the 1-indexed terminal row of the last row of the inline application region.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="Rectangle.Height"/> is exclusive: <c>Y + Height</c> is the row immediately
+    ///         <em>after</em> the region. The last row inside the region is <c>Y + Height - 1</c>.
+    ///         ANSI cursor-positioning sequences are 1-indexed, but <see cref="Rectangle.Y"/> is already
+    ///         the 1-indexed terminal row offset for the inline region, so no additional adjustment is
+    ///         required.
+    ///     </para>
+    ///     <para>
+    ///         Used by <see cref="Dispose"/> to park the cursor on the final row of the inline region
+    ///         on shutdown. See issue #5166.
+    ///     </para>
+    /// </remarks>
+    /// <param name="appScreen">The inline application region rectangle.</param>
+    /// <returns>The 1-indexed terminal row of the last row of the region.</returns>
+    internal static int GetInlineLastRow (Rectangle appScreen) => appScreen.Y + appScreen.Height - 1;
+
     /// <inheritdoc/>
     public void Dispose ()
     {
         try
         {
-            if (_platform == AnsiPlatform.Degraded)
-            {
-                return;
-            }
+            // Note: each Write below short-circuits the platform-specific output path when
+            // <see cref="_platform"/> is <see cref="AnsiPlatform.Degraded"/>, but still
+            // appends to the buffered last-output (see <see cref="OutputBase.Write(StringBuilder)"/>),
+            // which keeps shutdown sequences observable to tests.
 
             // Restore terminal state: disable mouse, reset attributes, show cursor
             Write (EscSeqUtils.CSI_DisableMouseEvents);
@@ -380,7 +400,7 @@ public class AnsiOutput : OutputBase, IOutput
                 // Position to the last row of the inline region (guaranteed to exist),
                 // then write \n to scroll the terminal if at the bottom edge.
                 Rectangle appScreen = AppScreenGetter?.Invoke () ?? default;
-                int lastInlineRow = appScreen.Y + appScreen.Height; // 1-indexed last row
+                int lastInlineRow = GetInlineLastRow (appScreen);
                 Write (EscSeqUtils.CSI_SetCursorPosition (lastInlineRow, 1));
                 Write ("\n");
             }

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiDriver/AnsiOutputDisposeFlushTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiDriver/AnsiOutputDisposeFlushTests.cs
@@ -1,0 +1,102 @@
+// Claude - Opus 4.7
+
+namespace DriverTests.AnsiDriver;
+
+/// <summary>
+///     Tests for <see cref="AnsiOutput.Dispose"/> verifying that the cleanup ANSI choreography
+///     (mouse-off, SGR reset, alt-buffer restore / inline cursor park, show cursor) is fully
+///     written to the output buffer before <see cref="AnsiOutput.Dispose"/> returns.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Regression guard for issue #5165: <see cref="AnsiOutput.Dispose"/> wrote cleanup
+///         ANSI sequences but did not flush the underlying native stdout before returning,
+///         allowing buffered cleanup bytes to be discarded on process exit. Also verifies
+///         that every cleanup sequence is emitted (none are skipped or short-circuited).
+///     </para>
+///     <para>
+///         The native stdout flush itself is a no-op when <c>_platform</c> is
+///         <see cref="AnsiPlatform.Degraded"/> (the only platform in headless test
+///         environments), so the closest practical proxy is to assert that every cleanup
+///         sequence is observable via <see cref="OutputBase.GetLastOutput"/>.
+///     </para>
+/// </remarks>
+[Collection ("Driver Tests")]
+public class AnsiOutputDisposeFlushTests
+{
+    [Fact]
+    [Trait ("Category", "LowLevelDriver")]
+    public void Dispose_FullScreen_WritesAllCleanupSequences ()
+    {
+        // Arrange
+        AnsiOutput output = new (AppModel.FullScreen);
+
+        // Act
+        output.Dispose ();
+        string written = output.GetLastOutput ();
+
+        // Assert — every FullScreen cleanup sequence must be observable.
+        Assert.Contains (EscSeqUtils.CSI_DisableMouseEvents, written);
+        Assert.Contains (EscSeqUtils.CSI_ResetAttributes, written);
+        Assert.Contains (EscSeqUtils.CSI_RestoreCursorAndRestoreAltBufferWithBackscroll, written);
+        Assert.Contains (EscSeqUtils.CSI_ShowCursor, written);
+    }
+
+    [Fact]
+    [Trait ("Category", "LowLevelDriver")]
+    public void Dispose_Inline_WritesAllCleanupSequences ()
+    {
+        // Arrange
+        Rectangle appScreen = new (0, 1, 80, 5);
+        AnsiOutput output = new (AppModel.Inline)
+        {
+            AppScreenGetter = () => appScreen
+        };
+
+        // Act
+        output.Dispose ();
+        string written = output.GetLastOutput ();
+
+        // Assert — every Inline cleanup sequence must be observable.
+        Assert.Contains (EscSeqUtils.CSI_DisableMouseEvents, written);
+        Assert.Contains (EscSeqUtils.CSI_ResetAttributes, written);
+        Assert.Contains (EscSeqUtils.CSI_ShowCursor, written);
+
+        // Inline mode parks cursor on the last row of the region, then writes a newline.
+        int lastInlineRow = AnsiOutput.GetInlineLastRow (appScreen);
+        Assert.Contains (EscSeqUtils.CSI_SetCursorPosition (lastInlineRow, 1), written);
+        Assert.Contains ("\n", written);
+    }
+
+    [Fact]
+    [Trait ("Category", "LowLevelDriver")]
+    public void Dispose_FullScreen_EmitsCleanupSequencesInExpectedOrder ()
+    {
+        // Arrange
+        AnsiOutput output = new (AppModel.FullScreen);
+
+        // Act
+        output.Dispose ();
+        string written = output.GetLastOutput ();
+
+        // Assert — sequences appear in the documented choreography order.
+        // Find the index of each cleanup sequence written during Dispose. Init writes
+        // (mouse enable, alt buffer activate, etc.) come before any of these in the buffer,
+        // so we look for the *last* occurrence of each cleanup sequence.
+        int mouseOff = written.LastIndexOf (EscSeqUtils.CSI_DisableMouseEvents, StringComparison.Ordinal);
+        int sgrReset = written.LastIndexOf (EscSeqUtils.CSI_ResetAttributes, StringComparison.Ordinal);
+        int altRestore = written.LastIndexOf (
+                                              EscSeqUtils.CSI_RestoreCursorAndRestoreAltBufferWithBackscroll,
+                                              StringComparison.Ordinal);
+        int showCursor = written.LastIndexOf (EscSeqUtils.CSI_ShowCursor, StringComparison.Ordinal);
+
+        Assert.True (mouseOff >= 0, "Mouse-off sequence not written during Dispose.");
+        Assert.True (sgrReset >= 0, "SGR reset sequence not written during Dispose.");
+        Assert.True (altRestore >= 0, "Alt-buffer restore sequence not written during Dispose.");
+        Assert.True (showCursor >= 0, "Show-cursor sequence not written during Dispose.");
+
+        Assert.True (mouseOff < sgrReset, "Mouse-off must be written before SGR reset.");
+        Assert.True (sgrReset < altRestore, "SGR reset must be written before alt-buffer restore.");
+        Assert.True (altRestore < showCursor, "Alt-buffer restore must be written before show-cursor.");
+    }
+}

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiDriver/AnsiOutputInlineDisposeTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiDriver/AnsiOutputInlineDisposeTests.cs
@@ -1,0 +1,67 @@
+// Claude - Opus 4.7
+
+namespace DriverTests.AnsiDriver;
+
+/// <summary>
+///     Tests for <see cref="AnsiOutput.Dispose"/> in <see cref="AppModel.Inline"/> mode.
+///     Verifies that the cursor is parked on the last row of the inline region (regression
+///     guard for issue #5166: <c>lastInlineRow</c> off-by-one parked cursor one row past
+///     the region, scrolling the host terminal on shutdown).
+/// </summary>
+[Collection ("Driver Tests")]
+public class AnsiOutputInlineDisposeTests
+{
+    [Theory]
+    [Trait ("Category", "LowLevelDriver")]
+    [InlineData (1, 1)]
+    [InlineData (1, 5)]
+    [InlineData (4, 6)]
+    [InlineData (10, 1)]
+    [InlineData (10, 24)]
+    public void GetInlineLastRow_ReturnsLastRowOfRegion_NotOnePast (int regionY, int regionHeight)
+    {
+        // Arrange
+        Rectangle appScreen = new (0, regionY, 80, regionHeight);
+        int expected = regionY + regionHeight - 1;
+        int forbidden = regionY + regionHeight;
+
+        // Act
+        int actual = AnsiOutput.GetInlineLastRow (appScreen);
+
+        // Assert
+        Assert.Equal (expected, actual);
+        Assert.NotEqual (forbidden, actual);
+    }
+
+    [Theory]
+    [Trait ("Category", "LowLevelDriver")]
+    [InlineData (1, 1)]
+    [InlineData (1, 5)]
+    [InlineData (4, 6)]
+    [InlineData (10, 1)]
+    [InlineData (10, 24)]
+    public void Dispose_Inline_ParksCursorOnLastRowOfRegion (int regionY, int regionHeight)
+    {
+        // Arrange
+        Rectangle appScreen = new (0, regionY, 80, regionHeight);
+        AnsiOutput output = new (AppModel.Inline)
+        {
+            AppScreenGetter = () => appScreen
+        };
+
+        // Act
+        output.Dispose ();
+        string written = output.GetLastOutput ();
+
+        // Assert
+        // ANSI cursor positioning is 1-indexed. appScreen.Y is already the 1-indexed
+        // terminal row offset for the inline region, so the last row is Y + Height - 1.
+        int expectedAnsiRow = regionY + regionHeight - 1;
+        int forbiddenAnsiRow = regionY + regionHeight;
+        string expectedSequence = EscSeqUtils.CSI_SetCursorPosition (expectedAnsiRow, 1);
+        string forbiddenSequence = EscSeqUtils.CSI_SetCursorPosition (forbiddenAnsiRow, 1);
+
+        Assert.Contains (expectedSequence, written);
+        Assert.DoesNotContain (forbiddenSequence, written);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5165.

`AnsiOutput.Dispose()` wrote its cleanup choreography (mouse-off, SGR reset, alt-buffer restore / inline cursor park, show cursor) but **did not flush** the underlying native stdout before returning. On the Windows VT and Unix raw-write paths, buffered cleanup bytes can be discarded when the process exits or when `WindowsVTOutputHelper.Dispose` closes the console handle, leaving the host terminal in a broken state (mouse tracking still on, SGR colors stuck, alt buffer not restored).

The constructor already calls `AnsiTerminalHelper.FlushNative` after writing init sequences for exactly this reason. The fix mirrors that call at the end of `Dispose`'s cleanup block so every shutdown sequence reaches the terminal before `Dispose` returns.

This PR is stacked on #5182 (which removed the `Degraded` early-return in `Dispose`, making cleanup writes observable to tests). Once #5182 merges, this PR can target `develop` directly with a clean diff.

## Changes

- `Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs`
  - Add `AnsiTerminalHelper.FlushNative (_platform)` at the end of the `Dispose` cleanup block, after `CSI_ShowCursor` is written. Inside the same `try` so the existing `catch` swallows any platform-specific flush failure during shutdown. Mirrors the constructor's flush-after-init pattern.
  - `FlushNative` is a no-op when `_platform == AnsiPlatform.Degraded`, so headless test environments are unaffected.
- `Tests/UnitTestsParallelizable/Drivers/AnsiDriver/AnsiOutputDisposeFlushTests.cs` (new)
  - `Dispose_FullScreen_WritesAllCleanupSequences` — every `FullScreen` cleanup sequence (`CSI_DisableMouseEvents`, `CSI_ResetAttributes`, `CSI_RestoreCursorAndRestoreAltBufferWithBackscroll`, `CSI_ShowCursor`) is observable via `GetLastOutput()` after `Dispose`.
  - `Dispose_Inline_WritesAllCleanupSequences` — every `Inline` cleanup sequence including the cursor-park `CSI_SetCursorPosition (Y + Height - 1, 1)` and trailing newline is observable.
  - `Dispose_FullScreen_EmitsCleanupSequencesInExpectedOrder` — sequences appear in documented choreography order (mouse-off &lt; SGR reset &lt; alt-buffer restore &lt; show cursor).

The native flush itself is a no-op in `AnsiPlatform.Degraded` (the only platform in headless test environments), so the closest practical proxy is to assert that every cleanup sequence is observable in the captured output. The bug shows up at process exit on real terminals where the native handle's buffer is dropped before the bytes drain.

## Test plan

- [x] `dotnet build Tests/UnitTestsParallelizable` succeeds.
- [x] `dotnet test --project Tests/UnitTestsParallelizable -- --filter-method "*AnsiOutputDisposeFlushTests*"` — all 3 tests pass.
- [x] All 38 existing tests under `Tests/UnitTestsParallelizable/Drivers/AnsiDriver/` still pass.
- [x] On `origin/develop` (without #5182), `Dispose`'s `Degraded` early-return drops every cleanup write, so the visibility tests would fail there — the choreography is invisible until #5182 lands.

https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdoS4YQ7v9aNPZaNsYnxjv)_