### PR TITLE
Fixes #5275. Clear stale TextView OSC 8 hyperlinks

### DIFF
--- a/Terminal.Gui/Drivers/AnsiHandling/Osc8UrlLinker.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/Osc8UrlLinker.cs
@@ -3,6 +3,8 @@ namespace Terminal.Gui.Drivers;
 
 internal static class Osc8UrlLinker
 {
+    internal readonly record struct UrlRange (int Start, int Length, string Url);
+
     internal readonly struct Options
     {
         internal readonly string [] _allowedSchemes;
@@ -28,6 +30,11 @@ internal static class Osc8UrlLinker
     internal static StringBuilder WrapOsc8 (StringBuilder input)
     {
         return WrapOsc8 (input, _defaultOptions);
+    }
+
+    internal static List<UrlRange> FindUrls (string input)
+    {
+        return FindUrls (input, _defaultOptions);
     }
 
     internal static StringBuilder WrapOsc8 (StringBuilder input, Options options)
@@ -101,6 +108,76 @@ internal static class Osc8UrlLinker
         }
 
         return result;
+    }
+
+    private static List<UrlRange> FindUrls (string input, Options options)
+    {
+        List<UrlRange> ranges = [];
+        ReadOnlySpan<char> span = input.AsSpan ();
+        ReadOnlySpan<char> delimiter = "://".AsSpan ();
+        int i = 0;
+
+        while (i < span.Length)
+        {
+            int rel = span.Slice (i).IndexOf (delimiter, StringComparison.Ordinal);
+            if (rel < 0)
+            {
+                break;
+            }
+
+            int delimAt = i + rel;
+            int schemeEnd = delimAt;
+            int schemeStart = schemeEnd - 1;
+
+            while (schemeStart >= 0 && char.IsLetter (span [schemeStart]))
+            {
+                schemeStart--;
+            }
+
+            schemeStart++;
+
+            if (schemeStart < 0 || schemeStart >= schemeEnd)
+            {
+                i = delimAt + delimiter.Length;
+                continue;
+            }
+
+            ReadOnlySpan<char> scheme = span.Slice (schemeStart, schemeEnd - schemeStart);
+            if (!IsAllowedScheme (scheme, options))
+            {
+                i = delimAt + delimiter.Length;
+                continue;
+            }
+
+            int urlStart = schemeStart;
+            int j = delimAt + delimiter.Length;
+
+            while (j < span.Length && !IsUrlTerminator (span [j]))
+            {
+                j++;
+            }
+
+            int urlEnd = TrimTrailingPunctuation (span, urlStart, j);
+            if (urlEnd <= (delimAt + delimiter.Length))
+            {
+                i = j;
+                continue;
+            }
+
+            string candidate = span.Slice (urlStart, urlEnd - urlStart).ToString ();
+
+            Uri? _;
+            if (options._validateWithUri && !IsValidUrl (candidate, options, out _))
+            {
+                i = j;
+                continue;
+            }
+
+            ranges.Add (new (urlStart, urlEnd - urlStart, candidate));
+            i = j;
+        }
+
+        return ranges;
     }
 
     private static int ParseEscapeSequence (string text, int start, int len)

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -57,6 +57,7 @@ public abstract class OutputBase
 
     // Last URL used for tracking hyperlink state
     private string? _lastUrl = null;
+    private readonly HashSet<int> _rowsWithUrls = [];
 
     private readonly StringBuilder _lastOutputStringBuilder = new ();
     private bool _clearLastOutputPending;
@@ -93,8 +94,21 @@ public abstract class OutputBase
                 return;
             }
 
+            if (!IsLegacyConsole && buffer is OutputBufferImpl outputBuffer)
+            {
+                outputBuffer.SyncAutoUrlsForRow (row);
+            }
+
+            bool rowHadUrlsPreviously = _rowsWithUrls.Contains (row);
+            bool rowHasUrlsNow = !IsLegacyConsole && RowContainsUrls (buffer, row, cols);
+
             outputStringBuilder.Clear ();
             _lastUrl = null; // Reset URL state at the start of each row
+
+            if (!IsLegacyConsole && rowHadUrlsPreviously && !rowHasUrlsNow)
+            {
+                outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
+            }
 
             // Process columns in row
             for (int col = left; col < cols; col++)
