### PR TITLE
 Fixes #5153. Make Markdown work like Label

### DIFF
--- a/Terminal.Gui/Views/Markdown/Markdown.cs
+++ b/Terminal.Gui/Views/Markdown/Markdown.cs
@@ -124,6 +124,11 @@ public partial class Markdown : View, IDesignable
     public override string Text { get => _markdown; set => SetMarkdown (value); }
 
     /// <inheritdoc/>
+    /// <remarks>
+    ///     Unlike <see cref="Label"/>, <see cref="Markdown"/> derives <see cref="View.HotKey"/>
+    ///     from <see cref="Text"/> (the raw markdown) rather than <see cref="View.Title"/>,
+    ///     because <see cref="Text"/> does not flow through <c>Title</c>.
+    /// </remarks>
     public override Rune HotKeySpecifier
     {
         get => base.HotKeySpecifier;

--- a/Terminal.Gui/Views/Markdown/Markdown.cs
+++ b/Terminal.Gui/Views/Markdown/Markdown.cs
@@ -123,6 +123,17 @@ public partial class Markdown : View, IDesignable
     /// <value>The raw Markdown string. Setting this property triggers reparsing, re-layout, and a redraw.</value>
     public override string Text { get => _markdown; set => SetMarkdown (value); }
 
+    /// <inheritdoc/>
+    public override Rune HotKeySpecifier
+    {
+        get => base.HotKeySpecifier;
+        set
+        {
+            TitleTextFormatter.HotKeySpecifier = TextFormatter.HotKeySpecifier = value;
+            UpdateHotKeyFromMarkdown ();
+        }
+    }
+
     /// <summary>Gets or sets the Markdig <see cref="Markdig.MarkdownPipeline"/> used for parsing.</summary>
     /// <value>
     ///     A custom pipeline, or <see langword="null"/> to use the default pipeline
@@ -298,11 +309,34 @@ public partial class Markdown : View, IDesignable
         }
 
         _markdown = value;
+        UpdateHotKeyFromMarkdown ();
         _scrollToTopPending = true;
         InvalidateParsedAndLayout ();
 
         OnMarkdownChanged ();
         MarkdownChanged?.Invoke (this, EventArgs.Empty);
+    }
+
+    private void UpdateHotKeyFromMarkdown ()
+    {
+        if (HotKeySpecifier == new Rune ('\xFFFF'))
+        {
+            HotKey = Key.Empty;
+
+            return;
+        }
+
+        if (TextFormatter.FindHotKey (_markdown, HotKeySpecifier, out _, out Key hotKey))
+        {
+            if (HotKey != hotKey)
+            {
+                HotKey = hotKey;
+            }
+
+            return;
+        }
+
+        HotKey = Key.Empty;
     }
 
     private void InvalidateParsedAndLayout ()

--- a/Terminal.Gui/Views/Markdown/Markdown.cs
+++ b/Terminal.Gui/Views/Markdown/Markdown.cs
@@ -87,6 +87,38 @@ public partial class Markdown : View, IDesignable
         SetupBindingsAndCommands ();
     }
 
+    /// <inheritdoc/>
+    /// <remarks>
+    ///     If <see cref="View.CanFocus"/> is <see langword="false"/> and a valid <see cref="View.HotKey"/>
+    ///     is set, the hotkey is forwarded to the next peer in <see cref="View.SuperView"/>'s
+    ///     <see cref="View.SubViews"/> — mirroring <see cref="Label"/> so that a non-focusable
+    ///     <see cref="Markdown"/> describing a focusable view (e.g. a <see cref="TextField"/>) moves
+    ///     focus to that view when its hotkey is pressed.
+    /// </remarks>
+    protected override bool OnActivating (CommandEventArgs args)
+    {
+        // If Markdown can't focus, forward HotKey to the next peer in the SubView list
+        if (CanFocus || !HotKey.IsValid)
+        {
+            return base.OnActivating (args);
+        }
+        int me = SuperView?.SubViews.IndexOf (this) ?? -1;
+
+        if (me == -1 || !(me < SuperView?.SubViews.Count - 1))
+        {
+            return base.OnActivating (args);
+        }
+        bool handled = SuperView?.SubViews.ElementAt (me + 1).InvokeCommand (Command.HotKey) == true;
+
+        if (!handled)
+        {
+            return base.OnActivating (args);
+        }
+        args.Handled = true;
+
+        return true;
+    }
+
     /// <summary>Gets or sets the Markdown-formatted text displayed by this view.</summary>
     /// <value>The raw Markdown string. Setting this property triggers reparsing, re-layout, and a redraw.</value>
     public override string Text { get => _markdown; set => SetMarkdown (value); }

