### PR TITLE
notify-clet: deterministic version handoff + flat-container poll

### DIFF
--- a/.github/workflows/notify-clet.yml
+++ b/.github/workflows/notify-clet.yml
@@ -3,39 +3,72 @@ name: Notify clet
 # Fires repository_dispatch to gui-cs/clet so that every TG develop NuGet
 # publish and every TG release tag drives a matching clet build/publish.
 # See gui-cs/clet#30 and gui-cs/clet D-020 for context.
+#
+# Design notes:
+#   - The version comes from the `published-version` artifact uploaded by
+#     publish.yml. This is deterministic — no NuGet search-API race.
+#   - We then poll NuGet's flat-container API (the endpoint that
+#     `dotnet restore` actually hits) until the package is downloadable.
+#     The flat-container is updated soon after publish; the search API
+#     (queried by `dotnet package search`) lags by minutes, which broke
+#     this workflow once before — see gui-cs/clet workflow run 25406348354.
+#   - Channel is derived from the SemVer suffix: contains '-' ⇒ develop.
 
 on:
-  release:
-    types: [published]
-  # Hooks the workflow that publishes the develop NuGet.
   workflow_run:
     workflows: ["Publish Terminal.Gui to Nuget"]
     types: [completed]
 
 permissions:
   contents: read
+  actions: read   # required to download artifacts from the triggering run
 
 jobs:
   notify-clet:
     runs-on: ubuntu-latest
-    # On release: always fire.
-    # On workflow_run: only fire on success (don't ship a clet build if the
-    # TG develop publish itself failed).
-    if: ${{ github.event_name == 'release' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Determine TG version
+      - name: Download published-version artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: published-version
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine version + channel
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "tg_version=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-            echo "event_type=tg-released" >> "$GITHUB_OUTPUT"
-          else
-            # Develop channel. Read the just-published version straight from NuGet.
-            TG_VER=$(dotnet package search "Terminal.Gui" --prerelease --format json | jq -r '.searchResult[0].packages[0].latestVersion')
-            echo "tg_version=$TG_VER" >> "$GITHUB_OUTPUT"
-            echo "event_type=tg-develop-published" >> "$GITHUB_OUTPUT"
+          TG_VER=$(cat version.txt | tr -d '[:space:]')
+          if [ -z "$TG_VER" ]; then
+            echo "::error::Empty version.txt from upstream publish workflow"
+            exit 1
           fi
-      - uses: peter-evans/repository-dispatch@v3
+          echo "tg_version=$TG_VER" >> "$GITHUB_OUTPUT"
+          if [[ "$TG_VER" == *-* ]]; then
+            echo "event_type=tg-develop-published" >> "$GITHUB_OUTPUT"
+            echo "Channel: develop ($TG_VER)"
+          else
+            echo "event_type=tg-released" >> "$GITHUB_OUTPUT"
+            echo "Channel: release ($TG_VER)"
+          fi
+
+      - name: Wait for NuGet flat-container to index the version
+        run: |
+          VER="${{ steps.version.outputs.tg_version }}"
+          for i in $(seq 1 60); do
+            if curl -fsS https://api.nuget.org/v3-flatcontainer/terminal.gui/index.json \
+               | jq -r '.versions[]' | grep -qx "$VER"; then
+              echo "Indexed on flat-container: $VER (after $((i*10))s)"
+              exit 0
+            fi
+            echo "Waiting for $VER on NuGet flat-container ($i/60, 10s each)..."
+            sleep 10
+          done
+          echo "::error::Timed out after 10min waiting for $VER on flat-container"
+          exit 1
+
+      - name: Dispatch to gui-cs/clet
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.CLET_DISPATCH_PAT }}
           repository: gui-cs/clet

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,21 @@ jobs:
         
     - name: Publish Terminal.Gui.${{ steps.gitversion.outputs.SemVer }} to NuGet.org
       run: dotnet nuget push Terminal.Gui/bin/Release/Terminal.Gui.${{ steps.gitversion.outputs.SemVer }}.nupkg --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }}
+
+    # Deterministic version handoff to notify-clet.yml. Avoids the NuGet
+    # search-API indexing lag that caused gui-cs/clet to skip TG develop.37
+    # (see clet workflow run 25406348354). notify-clet.yml downloads this
+    # artifact via workflow_run + actions/download-artifact and then polls
+    # NuGet flat-container until the version is restorable.
+    - name: Record published version for notify-clet
+      run: echo "${{ steps.gitversion.outputs.SemVer }}" > version.txt
+
+    - name: Upload published-version artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: published-version
+        path: version.txt
+        retention-days: 7
     
     # - name: Delist old NuGet packages
     #   if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Fixes the race that caused [gui-cs/clet workflow run 25406348354](https://github.com/gui-cs/clet/actions/runs/25406348354) to dispatch with TG_VERSION=2.0.2-develop.**36** when the triggering TG publish had just pushed **.37**.

## What broke

`notify-clet.yml` extracted the version with `dotnet package search "Terminal.Gui" --prerelease`. That hits NuGet's search/registration index, which is eventually consistent and lags the actual publish by tens of seconds to minutes. notify-clet ran 2s after publish.yml finished — the search index hadn't ingested the new version yet, so it returned the *previous* version. The clet workflow then built and pushed `Terminal.Gui.clet 2.0.2-develop.36` for the second time; `dotnet nuget push --skip-duplicate` silently no-op'd, and testers running `dotnet tool install --prerelease` stayed on the old version.

## Fix

**`publish.yml`:** after the `dotnet nuget push` step, write the GitVersion SemVer (already computed) to `version.txt` and upload it as a `published-version` artifact. Deterministic; no NuGet round-trip.

**`notify-clet.yml`:**
- Drop the `release: published` trigger and the `dotnet package search` call. publish.yml already triggers on both develop pushes and `v*` tags, so a single `workflow_run: ["Publish Terminal.Gui to Nuget"]` covers both channels.
- Download the `published-version` artifact from the triggering run via `actions/download-artifact@v4` with `run-id: ${{ github.event.workflow_run.id }}`.
- Poll NuGet's **flat-container** endpoint (the API that `dotnet restore` actually hits — indexes within seconds) until the version is downloadable, with a 10-minute cap. Flat-container is normally sub-minute; if the cap trips, fail loudly instead of dispatching a stale or unbuildable version.
- Channel (`tg-released` vs `tg-develop-published`) derived from the SemVer suffix in the artifact contents (contains `-` ⇒ develop), preserving [gui-cs/clet D-020](https://github.com/gui-cs/clet/blob/main/specs/decisions.md#d-020).
- New permission: `actions: read` (needed to download artifacts from another workflow's run).

## Why polling flat-container, not search

`dotnet restore` (used by clet's build job) reads from flat-container. `dotnet tool install` (used by end-user testers) reads from search/registration. The clet workflow only blocks on flat-container, so polling that is sufficient to guarantee the dispatched version is actually buildable. End-user search-index lag is a separate NuGet-side concern that no amount of polling on our side fixes — testers can pin via `--version` if they need the new build before the search index catches up.

## Test plan

- [ ] Merge to `develop` (or first to a long-lived test branch if desired) and watch the next develop publish: confirm the artifact uploads and notify-clet polls + dispatches with the right version.
- [ ] Verify the gui-cs/clet workflow receives `tg_version` matching the just-pushed TG version, not the previous one.
- [ ] Confirm `Terminal.Gui.clet 2.0.2-develop.<NN>` lands on NuGet matching the TG publish that triggered it.