@@ -197,9 +211,16 @@ public abstract class OutputBase
 
             SetCursorPositionImpl (lastCol, row);
 
-            // Wrap URLs with OSC 8 hyperlink sequences
-            StringBuilder processed = Osc8UrlLinker.WrapOsc8 (outputStringBuilder);
-            Write (processed);
+            Write (outputStringBuilder);
+
+            if (rowHasUrlsNow)
+            {
+                _rowsWithUrls.Add (row);
+            }
+            else
+            {
+                _rowsWithUrls.Remove (row);
+            }
         }
 
         if (IsLegacyConsole)
@@ -442,6 +463,11 @@ public abstract class OutputBase
             return output.ToString ();
         }
 
+        if (buffer is OutputBufferImpl outputBuffer)
+        {
+            outputBuffer.SyncAutoUrlsForAllRows ();
+        }
+
         StringBuilder ansiOutput = new ();
         Attribute? lastAttr = null;
 
@@ -451,24 +477,28 @@ public abstract class OutputBase
     }
 
     /// <summary>
-    ///     Writes buffered output to console, wrapping URLs with OSC 8 hyperlinks (non-legacy only),
-    ///     then clears the buffer and advances <paramref name="lastCol"/> by <paramref name="outputWidth"/>.
+    ///     Writes buffered output to console, then clears the buffer and advances
+    ///     <paramref name="lastCol"/> by <paramref name="outputWidth"/>.
     /// </summary>
     private void WriteToConsole (StringBuilder output, ref int lastCol, ref int outputWidth)
     {
-        if (IsLegacyConsole)
-        {
-            Write (output);
-        }
-        else
-        {
-            // Wrap URLs with OSC 8 hyperlink sequences
-            StringBuilder processed = Osc8UrlLinker.WrapOsc8 (output);
-            Write (processed);
-        }
+        Write (output);
 
         output.Clear ();
         lastCol += outputWidth;
         outputWidth = 0;
+    }
+
+    private static bool RowContainsUrls (IOutputBuffer buffer, int row, int cols)
+    {
+        for (int col = 0; col < cols; col++)
+        {
+            if (!string.IsNullOrEmpty (buffer.GetCellUrl (col, row)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -120,7 +120,7 @@ public abstract class OutputBase
             outputStringBuilder.Clear ();
             _lastUrl = null; // Reset URL state at the start of each row
 
-            if (!IsLegacyConsole && rowHadUrlsPreviously)
+            if (!IsLegacyConsole && rowHadUrlsPreviously && !rowHasUrlsNow)
             {
                 outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
             }
@@ -199,6 +199,21 @@ public abstract class OutputBase
                 }
             }
 
+            // Track row's URL status BEFORE the early-exit so _rowsWithUrls stays consistent
+            // with the buffer state — even for rows whose cells were all flushed via WriteToConsole
+            // during the inner loop (leaving outputStringBuilder empty at this point).
+            if (!IsLegacyConsole)
+            {
+                if (rowHasUrlsNow)
+                {
+                    _rowsWithUrls.Add (row);
+                }
+                else
+                {
+                    _rowsWithUrls.Remove (row);
+                }
+            }
+
             // Flush buffered output for row. Even when nothing remains buffered, an OSC 8 hyperlink
             // may still be open in the terminal because it was started in a prior batch flushed by
             // WriteToConsole and the row ended (or only clean cells followed) before any cell with
@@ -227,15 +242,6 @@ public abstract class OutputBase
             SetCursorPositionImpl (lastCol, row);
 
             Write (outputStringBuilder);
-
-            if (rowHasUrlsNow)
-            {
-                _rowsWithUrls.Add (row);
-            }
-            else
-            {
-                _rowsWithUrls.Remove (row);
-            }
         }
 
         if (IsLegacyConsole)

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -57,15 +57,28 @@ public abstract class OutputBase
 
     // Last URL used for tracking hyperlink state
     private string? _lastUrl = null;
+
+    // Rows that contained URLs in the last rendered frame; used to emit OSC 8 close
+    // before re-rendering a row that has since lost all URL cells, so terminals don't
+    // keep stale hyperlink metadata.
     private readonly HashSet<int> _rowsWithUrls = [];
+
+    // Identifies the buffer state we last synced _rowsWithUrls against. When the buffer
+    // is replaced, resized, or its URL maps are wiped, this stops matching and we drop
+    // the stale tracking before reading it.
+    private IOutputBuffer? _lastTrackedBuffer;
+    private int _lastTrackedRows;
+    private int _lastTrackedCols;
+    private int _lastTrackedUrlVersion;
 
     private readonly StringBuilder _lastOutputStringBuilder = new ();
     private bool _clearLastOutputPending;
 
     /// <summary>
-    ///     Writes dirty cells from the buffer to the console. Hides cursor, iterates rows/cols,
-    ///     skips clean cells, batches dirty cells into ANSI sequences, wraps URLs with OSC 8,
-    ///     then renders sixel images. Cursor visibility is managed by <c>ApplicationMainLoop.SetCursor()</c>.
+    ///     Writes dirty cells from the buffer to the console. Iterates rows/cols, skips clean cells,
+    ///     batches dirty cells into ANSI sequences, emits OSC 8 hyperlink start/close around URL cells,
+    ///     and finally renders queued sixel images. Cursor visibility is managed by
+    ///     <c>ApplicationMainLoop.SetCursor()</c>.
     /// </summary>
     public virtual void Write (IOutputBuffer buffer)
     {
@@ -77,6 +90,8 @@ public abstract class OutputBase
         int cols = buffer.Cols;
         Attribute? redrawAttr = null;
         int lastCol = -1;
+
+        InvalidateRowsWithUrlsIfStale (buffer, rows, cols);
 
         // Process each row
         for (int row = top; row < rows; row++)
@@ -500,5 +515,22 @@ public abstract class OutputBase
         }
 
         return false;
+    }
+
+    private void InvalidateRowsWithUrlsIfStale (IOutputBuffer buffer, int rows, int cols)
+    {
+        int urlVersion = buffer is OutputBufferImpl outputBuffer ? outputBuffer.UrlStateVersion : 0;
+
+        if (!ReferenceEquals (_lastTrackedBuffer, buffer)
+            || _lastTrackedRows != rows
+            || _lastTrackedCols != cols
+            || _lastTrackedUrlVersion != urlVersion)
+        {
+            _rowsWithUrls.Clear ();
+            _lastTrackedBuffer = buffer;
+            _lastTrackedRows = rows;
+            _lastTrackedCols = cols;
+            _lastTrackedUrlVersion = urlVersion;
+        }
     }
 }

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -120,7 +120,7 @@ public abstract class OutputBase
             outputStringBuilder.Clear ();
             _lastUrl = null; // Reset URL state at the start of each row
 
