### PR TITLE
Restore #5243 AOT fix lost in #5246 merge resolution

### DIFF
--- a/Terminal.Gui/Configuration/ConfigurationManager.cs
+++ b/Terminal.Gui/Configuration/ConfigurationManager.cs
@@ -204,7 +204,7 @@ public static class ConfigurationManager
                 // Some getters (notably ThemeManager.Themes while uninitialized) synthesize composite
                 // objects from other configuration properties, so a single populate-and-clone pass can
                 // observe half-initialized cache entries and persist null/default values into the clone.
-                hardCodedProperty.Value.PropertyValue = CloneHardCodedPropertyValue (hardCodedProperty.Value.PropertyValue);
+                hardCodedProperty.Value.PropertyValue = DeepCloner.DeepClone (hardCodedProperty.Value.PropertyValue);
                 hardCodedProperty.Value.Immutable = true;
             }
         }
@@ -220,58 +220,6 @@ public static class ConfigurationManager
         // BUGBUG: This a partial workaround.
         // BUGBUG: See https://github.com/gui-cs/Terminal.Gui/issues/4288
         ThemeManager.Themes? [ThemeManager.Theme].Apply ();
-    }
-
-    // AOT trimming removes the reflective Dictionary<,> constructor that DeepCloner relies on.
-    // Each non-trivially-cloneable config property type needs a typed clone path here to stay AOT-safe.
-    private static object? CloneHardCodedPropertyValue (object? propertyValue)
-    {
-        if (propertyValue is Dictionary<Command, PlatformKeyBinding> keyBindings)
-        {
-            return CloneKeyBindings (keyBindings);
-        }
-
-        return DeepCloner.DeepClone (propertyValue);
-    }
-
-    private static Dictionary<Command, PlatformKeyBinding> CloneKeyBindings (Dictionary<Command, PlatformKeyBinding> source)
-    {
-        Dictionary<Command, PlatformKeyBinding> clone = new (source.Comparer);
-
-        foreach (KeyValuePair<Command, PlatformKeyBinding> kvp in source)
-        {
-            clone [kvp.Key] = ClonePlatformKeyBinding (kvp.Value);
-        }
-
-        return clone;
-    }
-
-    private static PlatformKeyBinding ClonePlatformKeyBinding (PlatformKeyBinding binding)
-    {
-        return binding with
-        {
-            All = CloneKeyArray (binding.All),
-            Windows = CloneKeyArray (binding.Windows),
-            Linux = CloneKeyArray (binding.Linux),
-            Macos = CloneKeyArray (binding.Macos)
-        };
-    }
-
-    private static Key []? CloneKeyArray (Key []? keys)
-    {
-        if (keys is null)
-        {
-            return null;
-        }
-
-        Key [] clonedKeys = new Key [keys.Length];
-
-        for (int i = 0; i < keys.Length; i++)
-        {
-            clonedKeys [i] = new (keys [i]);
-        }
-
-        return clonedKeys;
     }
 
     #endregion Initialization

