### PR TITLE
 Fixes #5140. TableView: support CollectionNavigator = null to disable type-to-search

### DIFF
--- a/Terminal.Gui/Views/TableView/TableView.Navigation.cs
+++ b/Terminal.Gui/Views/TableView/TableView.Navigation.cs
@@ -101,6 +101,11 @@ public partial class TableView
 
     private bool CycleToNextTableEntryBeginningWith (Key key)
     {
+        // Type-to-search disabled
+        if (CollectionNavigator is null)
+        {
+            return false;
+        }
         int row = _cursorRow;
 
         // There is a multi select going on and not just for the current row

--- a/Terminal.Gui/Views/TableView/TableView.cs
+++ b/Terminal.Gui/Views/TableView/TableView.cs
@@ -165,8 +165,12 @@ public partial class TableView : View, IValue<TableSelection?>, IDesignable
         }
     }
 
-    /// <summary>Navigator for cycling the selected item in the table by typing. Set to null to disable this feature.</summary>
-    public ICollectionNavigator CollectionNavigator { get; set; }
+    /// <summary>
+    ///     Navigator for cycling the selected row in the table by typing. Set to <see langword="null"/> to disable
+    ///     type-to-search navigation; printable keys not otherwise bound will then bubble through normal key handling
+    ///     instead of being consumed for incremental row navigation.
+    /// </summary>
+    public ICollectionNavigator? CollectionNavigator { get; set; }
 
     /// <summary>
     ///     The maximum number of characters to render in any given column.  This prevents one long column from pushing

--- a/Tests/UnitTestsParallelizable/Views/TableViewLegacyTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TableViewLegacyTests.cs
@@ -212,7 +212,7 @@ public class TableViewLegacyTests : TestDriverBase
         tableView.Table = new DataTableSource (dt);
         tableView.SetSelection (selectedCol, tableView.Value?.SelectedCell.Y ?? 0, false);
 
-        Assert.Equal (expectedRow, tableView.CollectionNavigator.GetNextMatchingItem (0, "3".ToCharArray () [0]));
+        Assert.Equal (expectedRow, tableView.CollectionNavigator!.GetNextMatchingItem (0, "3".ToCharArray () [0]));
     }
 
     [Fact]

--- a/Tests/UnitTestsParallelizable/Views/TableViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TableViewTests.cs
@@ -253,6 +253,54 @@ public class TableViewTests : TestDriverBase
         Assert.Equal (2, tableView.Value!.SelectedCell.Y);
     }
 
+    // Claude - Opus 4.7
+    // Regression: setting CollectionNavigator to null disables type-to-search and lets printable keys bubble
+    [Fact]
+    public void CollectionNavigator_Null_DisablesTypeToSearch_KeyNotConsumed ()
+    {
+        var dt = new DataTable ();
+        dt.Columns.Add ("blah");
+        dt.Rows.Add ("apricot");
+        dt.Rows.Add ("bat");
+        dt.Rows.Add ("candle");
+
+        TableView tableView = new () { Table = new DataTableSource (dt), CollectionNavigator = null };
+        tableView.HasFocus = true;
+
+        Assert.Equal (0, tableView.Value!.SelectedCell.Y);
+
+        // Key.B would normally jump to "bat" (row 1) — with navigator disabled, selection must not move
+        // and the key event must not be consumed (returns false so it can bubble to the SuperView).
+        bool consumed = tableView.NewKeyDownEvent (Key.B);
+
+        Assert.False (consumed);
+        Assert.Equal (0, tableView.Value!.SelectedCell.Y);
+    }
+
+    // Claude - Opus 4.7
+    // Regression: with CollectionNavigator = null, HotKey path must not throw
+    [Fact]
+    public void CollectionNavigator_Null_HotKey_DoesNotThrow ()
+    {
+        var dt = new DataTable ();
+        dt.Columns.Add ("blah");
+        dt.Rows.Add ("apricot");
+        dt.Rows.Add ("bat");
+
+        TableView tableView = new ()
+        {
+            Table = new DataTableSource (dt),
+            CollectionNavigator = null,
+            HotKey = Key.B
+        };
+        tableView.HasFocus = true;
+
+        Exception? ex = Record.Exception (() => tableView.NewKeyDownEvent (Key.B));
+
+        Assert.Null (ex);
+        Assert.Equal (0, tableView.Value!.SelectedCell.Y);
+    }
+
     // Copilot
     // Behavior: Space toggles multi-selection via ToggleExtend command
     [Fact]


### PR DESCRIPTION
## Summary

Implements **option 2** from #5140 (preferred by @tig, @tznind, and @BDisp): make `TableView.CollectionNavigator = null` fully supported and null-safe, matching what the property's existing XML doc already promised ("Set to null to disable this feature"). No new API surface.

When `CollectionNavigator` is `null`, printable keys that aren't otherwise bound bubble through normal key handling instead of being consumed for incremental row navigation — letting apps use single-letter shortcuts (`q`, `r`, `/`, …) while focus remains in the table.

## Changes

- `Terminal.Gui/Views/TableView/TableView.cs` — change `CollectionNavigator` to `ICollectionNavigator?` and expand the XML `<summary>` to document the disabled-state behavior.
- `Terminal.Gui/Views/TableView/TableView.Navigation.cs` — early-return `false` from `CycleToNextTableEntryBeginningWith` when `CollectionNavigator is null`. Returning false lets `OnKeyDownNotHandled` propagate the key instead of consuming it.
- `Tests/UnitTestsParallelizable/Views/TableViewTests.cs` — two new tests covering the null path (key not consumed, no NRE on hotkey).
- `Tests/UnitTestsParallelizable/Views/TableViewLegacyTests.cs` — single `!` to silence a new CS8602 in an existing test now that the property is nullable.

## What this does NOT change

- Default behavior is unchanged: `CollectionNavigator` is still constructed in `TableView`'s constructor, so type-to-search works out of the box.
- No new public API; no behavior change for apps that don't opt out.

## Test plan

- [x] `dotnet build` — clean, no new warnings
- [x] `dotnet test --project Tests/UnitTestsParallelizable` — 16,794 passed / 0 failed / 17 skipped
- [x] All 120 existing `TableView*` tests still pass
- [x] New tests verify: `CollectionNavigator = null` disables type-to-search and lets the key bubble;
`CollectionNavigator = null` + `HotKey` does not throw