-            if (!IsLegacyConsole && rowHadUrlsPreviously && !rowHasUrlsNow)
+            if (!IsLegacyConsole && rowHadUrlsPreviously)
             {
                 outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
             }

--- a/Terminal.Gui/Drivers/Output/OutputBufferImpl.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBufferImpl.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Text;
 
 namespace Terminal.Gui.Drivers;
 
@@ -21,10 +22,14 @@ public class OutputBufferImpl : IOutputBuffer
     private int _rows;
 
     /// <summary>
-    ///     Maps cell positions to URLs for OSC 8 hyperlink support.
-    ///     Only stores entries for cells that actually have URLs, minimizing memory overhead.
+    ///     Maps cell positions to explicitly assigned URLs for OSC 8 hyperlink support.
     /// </summary>
-    private Dictionary<Point, string>? _urlMap;
+    private Dictionary<Point, string>? _explicitUrlMap;
+
+    /// <summary>
+    ///     Maps cell positions to auto-detected URLs found in plain text content.
+    /// </summary>
+    private Dictionary<Point, string>? _autoUrlMap;
 
     private Rune _column1ReplacementChar = Glyphs.WideGlyphReplacement;
 
@@ -58,15 +63,21 @@ public class OutputBufferImpl : IOutputBuffer
     /// <returns>The URL if one exists, otherwise null.</returns>
     public string? GetCellUrl (int col, int row)
     {
-        // Fast-path: skip locking when no URLs have been set
-        if (_urlMap is null)
+        if (_explicitUrlMap is null && _autoUrlMap is null)
         {
             return null;
         }
 
         lock (_contentsLock)
         {
-            return _urlMap?.TryGetValue (new Point (col, row), out string? url) == true ? url : null;
+            Point point = new (col, row);
+
+            if (_explicitUrlMap?.TryGetValue (point, out string? explicitUrl) == true)
+            {
+                return explicitUrl;
+            }
+
+            return _autoUrlMap?.TryGetValue (point, out string? autoUrl) == true ? autoUrl : null;
         }
     }
 
