### PR TITLE
Back-merge v2.1.0 from main into develop

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -34,7 +34,7 @@ branches:
     # Matches the main branch
     regex: ^main$
     # Uses an empty label for stable releases
-    label: rc
+    label: ''
     # Increments patch version (x.y.z+1) on commits
     increment: Patch
     # Specifies develop as the source branch

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ app.Run (window);
 
 See the [Examples](Examples/README.md) for more.
 
+# Showcase
+
+See the [Showcase](https://gui-cs.github.io/Terminal.Gui/docs/showcase) for applications built with Terminal.Gui.
+
 # Documentation 
 
 Comprehensive documentation is at [gui-cs.github.io/Terminal.Gui](https://gui-cs.github.io/Terminal.Gui).


### PR DESCRIPTION
Automatic back-merge after release v2.1.0. Merge this to keep `develop` in sync with `main`.