--- a/Terminal.Gui/Configuration/DeepCloner.cs
+++ b/Terminal.Gui/Configuration/DeepCloner.cs
@@ -369,6 +369,7 @@ public static class DeepCloner
     [UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = "Dictionary cloning only instantiates supported dictionary runtime types and falls back safely when comparer constructors are unavailable.")]
     private static IDictionary CreateDictionaryInstance (Type dictType, object? comparer)
     {
+        // Typed paths for dictionary types that require custom comparers.
         if (dictType == typeof (ConcurrentDictionary<string, ThemeScope>))
         {
             if (comparer is IEqualityComparer<string> stringComparer)
@@ -387,6 +388,32 @@ public static class DeepCloner
             }
 
             return new Dictionary<string, Scheme?> ();
+        }
+
+        // AOT-safe: use the source-generated JSON serializer to create empty dictionary instances.
+        // This avoids Activator.CreateInstance, whose target constructors are trimmed by the AOT linker
+        // for closed generic dictionary types not otherwise statically reachable.
+        // Only used when no comparer is needed — Deserialize("{}") always creates a default-comparer instance.
+        if (comparer is null)
+        {
+            try
+            {
+                JsonTypeInfo? jsonTypeInfo = ConfigurationManager.SerializerContext.GetTypeInfo (dictType);
+
+                if (jsonTypeInfo is not null)
+                {
+                    IDictionary? result = JsonSerializer.Deserialize ("{}", jsonTypeInfo) as IDictionary;
+
+                    if (result is not null)
+                    {
+                        return result;
+                    }
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // JSON serializer context may not be initialized — fall through to reflective construction.
+            }
         }
 
         try


### PR DESCRIPTION
## Summary

The fix from #5243 (\"Fixes #5259. AOT: use source-generated JSON serializer for dictionary construction in DeepCloner\") was reverted when commit `94dca985d` merged `origin/main` back into `release/v2.1.0-rc.1`. That merge had conflicts in `DeepCloner.cs` and `ConfigurationManager.cs` and the resolution picked main's pre-#5243 versions, silently dropping the fix.

PR #5246 (rc.1 → main) and PR #5247 (rc.1 backmerge → develop) then carried the broken state forward. **`v2.1.0-beta.1` was tagged before #5243 merged (no fix); `v2.1.0-rc.1` was tagged after, but doesn't have it either** because of the conflict resolution.

This PR restores `Terminal.Gui/Configuration/DeepCloner.cs` and `Terminal.Gui/Configuration/ConfigurationManager.cs` to their state at `11d6e27d7` (the original #5243 merge commit). The two files were checked out from that commit; no other changes.

## Diff content

**`DeepCloner.cs`** — adds back the 26-line `SourceGenerationContext.GetTypeInfo` → `JsonSerializer.Deserialize(\"{}\", typeInfo)` fallback in `CreateDictionaryInstance` (between the typed paths and `Activator.CreateInstance`), plus the `// Typed paths…` comment.

**`ConfigurationManager.cs`** — removes the 54-line per-type clone helpers (`CloneHardCodedPropertyValue`, `CloneKeyBindings`, `ClonePlatformKeyBinding`, `CloneKeyArray`) and reverts the call site back to `DeepCloner.DeepClone(...)`. Generic dictionary handling lives in `DeepCloner` again.

Net: +28 / -53.

## Repro before the fix (current `develop`)

```bash
dotnet publish Examples/NativeAot -c Release -r win-x64 --self-contained
./bin/Release/net10.0/win-x64/publish/NativeAot.exe
```

Crashes at module init:

```
Unhandled exception. System.MissingMethodException: No parameterless constructor defined for type
'System.Collections.Generic.Dictionary`2[Terminal.Gui.Drawing.ColorName16,System.String]'.
   at DeepCloner.CreateDictionaryInstance(...)
   at ConfigurationManager.Initialize() ...
   at RunModuleInitializers()
```

Same crash a downstream AOT consumer (gui-cs/clet) hit. Tracked through #5239 → #5240 (partial fix) → #5242 (residual) → #5243 (the right fix) → #5248 (filed when rc.1 still crashed — explained by this PR).

## Verification

Build and pack of TG with this branch checked out:

```
dotnet build Terminal.Gui/Terminal.Gui.csproj -c Release    # 0 errors
dotnet pack  Terminal.Gui/Terminal.Gui.csproj -c Release --no-build --output local_packages
```

Then in [`gui-cs/clet`](https://github.com/gui-cs/clet) on `feature/makefile-releases`, pinning `<PackageReference Include=\"Terminal.Gui\" Version=\"2.1.1-aot-debug-5248.1\" />`:

```
dotnet publish src/Clet -c Release -r win-x64 --self-contained -p:PublishAot=true -o publish/win-x64
./publish/win-x64/clet.exe --version    # was crashing against rc.1; now: 1.0.0-alpha (Terminal.Gui 2.1.1-aot-debug-5248.1), exit 0
./publish/win-x64/clet.exe list         # all 17 clets enumerate, exit 0
```

## How to make sure this stays fixed

PR #5243 added a `Dictionary<ColorName16, string>` test in `DeepClonerTests.cs` — that test was retained through the merges (verified). However, the test runs in a non-AOT context and so does not exercise the actual AOT trim path that broke. **An AOT regression test (publish `Examples/NativeAot` in CI and run it)** would have caught this conflict-resolution regression. PR #5243's commit log mentions adding such CI; if it didn't make it through the same merge, that's a separate follow-up.

## Linked

- Fixes (re-fixes): #5259
- Refs #5239, #5242, #5243, #5248
- Conflict-merge cause: 94dca985d
- Affected tags: v2.1.0-beta.1 (separate cause), v2.1.0-rc.1 (this conflict)

cc @tig

🤖 Generated with [Claude Code](https://claude.com/claude-code)