@@ -298,8 +309,8 @@ public class OutputBufferImpl : IOutputBuffer
 
         DirtyLines = new bool [Rows];
 
-        // Clear the URL map
-        _urlMap?.Clear ();
+        _explicitUrlMap?.Clear ();
+        _autoUrlMap?.Clear ();
 
         for (var row = 0; row < Rows; row++)
         {
@@ -417,7 +428,7 @@ public class OutputBufferImpl : IOutputBuffer
         }
         else
         {
-            _urlMap?.Remove (new Point (col, row));
+            _explicitUrlMap?.Remove (new Point (col, row));
         }
     }
 
@@ -429,8 +440,59 @@ public class OutputBufferImpl : IOutputBuffer
     /// <param name="url">The URL to associate with this cell.</param>
     private void SetCellUrl (int col, int row, string url)
     {
-        _urlMap ??= [];
-        _urlMap [new Point (col, row)] = url;
+        _explicitUrlMap ??= [];
+        _explicitUrlMap [new Point (col, row)] = url;
+    }
+
+    internal void SyncAutoUrlsForRow (int row)
+    {
+        lock (_contentsLock)
+        {
+            SyncAutoUrlsForRowCore (row);
+        }
+    }
+
+    internal void SyncAutoUrlsForAllRows ()
+    {
+        lock (_contentsLock)
+        {
+            for (int row = 0; row < Rows; row++)
+            {
+                SyncAutoUrlsForRowCore (row);
+            }
+        }
+    }
+
+    private void SyncAutoUrlsForRowCore (int row)
+    {
+        if (Contents is null || row < 0 || row >= Rows)
+        {
+            return;
+        }
+
+        for (int col = 0; col < Cols; col++)
+        {
+            _autoUrlMap?.Remove (new Point (col, row));
+        }
+
+        StringBuilder rowText = new (Cols);
+
+        for (int col = 0; col < Cols; col++)
+        {
+            string grapheme = Contents [row, col].Grapheme;
+            rowText.Append (string.IsNullOrEmpty (grapheme) ? " " : grapheme);
+        }
+
+        foreach (Osc8UrlLinker.UrlRange range in Osc8UrlLinker.FindUrls (rowText.ToString ()))
+        {
+            int end = Math.Min (range.Start + range.Length, Cols);
+
+            for (int col = range.Start; col < end; col++)
+            {
+                _autoUrlMap ??= [];
+                _autoUrlMap [new Point (col, row)] = range.Url;
+            }
+        }
     }
 
     /// <summary>

--- a/Terminal.Gui/Drivers/Output/OutputBufferImpl.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBufferImpl.cs
@@ -31,6 +31,15 @@ public class OutputBufferImpl : IOutputBuffer
     /// </summary>
     private Dictionary<Point, string>? _autoUrlMap;
 
+    private int _urlStateVersion;
+
+    /// <summary>
+    ///     Monotonic counter incremented when URL state is wiped (e.g. via
+    ///     <see cref="ClearContents(bool)"/> or <see cref="SetSize"/>). Consumers
+    ///     that cache per-frame URL-row tracking can compare to detect resets.
+    /// </summary>
+    internal int UrlStateVersion => _urlStateVersion;
+
     private Rune _column1ReplacementChar = Glyphs.WideGlyphReplacement;
 
     private Region? _clip;
@@ -309,8 +318,14 @@ public class OutputBufferImpl : IOutputBuffer
 
         DirtyLines = new bool [Rows];
 
-        _explicitUrlMap?.Clear ();
-        _autoUrlMap?.Clear ();
+        // Null out (rather than Clear) so GetCellUrl's null fast-path stays effective
+        // for the lifetime of the buffer until URLs are introduced again.
+        if (_explicitUrlMap is { } || _autoUrlMap is { })
+        {
+            _explicitUrlMap = null;
+            _autoUrlMap = null;
+            _urlStateVersion++;
+        }
 
         for (var row = 0; row < Rows; row++)
         {
@@ -470,28 +485,60 @@ public class OutputBufferImpl : IOutputBuffer
             return;
         }
 