--- a/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewTests.cs
@@ -1903,5 +1903,59 @@ public class MarkdownViewTests (ITestOutputHelper output)
         hostCode.Dispose ();
         hostNoCode.Dispose ();
     }
+
+    // Claude - Opus 4.7
+    [Theory]
+    [CombinatorialData]
+    public void HotKey_Command_SetsFocus_OnNextSubView (bool hasHotKey)
+    {
+        View superView = new () { CanFocus = true };
+        Terminal.Gui.Views.Markdown md = new () { CanFocus = false };
+        md.HotKey = hasHotKey ? Key.A.WithAlt : Key.Empty;
+        View nextSubView = new () { CanFocus = true };
+        superView.Add (md, nextSubView);
+        superView.BeginInit ();
+        superView.EndInit ();
+
+        Assert.False (md.HasFocus);
+        Assert.False (nextSubView.HasFocus);
+
+        md.InvokeCommand (Command.HotKey);
+
+        Assert.False (md.HasFocus);
+        Assert.Equal (hasHotKey, nextSubView.HasFocus);
+    }
+
+    // Claude - Opus 4.7
+    [Fact]
+    public void CanFocus_True_HotKey_DoesNotForward_ToPeer ()
+    {
+        View superView = new () { CanFocus = true };
+        Terminal.Gui.Views.Markdown md = new () { CanFocus = true, HotKey = Key.A.WithAlt };
+        View nextSubView = new () { CanFocus = true };
+        superView.Add (md, nextSubView);
+        superView.BeginInit ();
+        superView.EndInit ();
+
+        md.InvokeCommand (Command.HotKey);
+
+        Assert.True (md.HasFocus);
+        Assert.False (nextSubView.HasFocus);
+    }
+
+    // Claude - Opus 4.7
+    [Fact]
+    public void CanFocus_False_HotKey_NoNextPeer_DoesNotFocusMarkdown ()
+    {
+        View superView = new () { CanFocus = true };
+        Terminal.Gui.Views.Markdown md = new () { CanFocus = false, HotKey = Key.A.WithAlt };
+        superView.Add (md);
+        superView.BeginInit ();
+        superView.EndInit ();
+
+        md.InvokeCommand (Command.HotKey);
+
+        Assert.False (md.HasFocus);
+    }
 }
 

--- a/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Reflection;
+using System.Text;
 using JetBrains.Annotations;
 using UnitTests;
 
@@ -1904,58 +1905,143 @@ public class MarkdownViewTests (ITestOutputHelper output)
         hostNoCode.Dispose ();
     }
 
-    // Claude - Opus 4.7
-    [Theory]
-    [CombinatorialData]
-    public void HotKey_Command_SetsFocus_OnNextSubView (bool hasHotKey)
+    // Copilot
+    [Fact]
+    public void CanFocus_False_Text_HotKeySpecifier_SetsFocus_Next ()
     {
-        View superView = new () { CanFocus = true };
-        Terminal.Gui.Views.Markdown md = new () { CanFocus = false };
-        md.HotKey = hasHotKey ? Key.A.WithAlt : Key.Empty;
-        View nextSubView = new () { CanFocus = true };
-        superView.Add (md, nextSubView);
-        superView.BeginInit ();
-        superView.EndInit ();
+        using IApplication app = Application.Create ();
+        Runnable<bool> runnable = new ();
+        View otherView = new () { CanFocus = true };
+        Terminal.Gui.Views.Markdown markdown = new ()
+        {
+            CanFocus = false,
+            Width = 20,
+            Height = 1,
+            Text = "_Markdown"
+        };
+        View nextView = new () { CanFocus = true };
 
-        Assert.False (md.HasFocus);
-        Assert.False (nextSubView.HasFocus);
+        markdown.HotKeySpecifier = (Rune)'_';
 
-        md.InvokeCommand (Command.HotKey);
+        app.Begin (runnable);
+        runnable.Add (otherView, markdown, nextView);
+        otherView.SetFocus ();
 
-        Assert.False (md.HasFocus);
-        Assert.Equal (hasHotKey, nextSubView.HasFocus);
+        Assert.Equal (Key.M, markdown.HotKey);
+        Assert.True (otherView.HasFocus);
+        Assert.False (markdown.HasFocus);
+        Assert.False (nextView.HasFocus);
+
+        app.Keyboard.RaiseKeyDownEvent (markdown.HotKey);
+
+        Assert.False (otherView.HasFocus);
+        Assert.False (markdown.HasFocus);
+        Assert.True (nextView.HasFocus);
     }
 
