### PR TITLE
Back-merge v2.1.0-rc.4 from main into develop

### DIFF
--- a/.github/workflows/notify-clet.yml
+++ b/.github/workflows/notify-clet.yml
@@ -12,7 +12,8 @@ name: Notify clet
 #     The flat-container is updated soon after publish; the search API
 #     (queried by `dotnet package search`) lags by minutes, which broke
 #     this workflow once before — see gui-cs/clet workflow run 25406348354.
-#   - Channel is derived from the SemVer suffix: contains '-' ⇒ develop.
+#   - Channel is derived from the triggering workflow's branch:
+#     main ⇒ tg-main-published, anything else ⇒ tg-develop-published.
 
 on:
   workflow_run:
@@ -44,12 +45,13 @@ jobs:
             exit 1
           fi
           echo "tg_version=$TG_VER" >> "$GITHUB_OUTPUT"
-          if [[ "$TG_VER" == *-* ]]; then
-            echo "event_type=tg-develop-published" >> "$GITHUB_OUTPUT"
-            echo "Channel: develop ($TG_VER)"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+            echo "event_type=tg-main-published" >> "$GITHUB_OUTPUT"
+            echo "Channel: main ($TG_VER from $BRANCH)"
           else
-            echo "event_type=tg-released" >> "$GITHUB_OUTPUT"
-            echo "Channel: release ($TG_VER)"
+            echo "event_type=tg-develop-published" >> "$GITHUB_OUTPUT"
+            echo "Channel: develop ($TG_VER from $BRANCH)"
           fi
 
       - name: Wait for NuGet flat-container to index the version

--- a/docfx/docs/showcase.md
+++ b/docfx/docs/showcase.md
@@ -2,6 +2,9 @@
 
 ## Applications Built with Terminal.Gui
 
+- **[clet](https://github.com/gui-cs/clet)** - CLI-lets: simple CLI commands that prompt the user with rich TUI inputs (select, confirm, file picker, date, color, etc.) and return typed JSON. One binary, every prompt, JSON out. Works for humans and AI agents alike.
+  ![clet](https://raw.githubusercontent.com/gui-cs/clet/develop/docs/images/hero.png)
+  ⠀
 - **[UI Catalog](https://github.com/gui-cs/Terminal.Gui/tree/master/UICatalog)** - The UI Catalog project provides an easy to use and extend sample illustrating the capabilities of **Terminal.Gui**. Run `dotnet run --project UICatalog` to run the UI Catalog.
   ![Sample app](../images/sample.gif)  
   ⠀


### PR DESCRIPTION
Automatic back-merge after release v2.1.0-rc.4. Merge this to keep `develop` in sync with `main`.