-        for (int col = 0; col < Cols; col++)
+        if (_autoUrlMap is { Count: > 0 })
         {
-            _autoUrlMap?.Remove (new Point (col, row));
+            for (int col = 0; col < Cols; col++)
+            {
+                _autoUrlMap.Remove (new Point (col, row));
+            }
         }
 
+        // Build the row text and a parallel char-to-column map so grapheme clusters
+        // wider than a single char (ZWJ emoji, base + combining mark) don't shift the
+        // detected URL out of alignment with its actual columns.
         StringBuilder rowText = new (Cols);
+        int [] colByChar = new int [Cols * 2];
+        int charCount = 0;
 
         for (int col = 0; col < Cols; col++)
         {
             string grapheme = Contents [row, col].Grapheme;
-            rowText.Append (string.IsNullOrEmpty (grapheme) ? " " : grapheme);
+            string append = string.IsNullOrEmpty (grapheme) ? " " : grapheme;
+            rowText.Append (append);
+
+            if (charCount + append.Length > colByChar.Length)
+            {
+                Array.Resize (ref colByChar, Math.Max (colByChar.Length * 2, charCount + append.Length));
+            }
+
+            for (int k = 0; k < append.Length; k++)
+            {
+                colByChar [charCount++] = col;
+            }
         }
 
         foreach (Osc8UrlLinker.UrlRange range in Osc8UrlLinker.FindUrls (rowText.ToString ()))
         {
-            int end = Math.Min (range.Start + range.Length, Cols);
+            if (range.Start >= charCount)
+            {
+                continue;
+            }
 
-            for (int col = range.Start; col < end; col++)
+            int startCol = colByChar [range.Start];
+            int lastCharIdx = range.Start + range.Length - 1;
+            int endCol = lastCharIdx < charCount ? colByChar [lastCharIdx] + 1 : Cols;
+            endCol = Math.Min (endCol, Cols);
+
+            for (int col = startCol; col < endCol; col++)
             {
                 _autoUrlMap ??= [];
                 _autoUrlMap [new Point (col, row)] = range.Url;
             }
+        }
+
+        if (_autoUrlMap is { Count: 0 })
+        {
+            _autoUrlMap = null;
         }
     }
 

--- a/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
@@ -425,35 +425,6 @@ public class OutputBaseTests
         Assert.True (endIdx >= 0 && endIdx < replacementIdx, "OSC 8 close must be emitted before replacement spaces");
     }
 
-    // Copilot - GPT-5.4
-    // Regression coverage for the remaining floating-underline case when a row still contains
-    // a URL after redraw, but cells that were formerly part of a URL are now plain text.
-    // Warp appears to need an explicit OSC 8 close before those replacement cells are emitted;
-    // otherwise the old hyperlink metadata can remain attached to the old screen columns.
-    [Fact]
-    public void Write_AutoDetectedUrl_MovedWithinSameRow_ClosesBeforePlainReplacement ()
-    {
-        AnsiOutput output = new ();
-        IOutputBuffer buffer = output.GetLastBuffer ()!;
-        buffer.SetSize (48, 1);
-
-        buffer.Move (0, 0);
-        buffer.AddStr ("https://one.example then trailing text            ");
-        output.Write (buffer);
-
-        buffer.Move (0, 0);
-        buffer.AddStr ("plain intro then https://two.example            ");
-
-        output.Write (buffer);
-        string result = output.GetLastOutput ();
-        string end = EscSeqUtils.OSC_EndHyperlink ();
-        int replacementIdx = result.IndexOf ("plain intro then ", StringComparison.Ordinal);
-        int endIdx = result.IndexOf (end, StringComparison.Ordinal);
-
-        Assert.True (replacementIdx >= 0, "Replacement plain text was not emitted");
-        Assert.True (endIdx >= 0 && endIdx < replacementIdx, "OSC 8 close must be emitted before the old linked cells are redrawn as plain text");
-    }
-
     // Claude - Opus 4.7
     // Regression coverage for the char-vs-column mismatch in SyncAutoUrlsForRowCore.
     // When a multi-codepoint grapheme (ZWJ emoji, base + combining mark) precedes a URL