-    // Claude - Opus 4.7
+    // Copilot
     [Fact]
-    public void CanFocus_True_HotKey_DoesNotForward_ToPeer ()
+    public void CanFocus_False_LeftButtonClicked_SetsFocus_Next ()
     {
-        View superView = new () { CanFocus = true };
-        Terminal.Gui.Views.Markdown md = new () { CanFocus = true, HotKey = Key.A.WithAlt };
-        View nextSubView = new () { CanFocus = true };
-        superView.Add (md, nextSubView);
-        superView.BeginInit ();
-        superView.EndInit ();
+        using IApplication app = Application.Create ();
+        Runnable<bool> runnable = new ();
+        View otherView = new ()
+        {
+            X = 0,
+            Y = 0,
+            Width = 1,
+            Height = 1,
+            CanFocus = true
+        };
+        Terminal.Gui.Views.Markdown markdown = new ()
+        {
+            X = 0,
+            Y = 1,
+            Width = 20,
+            Height = 1,
+            CanFocus = false,
+            Text = "_Markdown"
+        };
+        View nextView = new ()
+        {
+            X = Pos.Right (markdown),
+            Y = Pos.Top (markdown),
+            Width = 1,
+            Height = 1,
+            CanFocus = true
+        };
 
-        md.InvokeCommand (Command.HotKey);
+        markdown.HotKeySpecifier = (Rune)'_';
 
-        Assert.True (md.HasFocus);
-        Assert.False (nextSubView.HasFocus);
+        app.Begin (runnable);
+        runnable.Add (otherView, markdown, nextView);
+        otherView.SetFocus ();
+
+        Assert.Equal (Key.M, markdown.HotKey);
+        Assert.True (otherView.HasFocus);
+        Assert.False (markdown.HasFocus);
+        Assert.False (nextView.HasFocus);
+
+        app.Mouse.RaiseMouseEvent (new Mouse { ScreenPosition = markdown.Frame.Location, Flags = MouseFlags.LeftButtonClicked });
+
+        Assert.False (markdown.HasFocus);
+        Assert.True (nextView.HasFocus);
     }
 
-    // Claude - Opus 4.7
+    // Copilot
     [Fact]
-    public void CanFocus_False_HotKey_NoNextPeer_DoesNotFocusMarkdown ()
+    public void CanFocus_True_Text_HotKeySpecifier_SetsFocus_OnMarkdown ()
     {
-        View superView = new () { CanFocus = true };
-        Terminal.Gui.Views.Markdown md = new () { CanFocus = false, HotKey = Key.A.WithAlt };
-        superView.Add (md);
-        superView.BeginInit ();
-        superView.EndInit ();
+        using IApplication app = Application.Create ();
+        Runnable<bool> runnable = new ();
+        View otherView = new () { CanFocus = true };
+        Terminal.Gui.Views.Markdown markdown = new ()
+        {
+            CanFocus = true,
+            Width = 20,
+            Height = 1,
+            Text = "_Markdown"
+        };
+        View nextView = new () { CanFocus = true };
 
-        md.InvokeCommand (Command.HotKey);
+        markdown.HotKeySpecifier = (Rune)'_';
 
-        Assert.False (md.HasFocus);
+        app.Begin (runnable);
+        runnable.Add (otherView, markdown, nextView);
+        otherView.SetFocus ();
+
+        Assert.Equal (Key.M, markdown.HotKey);
+
+        app.Keyboard.RaiseKeyDownEvent (markdown.HotKey);
+
+        Assert.False (otherView.HasFocus);
+        Assert.True (markdown.HasFocus);
+        Assert.False (nextView.HasFocus);
+    }
+
+    // Copilot
+    [Fact]
+    public void CanFocus_False_Text_HotKeySpecifier_NoNextPeer_DoesNotFocusMarkdown ()
+    {
+        using IApplication app = Application.Create ();
+        Runnable<bool> runnable = new ();
+        Terminal.Gui.Views.Markdown markdown = new ()
+        {
+            CanFocus = false,
+            Width = 20,
+            Height = 1,
+            Text = "_Markdown"
+        };
+
+        markdown.HotKeySpecifier = (Rune)'_';
+
+        app.Begin (runnable);
+        runnable.Add (markdown);
+
+        Assert.Equal (Key.M, markdown.HotKey);
+
+        app.Keyboard.RaiseKeyDownEvent (markdown.HotKey);
+
+        Assert.False (markdown.HasFocus);
     }
 }
