### PR TITLE
ci: branch-based dispatch for clet notifications

### DIFF
--- a/.github/workflows/notify-clet.yml
+++ b/.github/workflows/notify-clet.yml
@@ -12,7 +12,8 @@ name: Notify clet
 #     The flat-container is updated soon after publish; the search API
 #     (queried by `dotnet package search`) lags by minutes, which broke
 #     this workflow once before — see gui-cs/clet workflow run 25406348354.
-#   - Channel is derived from the SemVer suffix: contains '-' ⇒ develop.
+#   - Channel is derived from the triggering workflow's branch:
+#     main ⇒ tg-main-published, anything else ⇒ tg-develop-published.
 
 on:
   workflow_run:
@@ -44,12 +45,13 @@ jobs:
             exit 1
           fi
           echo "tg_version=$TG_VER" >> "$GITHUB_OUTPUT"
-          if [[ "$TG_VER" == *-* ]]; then
-            echo "event_type=tg-develop-published" >> "$GITHUB_OUTPUT"
-            echo "Channel: develop ($TG_VER)"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+            echo "event_type=tg-main-published" >> "$GITHUB_OUTPUT"
+            echo "Channel: main ($TG_VER from $BRANCH)"
           else
-            echo "event_type=tg-released" >> "$GITHUB_OUTPUT"
-            echo "Channel: release ($TG_VER)"
+            echo "event_type=tg-develop-published" >> "$GITHUB_OUTPUT"
+            echo "Channel: develop ($TG_VER from $BRANCH)"
           fi
 
       - name: Wait for NuGet flat-container to index the version


### PR DESCRIPTION
## Summary

- Send `tg-main-published` for any NuGet publish from `main` (rc, beta, stable)
- Send `tg-develop-published` for develop publishes
- Previously used the version suffix (contains `-` → develop), which incorrectly treated rc/beta the same as develop

## Why

gui-cs/clet now builds from TG main. The old logic sent `tg-develop-published` for rc.3, which clet no longer listens for (gui-cs/clet#112). This change lets any TG main-branch publish (rc, beta, stable) trigger a clet main-channel release.

Companion PR: gui-cs/clet#113 (listens for `tg-main-published`)

## Test plan

- [ ] Next TG develop publish sends `tg-develop-published`
- [ ] Next TG main publish (rc/stable) sends `tg-main-published`

🤖 Generated with [Claude Code](https://claude.com/claude-code)