@@ -550,6 +521,52 @@ public class OutputBaseTests
         // OutputBase tracking is invalidated.
         Assert.Null (buffer.GetCellUrl (0, 0));
         Assert.True (buffer.UrlStateVersion > 0);
+    }
+
+    // Claude - Opus 4.7
+    // Regression coverage for _rowsWithUrls bookkeeping when the per-row flush happens entirely
+    // via WriteToConsole (i.e. the end-of-row Write path takes the empty-builder early-exit).
+    // Before the fix, the Add/Remove of the row index lived after the early-exit, so a row that
+    // lost its URL via overwrite but had clean trailing cells (causing the builder to flush
+    // mid-loop and end empty) kept a stale row-tracking entry — leading to a spurious row-start
+    // OSC 8 close on subsequent frames.
+    [Fact]
+    public void Write_RowLosesUrl_BuilderFlushedMidLoop_RemovesRowTracking ()
+    {
+        // Arrange — buffer with a URL on row 0, then overwrite the URL cells with non-URL
+        // content followed by clean cells (so the builder flushes mid-loop and the row exits
+        // with an empty builder, taking the early-exit).
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (40, 1);
+
+        // Frame 1: write URL covering cols 0-18, trailing space cells stay as ' '.
+        buffer.Move (0, 0);
+        buffer.AddStr ("https://example.com");
+        output.Write (buffer);
+
+        // Frame 2: overwrite the URL cells with Y characters. Cells 0-19 become dirty (19
+        // Y's plus the adjacent-dirty mark on cell 19). Cells 20-39 stay clean — they will
+        // trigger the WriteToConsole flush and leave the row with an empty builder.
+        buffer.Move (0, 0);
+        buffer.AddStr ("YYYYYYYYYYYYYYYYYYY");
+        output.Write (buffer);
+
+        // Frame 3: trivial change. With the fix, row 0 has been removed from _rowsWithUrls,
+        // so no OSC 8 close is emitted at the start of row 0. Without the fix, the stale
+        // entry causes a spurious OSC 8 close.
+        buffer.Move (0, 0);
+        buffer.AddStr ("X");
+
+        // Act
+        output.Write (buffer);
+        string result = output.GetLastOutput ();
+        string end = EscSeqUtils.OSC_EndHyperlink ();
+
+        // Assert — frame 3 must NOT emit an OSC 8 close because frame 2's row no longer
+        // has any URL state, and _rowsWithUrls must reflect that even when the early-exit
+        // path is taken.
+        Assert.DoesNotContain (end, result);
     }
 
     // Copilot

--- a/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
@@ -425,6 +425,35 @@ public class OutputBaseTests
         Assert.True (endIdx >= 0 && endIdx < replacementIdx, "OSC 8 close must be emitted before replacement spaces");
     }
 
+    // Copilot - GPT-5.4
+    // Regression coverage for the remaining floating-underline case when a row still contains
+    // a URL after redraw, but cells that were formerly part of a URL are now plain text.
+    // Warp appears to need an explicit OSC 8 close before those replacement cells are emitted;
+    // otherwise the old hyperlink metadata can remain attached to the old screen columns.
+    [Fact]
+    public void Write_AutoDetectedUrl_MovedWithinSameRow_ClosesBeforePlainReplacement ()
+    {
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (48, 1);
+
+        buffer.Move (0, 0);
+        buffer.AddStr ("https://one.example then trailing text            ");
+        output.Write (buffer);
+
+        buffer.Move (0, 0);
+        buffer.AddStr ("plain intro then https://two.example            ");
+
+        output.Write (buffer);
+        string result = output.GetLastOutput ();
+        string end = EscSeqUtils.OSC_EndHyperlink ();
+        int replacementIdx = result.IndexOf ("plain intro then ", StringComparison.Ordinal);
+        int endIdx = result.IndexOf (end, StringComparison.Ordinal);
+
+        Assert.True (replacementIdx >= 0, "Replacement plain text was not emitted");
+        Assert.True (endIdx >= 0 && endIdx < replacementIdx, "OSC 8 close must be emitted before the old linked cells are redrawn as plain text");
+    }
+
     // Claude - Opus 4.7
     // Regression coverage for the char-vs-column mismatch in SyncAutoUrlsForRowCore.
     // When a multi-codepoint grapheme (ZWJ emoji, base + combining mark) precedes a URL