-


### PR DESCRIPTION
## Summary

Implements the maintainer-recommended scope for #5153: rather than adding inline OSC 8 hyperlink markup to `Label`/`TextView`, make `Markdown` work like `Label` so a non-focusable `Markdown` describing a focusable peer (e.g. a `TextField`) moves focus to that peer when its hotkey is pressed.

This makes the pattern from @tig's [comment](https://github.com/gui-cs/Terminal.Gui/issues/5153) work as written:

```csharp
new Markdown
{
    CanFocus = false,
    Text = "_See the [docs](https://github.com/gui-cs/Terminal.Gui) for details.",
    HotKeySpecifier = (Rune)'_'
};
```

Pressing Alt+S moves focus to the next peer in SuperView.SubViews. Mouse-clicking the Markdown does the same.

## Changes

Terminal.Gui/Views/Markdown/Markdown.cs
- OnActivating override mirroring Label.OnActivating: when CanFocus == false and HotKey.IsValid, forwards Command.HotKey to the immediate next peer.
- HotKeySpecifier override that derives HotKey from Text (the raw markdown) rather than Title, since Markdown.Text does not flow through Title the way Label.Text does. Includes a <remarks> block documenting the divergence from Label.
- UpdateHotKeyFromMarkdown helper invoked from both the HotKeySpecifier setter and SetMarkdown, so either property-set order produces a correct HotKey.

Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewTests.cs
- CanFocus_False_Text_HotKeySpecifier_SetsFocus_Next — exercises the full Text + HotKeySpecifier path through real keyboard dispatch (app.Keyboard.RaiseKeyDownEvent).
- CanFocus_False_LeftButtonClicked_SetsFocus_Next — parity with Label's mouse-click forwarding (Markdown.Mouse.cs remaps LeftButtonClicked to activate).
- CanFocus_True_Text_HotKeySpecifier_SetsFocus_OnMarkdown — focusable Markdown keeps the hotkey for itself.
- CanFocus_False_Text_HotKeySpecifier_NoNextPeer_DoesNotFocusMarkdown — no-next-peer case is a no-op.

## What this does NOT change

- No new public API; behavior only differs for Markdown instances explicitly configured with CanFocus = false and a hotkey.
- Label is unchanged.
- The original issue's broader inline-markup proposal is dropped per guidance

### Why not generalize the forwarding into `View.RaiseActivating` (the "extra credit" suggestion)?

I tried this, but tests showed it broke `CheckBox` inside `Shortcut`: `CheckBox` runs as `CanFocus = false` with a valid `HotKey` and toggles its state inside `OnActivated`, so a base-class fallback that consumed `Activate` before `RaiseActivated` fired regressed 15 `ShortcutTests`. Keeping the override scoped to `Label`/`Markdown` (the views whose semantics are "describe a peer") avoids that. 
But please suggest any ideas you have to resolve that! 

## Test plan

- dotnet build — clean, 0 warnings, 0 errors
- dotnet test --project Tests/UnitTestsParallelizable — 16,796 passed / 0 failed / 17 skipped
- All 86 existing MarkdownViewTests plus 4 new ones pass
- All existing LabelTests HotKey-forwarding tests unchanged and still pass
- Tests now exercise the full user-facing path: Text + HotKeySpecifier → keyboard / mouse dispatch → focus
moves to next peer