--- a/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
@@ -360,6 +360,69 @@ public class OutputBaseTests
         Assert.True (secondStart < 0, "No OSC 8 start should appear on row 1");
     }
 
+    // Copilot - GPT-5.4
+    // Regression coverage for plain-text URL auto-linking used by TextView/Editor.
+    // If a previously auto-linked URL is overwritten by non-URL text, the redraw must
+    // explicitly clear hyperlink state before writing the replacement text.
+    [Fact]
+    public void Write_AutoDetectedUrl_ThenPlainText_EmitsOsc8CloseBeforeReplacement ()
+    {
+        // Arrange
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (24, 1);
+
+        buffer.Move (0, 0);
+        buffer.AddStr ("https://example.com");
+        output.Write (buffer);
+
+        buffer.Move (0, 0);
+        buffer.AddStr ("plain replacement      ");
+
+        // Act
+        output.Write (buffer);
+        string result = output.GetLastOutput ();
+
+        // Assert
+        string start = EscSeqUtils.OSC_StartHyperlink ("https://example.com");
+        string end = EscSeqUtils.OSC_EndHyperlink ();
+        int replacementIdx = result.IndexOf ("plain replacement", StringComparison.Ordinal);
+        int endIdx = result.IndexOf (end, StringComparison.Ordinal);
+
+        Assert.DoesNotContain (start, result);
+        Assert.True (replacementIdx >= 0, "Replacement text was not emitted");
+        Assert.True (endIdx >= 0 && endIdx < replacementIdx, "OSC 8 close must be emitted before replacement text");
+    }
+
+    // Copilot - GPT-5.4
+    // Regression coverage for deleting all text in the Editor scenario.
+    // Clearing a row that previously contained an auto-detected URL must emit an OSC 8
+    // close so terminals do not keep hyperlink metadata at the former URL location.
+    [Fact]
+    public void Write_AutoDetectedUrl_ThenSpaces_EmitsOsc8CloseBeforeClearingCells ()
+    {
+        // Arrange
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (24, 1);
+
+        buffer.Move (0, 0);
+        buffer.AddStr ("https://example.com");
+        output.Write (buffer);
+
+        buffer.Move (0, 0);
+        buffer.AddStr ("                        ");
+
+        // Act
+        output.Write (buffer);
+        string result = output.GetLastOutput ();
+        string end = EscSeqUtils.OSC_EndHyperlink ();
+
+        // Assert
+        Assert.Contains (" ", result);
+        Assert.Contains (end, result);
+    }
+
     // Copilot
     [Fact]
     public void ToAnsi_LegacyConsole_NoOsc8 ()

--- a/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
@@ -417,10 +417,110 @@ public class OutputBaseTests
         output.Write (buffer);
         string result = output.GetLastOutput ();
         string end = EscSeqUtils.OSC_EndHyperlink ();
+        int replacementIdx = result.IndexOf ("                        ", StringComparison.Ordinal);
+        int endIdx = result.IndexOf (end, StringComparison.Ordinal);
 
         // Assert
-        Assert.Contains (" ", result);
-        Assert.Contains (end, result);
+        Assert.True (replacementIdx >= 0, "Replacement spaces were not emitted");
+        Assert.True (endIdx >= 0 && endIdx < replacementIdx, "OSC 8 close must be emitted before replacement spaces");
+    }
+
+    // Claude - Opus 4.7
+    // Regression coverage for the char-vs-column mismatch in SyncAutoUrlsForRowCore.
+    // When a multi-codepoint grapheme (ZWJ emoji, base + combining mark) precedes a URL
+    // on the same row, the URL's char offset in the concatenated row text diverges from
+    // its column position. The fix builds a char-to-column map so the auto-URL metadata
+    // lands on the actual URL cells, not shifted by the extra char count.
+    [Fact]
+    public void Write_AutoDetectedUrl_AfterMultiCharGrapheme_LinkAlignsWithUrlColumns ()
+    {
+        // Arrange — combining acute (U+0301) appended to 'e' yields a 2-char grapheme
+        // occupying a single column. Without the fix, the URL would be tagged starting
+        // one column past where it actually renders.
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (40, 1);
+
+        buffer.Move (0, 0);
+        buffer.AddStr ("é https://example.com");
+
+        // Act
+        output.Write (buffer);
+        string result = output.GetLastOutput ();
+        string start = EscSeqUtils.OSC_StartHyperlink ("https://example.com");
+
+        int startIdx = result.IndexOf (start, StringComparison.Ordinal);
+
+        // Assert — the visible URL text must follow the OSC 8 start sequence with no
+        // characters between them. Search strictly after the start sequence so we don't
+        // match the URL embedded as the OSC parameter inside the start sequence itself.
+        Assert.True (startIdx >= 0, "OSC 8 start sequence was not emitted");
+
+        int afterStart = startIdx + start.Length;
+        int visibleUrlIdx = result.IndexOf ("https://example.com", afterStart, StringComparison.Ordinal);
+
+        Assert.Equal (afterStart, visibleUrlIdx);
+    }
+
+    // Claude - Opus 4.7
+    // Regression coverage for stale _rowsWithUrls tracking on resize. After a SetSize call
+    // the buffer's URL maps are wiped, so OutputBase must drop its row tracking too.
+    // Otherwise the next render emits a spurious OSC 8 close at the start of any row index
+    // that previously contained a URL.
+    [Fact]
+    public void Write_AfterResize_DoesNotEmitSpuriousOsc8Close ()
+    {
+        // Arrange — render a URL, then resize (which clears URL maps) and render plain text.
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (40, 2);
+
+        buffer.Move (0, 0);
+        buffer.AddStr ("https://example.com");
+        output.Write (buffer);
+
+        // SetSize wipes URL state; row 0 used to have a URL.
+        buffer.SetSize (40, 2);
+
+        buffer.Move (0, 0);
+        buffer.AddStr ("plain text only");
+
+        // Act
+        output.Write (buffer);
+        string result = output.GetLastOutput ();
+        string end = EscSeqUtils.OSC_EndHyperlink ();
+
+        // Assert — no OSC 8 close should appear because row 0 no longer has any URL state
+        // and the buffer was reset between writes.
+        Assert.DoesNotContain (end, result);
+    }
+
+    // Claude - Opus 4.7
+    // After clearing URL state, GetCellUrl's null fast-path should be re-armed so subsequent
+    // cell lookups skip the lock entirely. This guards against the regression where
+    // ClearContents called .Clear() on the maps but left them allocated, defeating the
+    // fast-path for the lifetime of the buffer.
+    [Fact]
+    public void GetCellUrl_AfterUrlSetThenCleared_RestoresNullFastPath ()
+    {
+        // Arrange
+        OutputBufferImpl buffer = new () { Rows = 1, Cols = 10 };
+        buffer.SetSize (10, 1);
+        buffer.Move (0, 0);
+        buffer.CurrentUrl = "https://example.com";
+        buffer.AddStr ("https://x");
+        buffer.CurrentUrl = null;
+
+        Assert.NotNull (buffer.GetCellUrl (0, 0));
+
+        // Act
+        buffer.ClearContents (true);
+
+        // Assert — second call should hit the null fast-path. We can't directly observe the
+        // lock skip, but we can verify state was wiped and the version counter advanced so
+        // OutputBase tracking is invalidated.
+        Assert.Null (buffer.GetCellUrl (0, 0));
+        Assert.True (buffer.UrlStateVersion > 0);
     }
 
     // Copilot


### PR DESCRIPTION
## Summary

Fixes the stale OSC 8 hyperlink state in `TextView` when links come from plain-text URL auto-detection rather than explicit `Link` views.

- Fixes #5275

## Changes

- Split output-buffer URL tracking so explicit links and auto-detected plain-text URLs are synchronized independently.
- Reused `Osc8UrlLinker` URL-range detection to map auto-detected URLs into per-cell output state before rendering.
- Updated row rendering to emit OSC 8 close sequences when a row previously had hyperlinks but no longer does after redraw, scroll, or delete-all.
- Added regression coverage for overwriting auto-detected URLs with plain text and spaces.
- Preserved the explicit-link path fixed by #5254; this addresses a separate pre-existing bug in the plain-text auto-linking path.

## Testing

- `dotnet build --no-restore`
- `dotnet test --project Tests/UnitTestsParallelizable --no-build`

## To pull down this PR locally:

```bash
git remote add copilot https://github.com/harder/Terminal.Gui.git
git fetch copilot harder/issue-5275-textview-osc8
git checkout copilot/harder/issue-5275-textview-osc8
