### PR TITLE
Fixes #5144. Add bracketed-paste mode support

### DIFF
--- a/Examples/UICatalog/Scenarios/BracketedPasteDemo.cs
+++ b/Examples/UICatalog/Scenarios/BracketedPasteDemo.cs
@@ -25,7 +25,7 @@ public sealed class BracketedPasteDemo : Scenario
             X = 0,
             Y = Pos.Bottom (hint) + 1,
             Width = Dim.Fill (),
-            Title = "Paste into the focused TextField — the default OnPasted inserts the text."
+            Title = "Paste into the focused TextField — the default Command.Paste handler inserts the text."
         };
 
         Label log = new ()

--- a/Examples/UICatalog/Scenarios/BracketedPasteDemo.cs
+++ b/Examples/UICatalog/Scenarios/BracketedPasteDemo.cs
@@ -1,0 +1,71 @@
+#nullable enable
+
+namespace UICatalog.Scenarios;
+
+[ScenarioMetadata ("Bracketed Paste", "Logs bracketed-paste payloads delivered by the terminal")]
+[ScenarioCategory ("Input")]
+public sealed class BracketedPasteDemo : Scenario
+{
+    public override void Main ()
+    {
+        ConfigurationManager.Enable (ConfigLocations.All);
+        using IApplication app = Application.Create ();
+        app.Init ();
+
+        using Window appWindow = new ()
+        {
+            Title = GetQuitKeyAndName ()
+        };
+        appWindow.AssignHotKeys = true;
+
+        Label hint = new ()
+        {
+            X = 0,
+            Y = 0,
+            Text = "Paste anything from your system clipboard. Pastes show up as a single delivery if "
+                   + "your terminal supports bracketed-paste mode (most modern terminals do)."
+        };
+
+        TextField field = new ()
+        {
+            X = 0,
+            Y = Pos.Bottom (hint) + 1,
+            Width = Dim.Fill (),
+            Title = "Paste into the focused TextField — the default OnPasted inserts the text."
+        };
+
+        Label log = new ()
+        {
+            X = 0,
+            Y = Pos.Bottom (field) + 1,
+            Width = Dim.Fill (),
+            Height = Dim.Fill (),
+            Text = "Application.Paste log:\n"
+        };
+
+        var counter = 0;
+
+        app.Paste += (_, args) =>
+                     {
+                         counter++;
+                         log.Text += $"[{counter}] {args.Text.Length} chars: {Truncate (args.Text)}\n";
+                     };
+
+        appWindow.Add (hint, field, log);
+
+        app.Run (appWindow);
+    }
+
+    private static string Truncate (string text)
+    {
+        // Replace control chars so the display stays one line per paste.
+        string flattened = text.Replace ("\r", "\\r").Replace ("\n", "\\n").Replace ("\t", "\\t");
+
+        if (flattened.Length <= 60)
+        {
+            return flattened;
+        }
+
+        return flattened [..60] + "…";
+    }
+}

--- a/Examples/UICatalog/Scenarios/BracketedPasteDemo.cs
+++ b/Examples/UICatalog/Scenarios/BracketedPasteDemo.cs
@@ -3,7 +3,7 @@
 namespace UICatalog.Scenarios;
 
 [ScenarioMetadata ("Bracketed Paste", "Logs bracketed-paste payloads delivered by the terminal")]
-[ScenarioCategory ("Input")]
+[ScenarioCategory ("Text and Formatting")]
 public sealed class BracketedPasteDemo : Scenario
 {
     public override void Main ()
@@ -18,13 +18,7 @@ public sealed class BracketedPasteDemo : Scenario
         };
         appWindow.AssignHotKeys = true;
 
-        Label hint = new ()
-        {
-            X = 0,
-            Y = 0,
-            Text = "Paste anything from your system clipboard. Pastes show up as a single delivery if "
-                   + "your terminal supports bracketed-paste mode (most modern terminals do)."
-        };
+        Label hint = CreateHintLabel ();
 
         TextField field = new ()
         {
@@ -40,20 +34,43 @@ public sealed class BracketedPasteDemo : Scenario
             Y = Pos.Bottom (field) + 1,
             Width = Dim.Fill (),
             Height = Dim.Fill (),
-            Text = "Application.Paste log:\n"
+            Text = "Application.Paste log (only bracketed paste events appear here):\n"
         };
 
-        var counter = 0;
+        int counter = 0;
 
         app.Paste += (_, args) =>
                      {
-                         counter++;
-                         log.Text += $"[{counter}] {args.Text.Length} chars: {Truncate (args.Text)}\n";
-                     };
+                          counter++;
+                          log.Text += $"{FormatPasteLogEntry (counter, args.Text)}\n";
+                      };
 
         appWindow.Add (hint, field, log);
 
         app.Run (appWindow);
+    }
+
+    public static Label CreateHintLabel ()
+    {
+        Label hint = new ()
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill (),
+            Height = Dim.Auto (DimAutoStyle.Text),
+            Text = "Paste into the TextField below.\n"
+                   + "If Terminal.Gui detects bracketed paste, the paste is logged below as a single bracketed-paste event.\n"
+                   + "If text appears in the field but no new log entry is added, your terminal delivered it as normal input instead."
+        };
+
+        hint.TextFormatter.WordWrap = true;
+
+        return hint;
+    }
+
+    public static string FormatPasteLogEntry (int counter, string text)
+    {
+        return $"[{counter}] Bracketed paste event: {text.Length} chars: {Truncate (text)}";
     }
 
     private static string Truncate (string text)

--- a/Terminal.Gui/App/ApplicationImpl.Driver.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Driver.cs
@@ -197,6 +197,7 @@ internal partial class ApplicationImpl
         Driver.KeyDown += Driver_KeyDown;
         Driver.KeyUp += Driver_KeyUp;
         Driver.MouseEvent += Driver_MouseEvent;
+        Driver.Paste += Driver_Paste;
     }
 
     private void Driver_KeyDown (object? sender, Key e) => Keyboard.RaiseKeyDownEvent (e);
@@ -204,4 +205,6 @@ internal partial class ApplicationImpl
     private void Driver_KeyUp (object? sender, Key e) => Keyboard.RaiseKeyUpEvent (e);
 
     private void Driver_MouseEvent (object? sender, Mouse e) => Mouse.RaiseMouseEvent (e);
+
+    private void Driver_Paste (object? sender, string e) => RaisePasteEvent (e);
 }

--- a/Terminal.Gui/App/ApplicationImpl.cs
+++ b/Terminal.Gui/App/ApplicationImpl.cs
@@ -230,6 +230,34 @@ internal partial class ApplicationImpl : IApplication
         set => _mouse = value ?? throw new ArgumentNullException (nameof (value));
     }
 
+    /// <inheritdoc/>
+    public event EventHandler<PasteEventArgs>? Paste;
+
+    /// <inheritdoc/>
+    public bool RaisePasteEvent (string text)
+    {
+        PasteEventArgs args = new (text);
+
+        Paste?.Invoke (this, args);
+
+        if (args.Handled)
+        {
+            return true;
+        }
+
+        // Route to the focused view (mirrors keyboard dispatch). If no view is focused, fall through
+        // to the top-most runnable so embedded TextField / TextView still receives pastes when the
+        // user has not explicitly clicked into a control yet.
+        View? target = Navigation?.GetFocused () ?? TopRunnableView;
+
+        if (target is null)
+        {
+            return false;
+        }
+
+        return target.NewPasteEvent (args);
+    }
+
     #endregion Input (Mouse/Keyboard)
 
     #region Navigation and Popover

--- a/Terminal.Gui/App/ApplicationImpl.cs
+++ b/Terminal.Gui/App/ApplicationImpl.cs
@@ -256,7 +256,15 @@ internal partial class ApplicationImpl : IApplication
             return false;
         }
 
-        return focused.NewPasteEvent (args);
+        // Dispatch through Command.Paste so the bracketed-paste payload uses the same pipeline
+        // (sanitization, Pasting/Pasted events, bubbling) as keyboard-driven paste. The payload
+        // travels via CommandContext.Values; the default handler picks it up from ctx.Value.
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (focused), binding: null)
+        {
+            Routing = CommandRouting.BubblingUp
+        };
+
+        return focused.InvokeCommand (Command.Paste, ctx.WithValue (args.Text)) is true;
     }
 
     #endregion Input (Mouse/Keyboard)

--- a/Terminal.Gui/App/ApplicationImpl.cs
+++ b/Terminal.Gui/App/ApplicationImpl.cs
@@ -256,15 +256,13 @@ internal partial class ApplicationImpl : IApplication
             return false;
         }
 
-        // Dispatch through Command.Paste so the bracketed-paste payload uses the same pipeline
-        // (sanitization, Pasting/Pasted events, bubbling) as keyboard-driven paste. The payload
-        // travels via CommandContext.Values; the default handler picks it up from ctx.Value.
-        CommandContext ctx = new (Command.Paste, new WeakReference<View> (focused), binding: null)
-        {
-            Routing = CommandRouting.BubblingUp
-        };
+        // Dispatch through Command.Paste so bracketed paste shares the same paste handler
+        // (sanitization, Pasting/Pasted events, insertion) as keyboard-driven paste. Use a
+        // dedicated payload object so the handler does not mistake unrelated string-valued command
+        // context entries for pasted text.
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (focused), binding: null);
 
-        return focused.InvokeCommand (Command.Paste, ctx.WithValue (args.Text)) is true;
+        return focused.InvokeCommand (Command.Paste, ctx.WithValue (new PastePayload (args.Text))) is true;
     }
 
     #endregion Input (Mouse/Keyboard)

--- a/Terminal.Gui/App/ApplicationImpl.cs
+++ b/Terminal.Gui/App/ApplicationImpl.cs
@@ -245,17 +245,18 @@ internal partial class ApplicationImpl : IApplication
             return true;
         }
 
-        // Route to the focused view (mirrors keyboard dispatch). If no view is focused, fall through
-        // to the top-most runnable so embedded TextField / TextView still receives pastes when the
-        // user has not explicitly clicked into a control yet.
-        View? target = Navigation?.GetFocused () ?? TopRunnableView;
+        // Route only to the focused view — paste data is text destined for a text-input control,
+        // and silently dispatching to a non-text container would either drop the paste or surprise
+        // the user. Apps that want to handle pastes without a focused view should subscribe to
+        // Application.Paste and set Handled.
+        View? focused = Navigation?.GetFocused ();
 
-        if (target is null)
+        if (focused is null)
         {
             return false;
         }
 
-        return target.NewPasteEvent (args);
+        return focused.NewPasteEvent (args);
     }
 
     #endregion Input (Mouse/Keyboard)

--- a/Terminal.Gui/App/IApplication.cs
+++ b/Terminal.Gui/App/IApplication.cs
@@ -671,6 +671,29 @@ public interface IApplication : IDisposable
     /// </remarks>
     IMouse Mouse { get; set; }
 
+    /// <summary>
+    ///     Raised when the terminal delivers a bracketed paste. Fires before the paste is dispatched
+    ///     to the focused view; set <see cref="System.ComponentModel.HandledEventArgs.Handled"/> on
+    ///     the event arguments to <see langword="true"/> to prevent the focused view from receiving
+    ///     the paste.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Bracketed paste mode is enabled automatically by the driver. On terminals that do not
+    ///         support bracketed paste (or have it disabled by user configuration) the pasted text is
+    ///         delivered as ordinary key events and this event does not fire.
+    ///     </para>
+    /// </remarks>
+    event EventHandler<PasteEventArgs>? Paste;
+
+    /// <summary>
+    ///     Raises the <see cref="Paste"/> event with <paramref name="text"/>, then dispatches the paste
+    ///     to the focused view via <see cref="View.NewPasteEvent"/> if not already handled.
+    /// </summary>
+    /// <param name="text">The pasted content with bracketing markers stripped.</param>
+    /// <returns><see langword="true"/> if the paste was handled.</returns>
+    bool RaisePasteEvent (string text);
+
     #endregion Input (Mouse/Keyboard)
 
     #region Layout and Drawing

--- a/Terminal.Gui/App/IApplication.cs
+++ b/Terminal.Gui/App/IApplication.cs
@@ -688,11 +688,12 @@ public interface IApplication : IDisposable
 
     /// <summary>
     ///     Raises the <see cref="Paste"/> event with <paramref name="text"/>, then dispatches the
-    ///     paste to the focused view by invoking <see cref="Command.Paste"/> with the payload in
-    ///     <see cref="CommandContext.Values"/> if not already handled. The default
+    ///     paste to the focused view by invoking <see cref="Command.Paste"/> with a dedicated
+    ///     command-context paste payload if not already handled. The default
     ///     <see cref="Command.Paste"/> handler on <see cref="View"/> sanitizes the payload, raises
-    ///     <see cref="View.Pasting"/> and <see cref="View.Pasted"/>, and delegates insertion to the
-    ///     focused view's <see cref="View.OnPaste"/> override.
+    ///     <see cref="View.Pasting"/>, and delegates insertion to the focused view's
+    ///     <see cref="View.OnPaste"/> override. If the focused view consumes the paste and reports
+    ///     a final-text segment for the pasted range, the handler raises <see cref="View.Pasted"/>.
     /// </summary>
     /// <param name="text">The pasted content with bracketing markers stripped.</param>
     /// <returns><see langword="true"/> if the paste was handled.</returns>

--- a/Terminal.Gui/App/IApplication.cs
+++ b/Terminal.Gui/App/IApplication.cs
@@ -687,8 +687,12 @@ public interface IApplication : IDisposable
     event EventHandler<PasteEventArgs>? Paste;
 
     /// <summary>
-    ///     Raises the <see cref="Paste"/> event with <paramref name="text"/>, then dispatches the paste
-    ///     to the focused view via <see cref="View.NewPasteEvent"/> if not already handled.
+    ///     Raises the <see cref="Paste"/> event with <paramref name="text"/>, then dispatches the
+    ///     paste to the focused view by invoking <see cref="Command.Paste"/> with the payload in
+    ///     <see cref="CommandContext.Values"/> if not already handled. The default
+    ///     <see cref="Command.Paste"/> handler on <see cref="View"/> sanitizes the payload, raises
+    ///     <see cref="View.Pasting"/> and <see cref="View.Pasted"/>, and delegates insertion to the
+    ///     focused view's <see cref="View.OnPaste"/> override.
     /// </summary>
     /// <param name="text">The pasted content with bracketing markers stripped.</param>
     /// <returns><see langword="true"/> if the paste was handled.</returns>

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -145,6 +145,7 @@ public class AnsiOutput : OutputBase, IOutput
 
                 // TODO: Move Input related CSI sequences to AnsiInput
                 Write (EscSeqUtils.CSI_EnableMouseEvents);
+                Write (EscSeqUtils.CSI_EnableBracketedPaste);
             }
             else
             {
@@ -156,6 +157,7 @@ public class AnsiOutput : OutputBase, IOutput
 
                 // TODO: Move Input related CSI sequences to AnsiInput
                 Write (EscSeqUtils.CSI_EnableMouseEvents);
+                Write (EscSeqUtils.CSI_EnableBracketedPaste);
             }
 
             // Flush to ensure all sequences are sent
@@ -382,6 +384,7 @@ public class AnsiOutput : OutputBase, IOutput
             }
 
             // Restore terminal state: disable mouse, reset attributes, show cursor
+            Write (EscSeqUtils.CSI_DisableBracketedPaste);
             Write (EscSeqUtils.CSI_DisableMouseEvents);
             Write (EscSeqUtils.CSI_ResetAttributes);
 

--- a/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
@@ -134,13 +134,26 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
     /// <param name="inputLength">The total number of elements in the input collection.</param>
     protected void ProcessInputBase (Func<int, char> getCharAtIndex, Func<int, object> getObjectAtIndex, Action<object> appendOutput, int inputLength)
     {
+        List<string> pendingPastes = [];
+
         lock (_lockState)
         {
-            ProcessInputBaseImpl (getCharAtIndex, getObjectAtIndex, appendOutput, inputLength);
+            ProcessInputBaseImpl (getCharAtIndex, getObjectAtIndex, appendOutput, inputLength, pendingPastes);
+        }
+
+        foreach (string text in pendingPastes)
+        {
+            Paste?.Invoke (this, text);
         }
     }
 
-    private void ProcessInputBaseImpl (Func<int, char> getCharAtIndex, Func<int, object> getObjectAtIndex, Action<object> appendOutput, int inputLength)
+    private void ProcessInputBaseImpl (
+        Func<int, char> getCharAtIndex,
+        Func<int, object> getObjectAtIndex,
+        Action<object> appendOutput,
+        int inputLength,
+        List<string> pendingPastes
+    )
     {
         var index = 0; // Tracks position in the input string
 
@@ -199,11 +212,11 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
 
                 case AnsiResponseParserState.InBracketedPaste:
                     NoteBracketedPasteActivity ();
-                    AppendToPaste (currentChar);
+                    AppendToPaste (currentChar, pendingPastes);
 
                     if (_pasteBuffer.Length >= MaxBracketedPasteLength)
                     {
-                        FlushPaste (AnsiResponseParserState.DiscardingBracketedPasteRemainder);
+                        FlushPaste (AnsiResponseParserState.DiscardingBracketedPasteRemainder, pendingPastes);
                     }
 
                     break;
@@ -708,7 +721,7 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
     /// </remarks>
     public event EventHandler<string>? Paste;
 
-    private void AppendToPaste (char c)
+    private void AppendToPaste (char c, List<string> pendingPastes)
     {
         _pasteBuffer.Append (c);
 
@@ -719,7 +732,7 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
 
         // Full end marker matched — strip its characters from the buffer and dispatch.
         _pasteBuffer.Length -= EscSeqUtils.CSI_BracketedPasteEnd.Length;
-        FlushPaste (AnsiResponseParserState.Normal);
+        FlushPaste (AnsiResponseParserState.Normal, pendingPastes);
     }
 
     private void DiscardBracketedPasteRemainder (char c)
@@ -752,7 +765,7 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
         return _pasteEndMatchLength == endMarker.Length;
     }
 
-    private void FlushPaste (AnsiResponseParserState nextState)
+    private string DrainPasteBuffer (AnsiResponseParserState nextState)
     {
         if (nextState == AnsiResponseParserState.DiscardingBracketedPasteRemainder && _pasteEndMatchLength > 0)
         {
@@ -769,7 +782,13 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
 
         State = nextState;
 
-        Paste?.Invoke (this, text);
+        return text;
+    }
+
+    private void FlushPaste (AnsiResponseParserState nextState, List<string> pendingPastes)
+    {
+        string text = DrainPasteBuffer (nextState);
+        pendingPastes.Add (text);
     }
 
     private void NoteBracketedPasteActivity () => LastBracketedPasteInputAt = _timeProvider.Now;
@@ -786,24 +805,30 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
     /// </returns>
     internal bool FlushStaleBracketedPaste ()
     {
+        string? text = null;
+
         lock (_lockState)
         {
             if (State == AnsiResponseParserState.InBracketedPaste)
             {
-                FlushPaste (AnsiResponseParserState.Normal);
-
-                return true;
+                text = DrainPasteBuffer (AnsiResponseParserState.Normal);
             }
-
-            if (State != AnsiResponseParserState.DiscardingBracketedPasteRemainder)
+            else if (State == AnsiResponseParserState.DiscardingBracketedPasteRemainder)
+            {
+                ResetState ();
+            }
+            else
             {
                 return false;
             }
-
-            ResetState ();
-
-            return true;
         }
+
+        if (text is { })
+        {
+            Paste?.Invoke (this, text);
+        }
+
+        return true;
     }
 
     #endregion

--- a/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
@@ -21,9 +21,10 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
 
     /// <summary>
     ///     Maximum number of characters allowed in a single bracketed-paste payload. Pastes larger
-    ///     than this are truncated and the truncated content is delivered with the parser returning
-    ///     to <see cref="AnsiResponseParserState.Normal"/>. Guards against unbounded memory growth
-    ///     from a missing or stripped <c>ESC[201~</c> end marker.
+    ///     than this are truncated and the truncated content is delivered immediately. Any remaining
+    ///     bytes from the same paste are discarded until the matching <c>ESC[201~</c> end marker
+    ///     arrives so tail bytes cannot leak into normal input processing. Guards against unbounded
+    ///     memory growth from a missing or stripped end marker.
     /// </summary>
     internal const int MaxBracketedPasteLength = 1 * 1024 * 1024;
 
@@ -92,6 +93,12 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
     ///     Timestamp when <see cref="State"/> was last changed. Used to detect stale escape sequences.
     /// </summary>
     public DateTime StateChangedAt { get; private set; }
+
+    /// <summary>
+    ///     Timestamp when the parser last received a byte belonging to the current bracketed paste.
+    ///     Used to detect idle paste sessions without treating an active slow paste as stale.
+    /// </summary>
+    internal DateTime LastBracketedPasteInputAt { get; private set; }
 
     #endregion
 
@@ -191,12 +198,19 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
                     break;
 
                 case AnsiResponseParserState.InBracketedPaste:
+                    NoteBracketedPasteActivity ();
                     AppendToPaste (currentChar);
 
                     if (_pasteBuffer.Length >= MaxBracketedPasteLength)
                     {
-                        FlushPaste ();
+                        FlushPaste (AnsiResponseParserState.DiscardingBracketedPasteRemainder);
                     }
+
+                    break;
+
+                case AnsiResponseParserState.DiscardingBracketedPasteRemainder:
+                    NoteBracketedPasteActivity ();
+                    DiscardBracketedPasteRemainder (currentChar);
 
                     break;
 
@@ -376,6 +390,7 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
                 _pasteBuffer.Clear ();
                 _pasteEndMatchLength = 0;
                 State = AnsiResponseParserState.InBracketedPaste;
+                NoteBracketedPasteActivity ();
 
                 return false;
             }
@@ -697,7 +712,30 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
     {
         _pasteBuffer.Append (c);
 
-        // Track an in-flight suffix match against ESC[201~ so we can strip the marker on success
+        if (!AdvanceBracketedPasteEndMatch (c))
+        {
+            return;
+        }
+
+        // Full end marker matched — strip its characters from the buffer and dispatch.
+        _pasteBuffer.Length -= EscSeqUtils.CSI_BracketedPasteEnd.Length;
+        FlushPaste (AnsiResponseParserState.Normal);
+    }
+
+    private void DiscardBracketedPasteRemainder (char c)
+    {
+        if (!AdvanceBracketedPasteEndMatch (c))
+        {
+            return;
+        }
+
+        _pasteEndMatchLength = 0;
+        State = AnsiResponseParserState.Normal;
+    }
+
+    private bool AdvanceBracketedPasteEndMatch (char c)
+    {
+        // Track an in-flight suffix match against ESC[201~ so we can strip or discard the marker
         // without scanning the whole buffer on every character.
         string endMarker = EscSeqUtils.CSI_BracketedPasteEnd;
 
@@ -711,25 +749,30 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
             _pasteEndMatchLength = c == ESCAPE ? 1 : 0;
         }
 
-        if (_pasteEndMatchLength != endMarker.Length)
-        {
-            return;
-        }
-
-        // Full end marker matched — strip its characters from the buffer and dispatch.
-        _pasteBuffer.Length -= endMarker.Length;
-        FlushPaste ();
+        return _pasteEndMatchLength == endMarker.Length;
     }
 
-    private void FlushPaste ()
+    private void FlushPaste (AnsiResponseParserState nextState)
     {
+        if (nextState == AnsiResponseParserState.DiscardingBracketedPasteRemainder && _pasteEndMatchLength > 0)
+        {
+            _pasteBuffer.Length -= _pasteEndMatchLength;
+        }
+
         string text = _pasteBuffer.ToString ();
         _pasteBuffer.Clear ();
-        _pasteEndMatchLength = 0;
-        State = AnsiResponseParserState.Normal;
+
+        if (nextState != AnsiResponseParserState.DiscardingBracketedPasteRemainder)
+        {
+            _pasteEndMatchLength = 0;
+        }
+
+        State = nextState;
 
         Paste?.Invoke (this, text);
     }
+
+    private void NoteBracketedPasteActivity () => LastBracketedPasteInputAt = _timeProvider.Now;
 
     /// <summary>
     ///     Flushes any in-flight bracketed-paste buffer as a <see cref="Paste"/> event and returns the
@@ -738,19 +781,26 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
     ///     does not strand pasted content forever.
     /// </summary>
     /// <returns>
-    ///     <see langword="true"/> if a partial paste was flushed; <see langword="false"/> if the
-    ///     parser was not in <see cref="AnsiResponseParserState.InBracketedPaste"/>.
+    ///     <see langword="true"/> if the parser was reset from a bracketed-paste state;
+    ///     <see langword="false"/> if the parser was not in a bracketed-paste state.
     /// </returns>
     internal bool FlushStaleBracketedPaste ()
     {
         lock (_lockState)
         {
-            if (State != AnsiResponseParserState.InBracketedPaste)
+            if (State == AnsiResponseParserState.InBracketedPaste)
+            {
+                FlushPaste (AnsiResponseParserState.Normal);
+
+                return true;
+            }
+
+            if (State != AnsiResponseParserState.DiscardingBracketedPasteRemainder)
             {
                 return false;
             }
 
-            FlushPaste ();
+            ResetState ();
 
             return true;
         }

--- a/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
@@ -20,6 +20,26 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
     internal const int MaxHeldLength = 8 * 1024;
 
     /// <summary>
+    ///     Maximum number of characters allowed in a single bracketed-paste payload. Pastes larger
+    ///     than this are truncated and the truncated content is delivered with the parser returning
+    ///     to <see cref="AnsiResponseParserState.Normal"/>. Guards against unbounded memory growth
+    ///     from a missing or stripped <c>ESC[201~</c> end marker.
+    /// </summary>
+    internal const int MaxBracketedPasteLength = 1 * 1024 * 1024;
+
+    /// <summary>
+    ///     Buffer accumulating pasted text while the parser is in
+    ///     <see cref="AnsiResponseParserState.InBracketedPaste"/>.
+    /// </summary>
+    private readonly StringBuilder _pasteBuffer = new ();
+
+    /// <summary>
+    ///     Trailing characters of <see cref="_pasteBuffer"/> that may form the start of the
+    ///     <c>ESC[201~</c> end marker. Tracked so the marker bytes are not delivered as paste content.
+    /// </summary>
+    private int _pasteEndMatchLength;
+
+    /// <summary>
     ///     Tracks whether the parser is currently inside an OSC (Operating System Command) sequence.
     ///     OSC responses can be terminated by ST (ESC \) which requires special handling because
     ///     ESC normally starts a new sequence in the parser.
@@ -82,6 +102,8 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
         State = AnsiResponseParserState.Normal;
         _inOscSequence = false;
         _oscExpectingBackslash = false;
+        _pasteBuffer.Clear ();
+        _pasteEndMatchLength = 0;
 
         lock (_lockState)
         {
@@ -165,6 +187,16 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
                         // Invalid sequence, release held characters and reset to Normal
                         ReleaseHeld (appendOutput);
                         appendOutput (currentObj); // Add current character
+                    }
+
+                    break;
+
+                case AnsiResponseParserState.InBracketedPaste:
+                    AppendToPaste (currentChar);
+
+                    if (_pasteBuffer.Length >= MaxBracketedPasteLength)
+                    {
+                        FlushPaste ();
                     }
 
                     break;
@@ -335,6 +367,19 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
         lock (_lockState)
         {
             string cur = _heldContent.HeldToString ();
+
+            // Bracketed paste start (ESC[200~). Switch into paste-collecting mode and discard
+            // the marker. Subsequent input is accumulated as paste content until the matching
+            // end marker (ESC[201~) is seen — see ProcessInputBaseImpl InBracketedPaste case.
+            if (cur == EscSeqUtils.CSI_BracketedPasteStart)
+            {
+                _heldContent.ClearHeld ();
+                _pasteBuffer.Clear ();
+                _pasteEndMatchLength = 0;
+                State = AnsiResponseParserState.InBracketedPaste;
+
+                return false;
+            }
 
             if (HandleMouse && IsMouse (cur))
             {
@@ -632,6 +677,59 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
         {
             Keyboard?.Invoke (this, k);
         }
+    }
+
+    #endregion
+
+    #region Bracketed Paste Handling
+
+    /// <summary>
+    ///     Event raised when a complete bracketed paste sequence is detected. The string carries the
+    ///     pasted content with the bracketing markers (<c>ESC[200~</c> / <c>ESC[201~</c>) stripped.
+    /// </summary>
+    /// <remarks>
+    ///     Bracketed paste mode must be enabled by writing <see cref="EscSeqUtils.CSI_EnableBracketedPaste"/>
+    ///     to the terminal. Without it, terminals deliver pasted text as raw input characters which are
+    ///     indistinguishable from typing.
+    /// </remarks>
+    public event EventHandler<string>? Paste;
+
+    private void AppendToPaste (char c)
+    {
+        _pasteBuffer.Append (c);
+
+        // Track an in-flight suffix match against ESC[201~ so we can strip the marker on success
+        // without scanning the whole buffer on every character.
+        string endMarker = EscSeqUtils.CSI_BracketedPasteEnd;
+
+        if (_pasteEndMatchLength < endMarker.Length && c == endMarker [_pasteEndMatchLength])
+        {
+            _pasteEndMatchLength++;
+        }
+        else
+        {
+            // Mismatch: ESC[201~ has no repeated prefix, so the only restart is at a fresh ESC.
+            _pasteEndMatchLength = c == ESCAPE ? 1 : 0;
+        }
+
+        if (_pasteEndMatchLength != endMarker.Length)
+        {
+            return;
+        }
+
+        // Full end marker matched — strip its characters from the buffer and dispatch.
+        _pasteBuffer.Length -= endMarker.Length;
+        FlushPaste ();
+    }
+
+    private void FlushPaste ()
+    {
+        string text = _pasteBuffer.ToString ();
+        _pasteBuffer.Clear ();
+        _pasteEndMatchLength = 0;
+        State = AnsiResponseParserState.Normal;
+
+        Paste?.Invoke (this, text);
     }
 
     #endregion

--- a/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
@@ -99,14 +99,13 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
 
     protected void ResetState ()
     {
-        State = AnsiResponseParserState.Normal;
-        _inOscSequence = false;
-        _oscExpectingBackslash = false;
-        _pasteBuffer.Clear ();
-        _pasteEndMatchLength = 0;
-
         lock (_lockState)
         {
+            State = AnsiResponseParserState.Normal;
+            _inOscSequence = false;
+            _oscExpectingBackslash = false;
+            _pasteBuffer.Clear ();
+            _pasteEndMatchLength = 0;
             _heldContent.ClearHeld ();
         }
     }
@@ -730,6 +729,31 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
         State = AnsiResponseParserState.Normal;
 
         Paste?.Invoke (this, text);
+    }
+
+    /// <summary>
+    ///     Flushes any in-flight bracketed-paste buffer as a <see cref="Paste"/> event and returns the
+    ///     parser to <see cref="AnsiResponseParserState.Normal"/>. Called by the input processor when
+    ///     the paste has been idle too long, so a terminal that drops the <c>ESC[201~</c> end marker
+    ///     does not strand pasted content forever.
+    /// </summary>
+    /// <returns>
+    ///     <see langword="true"/> if a partial paste was flushed; <see langword="false"/> if the
+    ///     parser was not in <see cref="AnsiResponseParserState.InBracketedPaste"/>.
+    /// </returns>
+    internal bool FlushStaleBracketedPaste ()
+    {
+        lock (_lockState)
+        {
+            if (State != AnsiResponseParserState.InBracketedPaste)
+            {
+                return false;
+            }
+
+            FlushPaste ();
+
+            return true;
+        }
     }
 
     #endregion

--- a/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserState.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserState.cs
@@ -27,5 +27,11 @@ public enum AnsiResponseParserState
     ///     Parser has encountered the bracketed-paste start sequence (<c>ESC[200~</c>) and is
     ///     accumulating pasted content until the matching end sequence (<c>ESC[201~</c>).
     /// </summary>
-    InBracketedPaste
+    InBracketedPaste,
+
+    /// <summary>
+    ///     Parser has already delivered the truncated prefix of an oversized bracketed paste and is
+    ///     discarding the remaining bytes until the matching end sequence (<c>ESC[201~</c>) arrives.
+    /// </summary>
+    DiscardingBracketedPasteRemainder
 }

--- a/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserState.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserState.cs
@@ -21,5 +21,11 @@ public enum AnsiResponseParserState
     ///     Parser has encountered Esc[ and considers that it is in the process
     ///     of reading an ANSI sequence.
     /// </summary>
-    InResponse
+    InResponse,
+
+    /// <summary>
+    ///     Parser has encountered the bracketed-paste start sequence (<c>ESC[200~</c>) and is
+    ///     accumulating pasted content until the matching end sequence (<c>ESC[201~</c>).
+    /// </summary>
+    InBracketedPaste
 }

--- a/Terminal.Gui/Drivers/AnsiHandling/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/EscSeqUtils/EscSeqUtils.cs
@@ -279,6 +279,43 @@ public static class EscSeqUtils
 
     #endregion Mouse
 
+    #region Bracketed Paste
+
+    /// <summary>
+    ///     ESC [ ? 2004 h - Enable bracketed paste mode.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         When bracketed paste mode is enabled, the terminal wraps pasted content with the start
+    ///         marker <see cref="CSI_BracketedPasteStart"/> (<c>ESC[200~</c>) and the end marker
+    ///         <see cref="CSI_BracketedPasteEnd"/> (<c>ESC[201~</c>). This lets applications distinguish
+    ///         pasted text from typed input and handle large pastes efficiently.
+    ///     </para>
+    ///     <para>
+    ///         Supported by xterm, Windows Terminal, iTerm2, and most modern terminal emulators.
+    ///     </para>
+    /// </remarks>
+    public static readonly string CSI_EnableBracketedPaste = CSI + "?2004h";
+
+    /// <summary>
+    ///     ESC [ ? 2004 l - Disable bracketed paste mode.
+    /// </summary>
+    public static readonly string CSI_DisableBracketedPaste = CSI + "?2004l";
+
+    /// <summary>
+    ///     ESC [ 200 ~ - Sequence emitted by the terminal at the start of pasted content when
+    ///     bracketed paste mode is enabled via <see cref="CSI_EnableBracketedPaste"/>.
+    /// </summary>
+    public static readonly string CSI_BracketedPasteStart = CSI + "200~";
+
+    /// <summary>
+    ///     ESC [ 201 ~ - Sequence emitted by the terminal at the end of pasted content when
+    ///     bracketed paste mode is enabled via <see cref="CSI_EnableBracketedPaste"/>.
+    /// </summary>
+    public static readonly string CSI_BracketedPasteEnd = CSI + "201~";
+
+    #endregion Bracketed Paste
+
     #region Keyboard
 
     /// <summary>

--- a/Terminal.Gui/Drivers/DotNetDriver/NetInput.cs
+++ b/Terminal.Gui/Drivers/DotNetDriver/NetInput.cs
@@ -56,6 +56,9 @@ public class NetInput : InputImpl<ConsoleKeyInfo>, ITestableInput<ConsoleKeyInfo
             // Mode 1015 (URXVT) - UTF-8 coordinate encoding (fallback for older terminals)
             // Mode 1006 (SGR) - Modern decimal format with unlimited coordinates (preferred)
             Console.Out.Write (EscSeqUtils.CSI_EnableMouseEvents);
+
+            // Mode 2004 - Bracketed paste mode. Pastes are wrapped in ESC[200~ ... ESC[201~.
+            Console.Out.Write (EscSeqUtils.CSI_EnableBracketedPaste);
             Console.TreatControlCAsInput = true;
         }
         catch
@@ -73,7 +76,8 @@ public class NetInput : InputImpl<ConsoleKeyInfo>, ITestableInput<ConsoleKeyInfo
 
         try
         {
-            // Disable mouse events first
+            // Disable bracketed paste and mouse events first
+            Console.Out.Write (EscSeqUtils.CSI_DisableBracketedPaste);
             Console.Out.Write (EscSeqUtils.CSI_DisableMouseEvents);
 
             //Disable alternative screen buffer.

--- a/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
+++ b/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
@@ -189,7 +189,8 @@ public class NetOutput : OutputBase, IOutput
         // Best-effort: mirror behavior of ANSI/Unix outputs for consoles that accept CSI sequences.
         try
         {
-            // Disable mouse events to prevent mouse events from being sent to the application while it is suspended.
+            // Disable bracketed paste and mouse events while suspended.
+            Write (EscSeqUtils.CSI_DisableBracketedPaste);
             Write (EscSeqUtils.CSI_DisableMouseEvents);
 
             // Check if we have a real console first
@@ -227,8 +228,9 @@ public class NetOutput : OutputBase, IOutput
         }
         finally
         {
-            // Enable mouse events to allow mouse events to be sent to the application when it is resumed.
+            // Re-enable mouse events and bracketed paste after resume.
             Write (EscSeqUtils.CSI_EnableMouseEvents);
+            Write (EscSeqUtils.CSI_EnableBracketedPaste);
         }
     }
 }

--- a/Terminal.Gui/Drivers/DriverImpl.cs
+++ b/Terminal.Gui/Drivers/DriverImpl.cs
@@ -70,6 +70,7 @@ internal class DriverImpl : IDriver
         _inputProcessor.KeyDown += (s, e) => KeyDown?.Invoke (s, e);
         _inputProcessor.KeyUp += (s, e) => KeyUp?.Invoke (s, e);
         _inputProcessor.SyntheticMouseEvent += (s, e) => MouseEvent?.Invoke (s, e);
+        _inputProcessor.Paste += (s, e) => Paste?.Invoke (s, e);
         _outputBuffer = outputBuffer;
         _output = output;
         _ansiRequestScheduler = ansiRequestScheduler;
@@ -484,6 +485,9 @@ internal class DriverImpl : IDriver
 
     /// <summary>Event fired when a mouse event occurs.</summary>
     public event EventHandler<Mouse>? MouseEvent;
+
+    /// <summary>Event fired when a bracketed paste is received from the terminal.</summary>
+    public event EventHandler<string>? Paste;
 
     #endregion Input Events
 

--- a/Terminal.Gui/Drivers/IDriver.cs
+++ b/Terminal.Gui/Drivers/IDriver.cs
@@ -424,6 +424,13 @@ public interface IDriver : IDisposable
     /// <summary>Event fired when a mouse event occurs.</summary>
     event EventHandler<Mouse>? MouseEvent;
 
+    /// <summary>
+    ///     Event fired when a bracketed paste is received from the terminal. The string contains the
+    ///     raw pasted text with the ANSI bracketing markers stripped. Only fires on terminals that
+    ///     support bracketed paste mode (most modern terminals).
+    /// </summary>
+    event EventHandler<string>? Paste;
+
     #endregion Input Events
 
     #region ANSI Escape Sequences

--- a/Terminal.Gui/Drivers/Input/IInputProcessor.cs
+++ b/Terminal.Gui/Drivers/Input/IInputProcessor.cs
@@ -103,4 +103,25 @@ public interface IInputProcessor
     event EventHandler<string>? AnsiSequenceSwallowed;
 
     #endregion
+
+    #region Paste Events
+
+    /// <summary>
+    ///     Event raised when bracketed paste content is delivered. The string contains the raw pasted
+    ///     text with the ANSI bracketing markers stripped.
+    /// </summary>
+    /// <remarks>
+    ///     Bracketed paste mode must be enabled by the driver (typically by writing
+    ///     <see cref="EscSeqUtils.CSI_EnableBracketedPaste"/> at startup). On terminals that do not
+    ///     support bracketed paste, pasted text is delivered as ordinary key events instead.
+    /// </remarks>
+    event EventHandler<string>? Paste;
+
+    /// <summary>
+    ///     Raises the <see cref="Paste"/> event. For unit tests and driver implementations.
+    /// </summary>
+    /// <param name="text">The pasted content with bracketing markers stripped.</param>
+    void RaisePasteEvent (string text);
+
+    #endregion
 }

--- a/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
+++ b/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
@@ -67,6 +67,8 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
         // Enable keyboard handling
         Parser.HandleKeyboard = true;
 
+        Parser.Paste += (_, text) => RaisePasteEvent (text);
+
         Parser.Keyboard += (_, keyEvent) =>
                            {
                                Key normalizedKeyEvent = OnKeyboardEventParsed (keyEvent);
@@ -337,6 +339,16 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
 
     /// <inheritdoc/>
     public event EventHandler<string>? AnsiSequenceSwallowed;
+
+    #endregion
+
+    #region Paste Events
+
+    /// <inheritdoc/>
+    public event EventHandler<string>? Paste;
+
+    /// <inheritdoc/>
+    public void RaisePasteEvent (string text) => Paste?.Invoke (this, text);
 
     #endregion
 

--- a/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
+++ b/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
@@ -17,6 +17,15 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
     private readonly TimeSpan _escTimeout = TimeSpan.FromMilliseconds (50);
 
     /// <summary>
+    ///     Timeout for detecting a stranded bracketed-paste session. If the terminal opens a paste with
+    ///     <c>ESC[200~</c> but never delivers the matching <c>ESC[201~</c> end marker (dropped
+    ///     connection, broken terminal), the buffered content is flushed after this duration so input
+    ///     resumes flowing. Pastes legitimately span seconds for large clipboards, so this is much
+    ///     longer than <see cref="_escTimeout"/>.
+    /// </summary>
+    private readonly TimeSpan _bracketedPasteTimeout = TimeSpan.FromSeconds (5);
+
+    /// <summary>
     ///     ANSI response parser for handling escape sequences from the input stream.
     /// </summary>
     internal AnsiResponseParser<TInputRecord> Parser { get; }
@@ -122,8 +131,32 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
             ProcessAfterParsing (input);
         }
 
+        FlushStaleBracketedPasteIfNeeded ();
+
         // Check for expired deferred clicks
         CheckForExpiredMouseClicks ();
+    }
+
+    private void FlushStaleBracketedPasteIfNeeded ()
+    {
+        if (Parser.State != AnsiResponseParserState.InBracketedPaste)
+        {
+            return;
+        }
+
+        if (_timeProvider.Now - Parser.StateChangedAt < _bracketedPasteTimeout)
+        {
+            return;
+        }
+
+        Logging.Warning (
+                         $"{
+                             nameof (InputProcessorImpl<TInputRecord>)
+                         } flushing stale bracketed-paste buffer after {
+                             _bracketedPasteTimeout.TotalSeconds
+                         }s without an end marker");
+
+        Parser.FlushStaleBracketedPaste ();
     }
 
     /// <summary>

--- a/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
+++ b/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
@@ -139,22 +139,23 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
 
     private void FlushStaleBracketedPasteIfNeeded ()
     {
-        if (Parser.State != AnsiResponseParserState.InBracketedPaste)
+        if (Parser.State is not AnsiResponseParserState.InBracketedPaste
+            and not AnsiResponseParserState.DiscardingBracketedPasteRemainder)
         {
             return;
         }
 
-        if (_timeProvider.Now - Parser.StateChangedAt < _bracketedPasteTimeout)
+        if (_timeProvider.Now - Parser.LastBracketedPasteInputAt < _bracketedPasteTimeout)
         {
             return;
         }
 
         Logging.Warning (
                          $"{
-                             nameof (InputProcessorImpl<TInputRecord>)
-                         } flushing stale bracketed-paste buffer after {
-                             _bracketedPasteTimeout.TotalSeconds
-                         }s without an end marker");
+                              nameof (InputProcessorImpl<TInputRecord>)
+                         } abandoning stale bracketed-paste state after {
+                              _bracketedPasteTimeout.TotalSeconds
+                         }s without activity");
 
         Parser.FlushStaleBracketedPaste ();
     }

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixTerminalHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixTerminalHelper.cs
@@ -107,7 +107,8 @@ internal static class UnixTerminalHelper
 
         try
         {
-            // Disable mouse events to prevent mouse events from being sent to the application while it is suspended.
+            // Disable bracketed paste and mouse events while suspended.
+            output.Write (EscSeqUtils.CSI_DisableBracketedPaste);
             output.Write (EscSeqUtils.CSI_DisableMouseEvents);
 
             // Check if we have a real console first
@@ -154,8 +155,9 @@ internal static class UnixTerminalHelper
         }
         finally
         {
-            // Enable mouse events to allow mouse events to be sent to the application when it is resumed.
+            // Re-enable mouse events and bracketed paste after resume.
             output.Write (EscSeqUtils.CSI_EnableMouseEvents);
+            output.Write (EscSeqUtils.CSI_EnableBracketedPaste);
         }
     }
 

--- a/Terminal.Gui/Input/PasteEventArgs.cs
+++ b/Terminal.Gui/Input/PasteEventArgs.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel;
+
+namespace Terminal.Gui.Input;
+
+/// <summary>
+///     Event arguments for paste events delivered by the terminal's bracketed paste mode.
+///     Set <see cref="HandledEventArgs.Handled"/> to <see langword="true"/> to stop further processing.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Bracketed paste delivers the entire pasted payload as a single string, distinct from
+///         keyboard input. Subscribers can choose to insert the text, validate or sanitize it, or
+///         ignore the paste entirely.
+///     </para>
+/// </remarks>
+public class PasteEventArgs : HandledEventArgs
+{
+    /// <summary>
+    ///     Initializes a new <see cref="PasteEventArgs"/>.
+    /// </summary>
+    /// <param name="text">The pasted text with bracketing markers stripped.</param>
+    public PasteEventArgs (string text) { Text = text; }
+
+    /// <summary>
+    ///     The pasted text. Bracketing markers (<c>ESC[200~</c> / <c>ESC[201~</c>) are stripped by
+    ///     the parser and are never present in this string.
+    /// </summary>
+    public string Text { get; }
+
+    /// <inheritdoc/>
+    public override string ToString () => $"Paste ({Text.Length} chars)";
+}

--- a/Terminal.Gui/Input/PasteEventArgs.cs
+++ b/Terminal.Gui/Input/PasteEventArgs.cs
@@ -3,14 +3,18 @@ using System.ComponentModel;
 namespace Terminal.Gui.Input;
 
 /// <summary>
-///     Event arguments for paste events delivered by the terminal's bracketed paste mode.
-///     Set <see cref="HandledEventArgs.Handled"/> to <see langword="true"/> to stop further processing.
+///     Event arguments for the application-level <see cref="IApplication.Paste"/> event. Carries the
+///     raw payload delivered by the terminal's bracketed-paste mode, before any view-level
+///     sanitization. Set <see cref="HandledEventArgs.Handled"/> to <see langword="true"/> to stop
+///     the paste from being dispatched to the focused view.
 /// </summary>
 /// <remarks>
 ///     <para>
 ///         Bracketed paste delivers the entire pasted payload as a single string, distinct from
-///         keyboard input. Subscribers can choose to insert the text, validate or sanitize it, or
-///         ignore the paste entirely.
+///         keyboard input. Subscribers at the application boundary observe the unmodified text.
+///         View-level sanitization (line-ending normalization, control-character stripping) is
+///         performed downstream by <see cref="View.OnSanitizingPaste"/> when the
+///         <see cref="Command.Paste"/> handler runs.
 ///     </para>
 /// </remarks>
 public class PasteEventArgs : HandledEventArgs

--- a/Terminal.Gui/Input/PastePayload.cs
+++ b/Terminal.Gui/Input/PastePayload.cs
@@ -1,0 +1,8 @@
+namespace Terminal.Gui.Input;
+
+/// <summary>
+///     Dedicated command-context payload used to carry bracketed-paste text through
+///     <see cref="Command.Paste"/> without colliding with unrelated <see cref="IValue"/> values already
+///     present in the command context.
+/// </summary>
+internal readonly record struct PastePayload (string Text);

--- a/Terminal.Gui/Input/PastedEventArgs.cs
+++ b/Terminal.Gui/Input/PastedEventArgs.cs
@@ -8,10 +8,13 @@ namespace Terminal.Gui.Input;
 public class PastedEventArgs : EventArgs
 {
     /// <summary>Initializes a new <see cref="PastedEventArgs"/>.</summary>
-    /// <param name="text">The text that was inserted into the view.</param>
+    /// <param name="text">The final-text segment corresponding to the pasted range.</param>
     public PastedEventArgs (string text) { Text = text; }
 
-    /// <summary>The text that was inserted into the view (post-sanitization, post-<see cref="View.Pasting"/>).</summary>
+    /// <summary>
+    ///     The final-text segment corresponding to the pasted range (post-sanitization,
+    ///     post-<see cref="View.Pasting"/>).
+    /// </summary>
     public string Text { get; }
 
     /// <inheritdoc/>

--- a/Terminal.Gui/Input/PastedEventArgs.cs
+++ b/Terminal.Gui/Input/PastedEventArgs.cs
@@ -1,0 +1,19 @@
+namespace Terminal.Gui.Input;
+
+/// <summary>
+///     Event arguments for the <see cref="View.Pasted"/> event raised after the default
+///     <see cref="Command.Paste"/> handler has consumed a paste. Observation only — handlers cannot
+///     cancel or alter what has already been inserted.
+/// </summary>
+public class PastedEventArgs : EventArgs
+{
+    /// <summary>Initializes a new <see cref="PastedEventArgs"/>.</summary>
+    /// <param name="text">The text that was inserted into the view.</param>
+    public PastedEventArgs (string text) { Text = text; }
+
+    /// <summary>The text that was inserted into the view (post-sanitization, post-<see cref="View.Pasting"/>).</summary>
+    public string Text { get; }
+
+    /// <inheritdoc/>
+    public override string ToString () => $"Pasted ({Text.Length} chars)";
+}

--- a/Terminal.Gui/Input/PastingEventArgs.cs
+++ b/Terminal.Gui/Input/PastingEventArgs.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+
+namespace Terminal.Gui.Input;
+
+/// <summary>
+///     Event arguments for the cancellable <see cref="View.Pasting"/> event raised by the default
+///     <see cref="Command.Paste"/> handler. <see cref="Text"/> is mutable so subscribers can
+///     normalize or filter the payload before the view inserts it; set
+///     <see cref="HandledEventArgs.Handled"/> to <see langword="true"/> to cancel the paste.
+/// </summary>
+public class PastingEventArgs : HandledEventArgs
+{
+    /// <summary>Initializes a new <see cref="PastingEventArgs"/>.</summary>
+    /// <param name="text">The (already sanitized) pasted text that the view is about to insert.</param>
+    public PastingEventArgs (string text) { Text = text; }
+
+    /// <summary>
+    ///     The pasted text the view is about to insert. Already sanitized by
+    ///     <see cref="View.OnSanitizingPaste"/>. Subscribers may replace it with a different string
+    ///     to alter what gets inserted.
+    /// </summary>
+    public string Text { get; set; }
+
+    /// <inheritdoc/>
+    public override string ToString () => $"Pasting ({Text.Length} chars)";
+}

--- a/Terminal.Gui/ViewBase/View.Command.cs
+++ b/Terminal.Gui/ViewBase/View.Command.cs
@@ -22,6 +22,10 @@ public partial class View // Command APIs
 
         // NotBound - Invoked if no handler is bound
         AddCommand (Command.NotBound, DefaultCommandNotBoundHandler);
+
+        // Paste - Default handler resolves payload (bracketed paste payload or clipboard),
+        // sanitizes, raises Pasting/Pasted, and delegates insertion to OnPaste.
+        AddCommand (Command.Paste, DefaultPasteHandler);
     }
 
     #region Command Management

--- a/Terminal.Gui/ViewBase/View.Paste.cs
+++ b/Terminal.Gui/ViewBase/View.Paste.cs
@@ -1,0 +1,68 @@
+namespace Terminal.Gui.ViewBase;
+
+public partial class View // Paste APIs
+{
+    /// <summary>
+    ///     Called when bracketed-paste content is dispatched to this view (typically the focused
+    ///     view). Raises the cancellable <see cref="OnPasted"/> / <see cref="Pasted"/> events; if the
+    ///     paste is not handled, it bubbles up to <see cref="SuperView"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Override <see cref="OnPasted"/> in a subclass to provide default paste behavior (for
+    ///         example, <see cref="TextField"/> inserts the pasted text). Subscribe to <see cref="Pasted"/>
+    ///         to handle pastes externally.
+    ///     </para>
+    ///     <para>
+    ///         Pastes are only delivered through this method on terminals that support bracketed paste
+    ///         mode. On terminals that do not, pasted text is delivered character-by-character through
+    ///         the normal keyboard pipeline.
+    ///     </para>
+    /// </remarks>
+    /// <param name="args">Carries the pasted text and a cancellation flag.</param>
+    /// <returns><see langword="true"/> if the paste was handled.</returns>
+    public bool NewPasteEvent (PasteEventArgs args)
+    {
+        if (!Enabled)
+        {
+            return false;
+        }
+
+        if (OnPasted (args) || args.Handled)
+        {
+            return true;
+        }
+
+        Pasted?.Invoke (this, args);
+
+        if (args.Handled)
+        {
+            return true;
+        }
+
+        // Bubble to SuperView so a container can provide default paste handling for its children.
+        if (SuperView is { } superView)
+        {
+            return superView.NewPasteEvent (args);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Called before the <see cref="Pasted"/> event is raised. Override to provide default paste
+    ///     handling (for example, inserting the pasted text into a text-input view). Set
+    ///     <see cref="System.ComponentModel.HandledEventArgs.Handled"/> on <paramref name="args"/> or
+    ///     return <see langword="true"/> to stop further processing.
+    /// </summary>
+    /// <param name="args">Carries the pasted text.</param>
+    /// <returns><see langword="true"/> if the paste was handled.</returns>
+    protected virtual bool OnPasted (PasteEventArgs args) => false;
+
+    /// <summary>
+    ///     Raised when bracketed-paste content is delivered to this view. Set
+    ///     <see cref="System.ComponentModel.HandledEventArgs.Handled"/> to <see langword="true"/> to
+    ///     stop the paste from being processed further (including bubbling to the SuperView).
+    /// </summary>
+    public event EventHandler<PasteEventArgs>? Pasted;
+}

--- a/Terminal.Gui/ViewBase/View.Paste.cs
+++ b/Terminal.Gui/ViewBase/View.Paste.cs
@@ -1,68 +1,129 @@
+using System.Text;
+
 namespace Terminal.Gui.ViewBase;
 
 public partial class View // Paste APIs
 {
     /// <summary>
-    ///     Called when bracketed-paste content is dispatched to this view (typically the focused
-    ///     view). Raises the cancellable <see cref="OnPasted"/> / <see cref="Pasted"/> events; if the
-    ///     paste is not handled, it bubbles up to <see cref="SuperView"/>.
+    ///     Default handler for <see cref="Command.Paste"/>. Resolves the paste payload (from
+    ///     <see cref="ICommandContext.Value"/> when bracketed paste delivered one, otherwise from
+    ///     <see cref="IApplication.Clipboard"/>), sanitizes it via <see cref="OnSanitizingPaste"/>,
+    ///     raises the cancellable <see cref="Pasting"/> event, calls <see cref="OnPaste"/> to insert
+    ///     the text, then raises <see cref="Pasted"/>.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Override <see cref="OnPasted"/> in a subclass to provide default paste behavior (for
-    ///         example, <see cref="TextField"/> inserts the pasted text). Subscribe to <see cref="Pasted"/>
-    ///         to handle pastes externally.
+    ///         Plain <see cref="View"/> instances return <see langword="false"/> from
+    ///         <see cref="OnPaste"/> by default. Subclasses that accept text (for example
+    ///         <see cref="TextField"/> and <see cref="TextView"/>) override
+    ///         <see cref="OnPaste"/> to perform the insertion.
     ///     </para>
     ///     <para>
-    ///         Pastes are only delivered through this method on terminals that support bracketed paste
-    ///         mode. On terminals that do not, pasted text is delivered character-by-character through
-    ///         the normal keyboard pipeline.
+    ///         Bracketed-paste payloads carry the raw bytes delivered by the terminal between
+    ///         <c>ESC[200~</c> and <c>ESC[201~</c>. Keyboard-driven pastes (<c>Ctrl+V</c>) have no
+    ///         payload and fall through to the clipboard. Both paths share this handler, so any
+    ///         sanitization or event subscription works for both.
     ///     </para>
     /// </remarks>
-    /// <param name="args">Carries the pasted text and a cancellation flag.</param>
-    /// <returns><see langword="true"/> if the paste was handled.</returns>
-    public bool NewPasteEvent (PasteEventArgs args)
+    /// <returns>
+    ///     <see langword="true"/> if the paste was consumed (sanitized text inserted, or cancelled
+    ///     by a subscriber); <see langword="false"/> if nothing was pasted.
+    /// </returns>
+    private bool? DefaultPasteHandler (ICommandContext? ctx)
     {
         if (!Enabled)
         {
             return false;
         }
 
-        if (OnPasted (args) || args.Handled)
+        string? payload = ctx?.Value as string ?? App?.Clipboard?.GetClipboardData ();
+
+        if (string.IsNullOrEmpty (payload))
+        {
+            return false;
+        }
+
+        string sanitized = OnSanitizingPaste (payload);
+
+        if (string.IsNullOrEmpty (sanitized))
+        {
+            return false;
+        }
+
+        PastingEventArgs pasting = new (sanitized);
+        Pasting?.Invoke (this, pasting);
+
+        if (pasting.Handled)
         {
             return true;
         }
 
-        Pasted?.Invoke (this, args);
-
-        if (args.Handled)
+        if (string.IsNullOrEmpty (pasting.Text))
         {
-            return true;
+            return false;
         }
 
-        // Bubble to SuperView so a container can provide default paste handling for its children.
-        if (SuperView is { } superView)
+        if (!OnPaste (pasting.Text))
         {
-            return superView.NewPasteEvent (args);
+            return false;
         }
 
-        return false;
+        Pasted?.Invoke (this, new (pasting.Text));
+
+        return true;
     }
 
     /// <summary>
-    ///     Called before the <see cref="Pasted"/> event is raised. Override to provide default paste
-    ///     handling (for example, inserting the pasted text into a text-input view). Set
-    ///     <see cref="System.ComponentModel.HandledEventArgs.Handled"/> on <paramref name="args"/> or
-    ///     return <see langword="true"/> to stop further processing.
+    ///     Override to filter or transform raw paste payloads before they are inserted into the
+    ///     view. The default implementation strips C0/C1 control characters (including ESC) but
+    ///     preserves tab, line feed, and carriage return — matching Windows Terminal's
+    ///     <c>FilterStringForPaste</c> baseline.
     /// </summary>
-    /// <param name="args">Carries the pasted text.</param>
-    /// <returns><see langword="true"/> if the paste was handled.</returns>
-    protected virtual bool OnPasted (PasteEventArgs args) => false;
+    /// <remarks>
+    ///     <para>
+    ///         <see cref="TextField"/> overrides this to take only the first line and drop tab/CR/LF.
+    ///         <see cref="TextView"/> overrides this to normalize <c>\r\n</c> / <c>\r</c> to <c>\n</c>.
+    ///     </para>
+    /// </remarks>
+    /// <param name="raw">The raw payload, either from the terminal or the clipboard.</param>
+    /// <returns>The sanitized text that will be passed to <see cref="OnPaste"/>.</returns>
+    protected virtual string OnSanitizingPaste (string raw) => StripControlCharsExceptTabAndNewline (raw);
 
     /// <summary>
-    ///     Raised when bracketed-paste content is delivered to this view. Set
-    ///     <see cref="System.ComponentModel.HandledEventArgs.Handled"/> to <see langword="true"/> to
-    ///     stop the paste from being processed further (including bubbling to the SuperView).
+    ///     Override to insert sanitized paste text into the view. The default returns
+    ///     <see langword="false"/> because a plain <see cref="View"/> has no text model. Text-input
+    ///     views (<see cref="TextField"/>, <see cref="TextView"/>) override this to perform the
+    ///     insertion.
     /// </summary>
-    public event EventHandler<PasteEventArgs>? Pasted;
+    /// <param name="text">The sanitized text to insert. Never <see langword="null"/> or empty.</param>
+    /// <returns><see langword="true"/> if the view consumed the paste.</returns>
+    protected virtual bool OnPaste (string text) => false;
+
+    /// <summary>
+    ///     Raised by the default <see cref="Command.Paste"/> handler after sanitization but before
+    ///     insertion. Subscribers may rewrite <see cref="PastingEventArgs.Text"/> or set
+    ///     <see cref="System.ComponentModel.HandledEventArgs.Handled"/> to cancel.
+    /// </summary>
+    public event EventHandler<PastingEventArgs>? Pasting;
+
+    /// <summary>
+    ///     Raised by the default <see cref="Command.Paste"/> handler after <see cref="OnPaste"/>
+    ///     consumes a paste. Observation only — the text has already been inserted.
+    /// </summary>
+    public event EventHandler<PastedEventArgs>? Pasted;
+
+    private static string StripControlCharsExceptTabAndNewline (string text)
+    {
+        StringBuilder sb = new (text.Length);
+
+        foreach (char c in text)
+        {
+            if (c == '\t' || c == '\n' || c == '\r' || (c >= 0x20 && c < 0x7F) || c >= 0xA0)
+            {
+                sb.Append (c);
+            }
+        }
+
+        return sb.ToString ();
+    }
 }

--- a/Terminal.Gui/ViewBase/View.Paste.cs
+++ b/Terminal.Gui/ViewBase/View.Paste.cs
@@ -4,12 +4,14 @@ namespace Terminal.Gui.ViewBase;
 
 public partial class View // Paste APIs
 {
+    private protected bool CurrentPasteUsesPayload { get; private set; }
+
     /// <summary>
-    ///     Default handler for <see cref="Command.Paste"/>. Resolves the paste payload (from
-    ///     <see cref="ICommandContext.Value"/> when bracketed paste delivered one, otherwise from
+    ///     Default handler for <see cref="Command.Paste"/>. Resolves the paste payload (from a
+    ///     dedicated <see cref="PastePayload"/> when bracketed paste delivered one, otherwise from
     ///     <see cref="IApplication.Clipboard"/>), sanitizes it via <see cref="OnSanitizingPaste"/>,
     ///     raises the cancellable <see cref="Pasting"/> event, calls <see cref="OnPaste"/> to insert
-    ///     the text, then raises <see cref="Pasted"/>.
+    ///     the text, then raises <see cref="Pasted"/> if insertion actually occurred.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -36,7 +38,9 @@ public partial class View // Paste APIs
             return false;
         }
 
-        string? payload = ctx?.Value as string ?? App?.Clipboard?.GetClipboardData ();
+        PastePayload? pastePayload = ctx?.Value is PastePayload value ? value : null;
+        bool usesPayload = pastePayload is { };
+        string? payload = usesPayload ? pastePayload.Value.Text : App?.Clipboard?.GetClipboardData ();
 
         if (string.IsNullOrEmpty (payload))
         {
@@ -63,14 +67,28 @@ public partial class View // Paste APIs
             return false;
         }
 
-        if (!OnPaste (pasting.Text))
+        CurrentPasteUsesPayload = usesPayload;
+
+        try
         {
-            return false;
+            if (!OnPaste (pasting.Text))
+            {
+                return false;
+            }
+
+            string? pastedText = GetPastedEventText (pasting.Text);
+
+            if (ShouldRaisePastedEvent (pasting.Text) && !string.IsNullOrEmpty (pastedText))
+            {
+                Pasted?.Invoke (this, new (pastedText));
+            }
+
+            return true;
         }
-
-        Pasted?.Invoke (this, new (pasting.Text));
-
-        return true;
+        finally
+        {
+            CurrentPasteUsesPayload = false;
+        }
     }
 
     /// <summary>
@@ -100,6 +118,34 @@ public partial class View // Paste APIs
     protected virtual bool OnPaste (string text) => false;
 
     /// <summary>
+    ///     Override to suppress <see cref="Pasted"/> when <see cref="OnPaste"/> consumes a paste
+    ///     without inserting the text.
+    /// </summary>
+    /// <param name="text">The sanitized text passed to <see cref="OnPaste"/>.</param>
+    /// <returns>
+    ///     <see langword="true"/> to raise <see cref="Pasted"/>; <see langword="false"/> when the
+    ///     paste was consumed without insertion.
+    /// </returns>
+    protected virtual bool ShouldRaisePastedEvent (string text) => true;
+
+    /// <summary>
+    ///     Override to provide the text for <see cref="Pasted"/> after <see cref="OnPaste"/> has run.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The default returns the sanitized text passed into <see cref="OnPaste"/>.
+    ///         Views that rewrite or partially reject the paste during insertion can override this to
+    ///         report the segment of final view text that corresponds to the pasted range.
+    ///     </para>
+    /// </remarks>
+    /// <param name="text">The sanitized text passed to <see cref="OnPaste"/>.</param>
+    /// <returns>
+    ///     The text to expose through <see cref="Pasted"/>; return <see langword="null"/> to suppress
+    ///     the event.
+    /// </returns>
+    protected virtual string? GetPastedEventText (string text) => text;
+
+    /// <summary>
     ///     Raised by the default <see cref="Command.Paste"/> handler after sanitization but before
     ///     insertion. Subscribers may rewrite <see cref="PastingEventArgs.Text"/> or set
     ///     <see cref="System.ComponentModel.HandledEventArgs.Handled"/> to cancel.
@@ -108,7 +154,8 @@ public partial class View // Paste APIs
 
     /// <summary>
     ///     Raised by the default <see cref="Command.Paste"/> handler after <see cref="OnPaste"/>
-    ///     consumes a paste. Observation only — the text has already been inserted.
+    ///     consumes a paste and the view reports that the text was inserted. Observation only — the
+    ///     text has already been inserted.
     /// </summary>
     public event EventHandler<PastedEventArgs>? Pasted;
 

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.Commands.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.Commands.cs
@@ -85,7 +85,9 @@ public partial class TextField
         AddCommand (Command.DisableOverwrite, () => SetOverwrite (false));
         AddCommand (Command.Copy, () => Copy ());
         AddCommand (Command.Cut, () => Cut ());
-        AddCommand (Command.Paste, () => Paste ());
+
+        // Command.Paste uses the default View base handler — sanitization via OnSanitizingPaste,
+        // insertion via OnPaste. No explicit AddCommand needed.
         AddCommand (Command.SelectAll, () => SelectAll ());
         AddCommand (Command.DeleteAll, () => DeleteAll ());
         AddCommand (Command.Context, () => ShowContextMenu (true));
@@ -150,35 +152,13 @@ public partial class TextField
         return true;
     }
 
-    /// <summary>Paste the selected text from the clipboard.</summary>
-    public bool Paste ()
-    {
-        if (ReadOnly)
-        {
-            return true;
-        }
-
-        string? cbTxt = App?.Clipboard?.GetClipboardData ().Split ("\n") [0];
-
-        if (string.IsNullOrEmpty (cbTxt))
-        {
-            return false;
-        }
-
-        SetSelectedStartSelectedLength ();
-        int selStart = _selectionStart == -1 ? InsertionPoint : _selectionStart;
-
-        Text = StringExtensions.ToString (_text.GetRange (0, selStart))
-               + cbTxt
-               + StringExtensions.ToString (_text.GetRange (selStart + SelectedLength, _text.Count - (selStart + SelectedLength)));
-
-        _insertionPoint = Math.Min (selStart + GraphemeHelper.GetGraphemeCount (cbTxt), _text.Count);
-        ClearAllSelection ();
-        SetNeedsDraw ();
-        Adjust ();
-
-        return true;
-    }
+    /// <summary>Paste the clipboard contents into the text field at the cursor / selection.</summary>
+    /// <remarks>
+    ///     Routes through <see cref="Command.Paste"/> with a <see langword="null"/> payload, so the
+    ///     default <see cref="View"/> handler reads from <see cref="IApplication.Clipboard"/>,
+    ///     sanitizes via <see cref="OnSanitizingPaste"/>, and inserts via <see cref="OnPaste"/>.
+    /// </remarks>
+    public bool Paste () => InvokeCommand (Command.Paste) is true;
 
     /// <summary>Redoes the latest changes.</summary>
     public bool Redo ()

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.Text.cs
@@ -40,36 +40,17 @@ public partial class TextField
     }
 
     /// <inheritdoc/>
-    protected override bool OnPasted (PasteEventArgs args)
+    /// <remarks>
+    ///     TextField is single-line — keep only the first line of the paste and drop C0/C1 control
+    ///     characters (except tab, which TextField accepts as a literal). Matches Windows Terminal's
+    ///     <c>FilterStringForPaste</c> behavior for single-line targets and mirrors the existing
+    ///     clipboard-paste command.
+    /// </remarks>
+    protected override string OnSanitizingPaste (string raw)
     {
-        if (ReadOnly || string.IsNullOrEmpty (args.Text))
-        {
-            return false;
-        }
+        int newline = raw.IndexOfAny (['\r', '\n']);
+        string firstLine = newline >= 0 ? raw [..newline] : raw;
 
-        // TextField is single-line — take only the first line of the paste and drop control
-        // characters. This mirrors the existing clipboard-Paste command (see TextField.Commands.cs)
-        // and matches Windows Terminal's FilterStringForPaste behavior for single-line targets.
-        string sanitized = SanitizeSingleLinePaste (args.Text);
-
-        if (sanitized.Length == 0)
-        {
-            return false;
-        }
-
-        InsertText (sanitized, false);
-        args.Handled = true;
-
-        return true;
-    }
-
-    private static string SanitizeSingleLinePaste (string text)
-    {
-        int newline = text.IndexOfAny (['\r', '\n']);
-        string firstLine = newline >= 0 ? text [..newline] : text;
-
-        // Strip C0/C1 control chars (including ESC). Keep tabs since the existing TextField
-        // accepts a literal tab in its text. DEL (0x7F) is dropped.
         StringBuilder sb = new (firstLine.Length);
 
         foreach (char c in firstLine)
@@ -81,6 +62,35 @@ public partial class TextField
         }
 
         return sb.ToString ();
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    ///     Returns <see langword="true"/> even when <see cref="ReadOnly"/> so that <c>Ctrl+V</c>
+    ///     does not bubble to a parent view that might also bind paste. The
+    ///     <see cref="View.Pasted"/> event still fires in that case; subscribers that care should
+    ///     check <see cref="ReadOnly"/>.
+    /// </remarks>
+    protected override bool OnPaste (string text)
+    {
+        if (ReadOnly)
+        {
+            return true;
+        }
+
+        SetSelectedStartSelectedLength ();
+        int selStart = _selectionStart == -1 ? InsertionPoint : _selectionStart;
+
+        Text = StringExtensions.ToString (_text.GetRange (0, selStart))
+               + text
+               + StringExtensions.ToString (_text.GetRange (selStart + SelectedLength, _text.Count - (selStart + SelectedLength)));
+
+        _insertionPoint = Math.Min (selStart + GraphemeHelper.GetGraphemeCount (text), _text.Count);
+        ClearAllSelection ();
+        SetNeedsDraw ();
+        Adjust ();
+
+        return true;
     }
 
     /// <summary>Raises the <see cref="TextChanging"/> event, enabling canceling the change or adjusting the text.</summary>

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.Text.cs
@@ -47,10 +47,40 @@ public partial class TextField
             return false;
         }
 
-        InsertText (args.Text, false);
+        // TextField is single-line — take only the first line of the paste and drop control
+        // characters. This mirrors the existing clipboard-Paste command (see TextField.Commands.cs)
+        // and matches Windows Terminal's FilterStringForPaste behavior for single-line targets.
+        string sanitized = SanitizeSingleLinePaste (args.Text);
+
+        if (sanitized.Length == 0)
+        {
+            return false;
+        }
+
+        InsertText (sanitized, false);
         args.Handled = true;
 
         return true;
+    }
+
+    private static string SanitizeSingleLinePaste (string text)
+    {
+        int newline = text.IndexOfAny (['\r', '\n']);
+        string firstLine = newline >= 0 ? text [..newline] : text;
+
+        // Strip C0/C1 control chars (including ESC). Keep tabs since the existing TextField
+        // accepts a literal tab in its text. DEL (0x7F) is dropped.
+        StringBuilder sb = new (firstLine.Length);
+
+        foreach (char c in firstLine)
+        {
+            if (c == '\t' || (c >= 0x20 && c < 0x7F) || c >= 0xA0)
+            {
+                sb.Append (c);
+            }
+        }
+
+        return sb.ToString ();
     }
 
     /// <summary>Raises the <see cref="TextChanging"/> event, enabling canceling the change or adjusting the text.</summary>

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.Text.cs
@@ -39,6 +39,20 @@ public partial class TextField
         }
     }
 
+    /// <inheritdoc/>
+    protected override bool OnPasted (PasteEventArgs args)
+    {
+        if (ReadOnly || string.IsNullOrEmpty (args.Text))
+        {
+            return false;
+        }
+
+        InsertText (args.Text, false);
+        args.Handled = true;
+
+        return true;
+    }
+
     /// <summary>Raises the <see cref="TextChanging"/> event, enabling canceling the change or adjusting the text.</summary>
     /// <param name="args">The event arguments.</param>
     /// <returns><see langword="true"/> if the event was cancelled or the text was adjusted by the event.</returns>

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.Text.cs
@@ -6,6 +6,7 @@ namespace Terminal.Gui.Views;
 public partial class TextField
 {
     private CultureInfo _currentCulture;
+    private string? _lastPastedText;
 
     /// <summary>Raised before <see cref="Text"/> changes. The change can be canceled the text adjusted.</summary>
     public event EventHandler<ResultEventArgs<string>>? TextChanging;
@@ -42,9 +43,8 @@ public partial class TextField
     /// <inheritdoc/>
     /// <remarks>
     ///     TextField is single-line — keep only the first line of the paste and drop C0/C1 control
-    ///     characters (except tab, which TextField accepts as a literal). Matches Windows Terminal's
-    ///     <c>FilterStringForPaste</c> behavior for single-line targets and mirrors the existing
-    ///     clipboard-paste command.
+    ///     characters, including tab. This matches what <see cref="Text"/> can actually accept and
+    ///     keeps <see cref="View.Pasting"/> aligned with the text that will be inserted.
     /// </remarks>
     protected override string OnSanitizingPaste (string raw)
     {
@@ -55,7 +55,7 @@ public partial class TextField
 
         foreach (char c in firstLine)
         {
-            if (c == '\t' || (c >= 0x20 && c < 0x7F) || c >= 0xA0)
+            if ((c >= 0x20 && c < 0x7F) || c >= 0xA0)
             {
                 sb.Append (c);
             }
@@ -67,12 +67,12 @@ public partial class TextField
     /// <inheritdoc/>
     /// <remarks>
     ///     Returns <see langword="true"/> even when <see cref="ReadOnly"/> so that <c>Ctrl+V</c>
-    ///     does not bubble to a parent view that might also bind paste. The
-    ///     <see cref="View.Pasted"/> event still fires in that case; subscribers that care should
-    ///     check <see cref="ReadOnly"/>.
+    ///     does not bubble to a parent view that might also bind paste.
     /// </remarks>
     protected override bool OnPaste (string text)
     {
+        _lastPastedText = null;
+
         if (ReadOnly)
         {
             return true;
@@ -80,17 +80,220 @@ public partial class TextField
 
         SetSelectedStartSelectedLength ();
         int selStart = _selectionStart == -1 ? InsertionPoint : _selectionStart;
+        int selectedLength = SelectedLength;
+        List<string> oldText = [.. _text];
+        string oldTextString = StringExtensions.ToString (oldText);
+        List<string> pastedText = text.ToStringList ();
+        List<string> proposedText = [.. oldText.GetRange (0, selStart),
+                                     .. pastedText,
+                                     .. oldText.GetRange (selStart + selectedLength, oldText.Count - (selStart + selectedLength))];
 
-        Text = StringExtensions.ToString (_text.GetRange (0, selStart))
-               + text
-               + StringExtensions.ToString (_text.GetRange (selStart + SelectedLength, _text.Count - (selStart + SelectedLength)));
+        Text = StringExtensions.ToString (proposedText);
+        bool proposedEqualsFinal = AreEqual (proposedText, _text);
 
-        _insertionPoint = Math.Min (selStart + GraphemeHelper.GetGraphemeCount (text), _text.Count);
+        if (oldTextString == Text && !proposedEqualsFinal)
+        {
+            return true;
+        }
+
+        GetActualPastedText (text, proposedText, selStart, pastedText.Count, _text, out string actualPastedText, out int insertionPoint);
+
+        if (string.IsNullOrEmpty (actualPastedText))
+        {
+            _insertionPoint = insertionPoint;
+            ClearAllSelection ();
+            SetNeedsDraw ();
+            Adjust ();
+
+            return true;
+        }
+
+        _lastPastedText = actualPastedText;
+        _insertionPoint = insertionPoint;
         ClearAllSelection ();
         SetNeedsDraw ();
         Adjust ();
 
         return true;
+    }
+
+    /// <inheritdoc/>
+    protected override bool ShouldRaisePastedEvent (string text) => !ReadOnly && !string.IsNullOrEmpty (_lastPastedText);
+
+    /// <inheritdoc/>
+    protected override string? GetPastedEventText (string text) => _lastPastedText;
+
+    private static void GetActualPastedText (string text, List<string> proposedText, int pasteStart, int pastedLength, List<string> finalText, out string actualPastedText, out int insertionPoint)
+    {
+        if (AreEqual (proposedText, finalText))
+        {
+            actualPastedText = text;
+            insertionPoint = Math.Min (pasteStart + pastedLength, finalText.Count);
+
+            return;
+        }
+
+        if (proposedText.Count == finalText.Count)
+        {
+            int actualPastedLength = Math.Min (pastedLength, finalText.Count - pasteStart);
+            actualPastedText = actualPastedLength > 0
+                                   ? StringExtensions.ToString (finalText.GetRange (pasteStart, actualPastedLength))
+                                   : string.Empty;
+            insertionPoint = Math.Min (pasteStart + actualPastedLength, finalText.Count);
+
+            return;
+        }
+
+        actualPastedText = GetActualPastedTextFromEditOperations (proposedText, pasteStart, pastedLength, finalText, out insertionPoint);
+    }
+
+    private static string GetActualPastedTextFromEditOperations (List<string> proposedText, int pasteStart, int pastedLength, List<string> finalText, out int insertionPoint)
+    {
+        List<PasteEditOperation> operations = BuildPasteEditOperations (proposedText, finalText);
+        int pasteEnd = pasteStart + pastedLength;
+        int proposedIndex = 0;
+        int finalIndex = 0;
+        int pastedStart = -1;
+        int pastedEnd = -1;
+        int boundaryAfterPaste = -1;
+
+        foreach (PasteEditOperation operation in operations)
+        {
+            if (ConsumesFinal (operation)
+                && IsWithinPasteRange (operation, proposedIndex, pasteStart, pasteEnd))
+            {
+                if (pastedStart == -1)
+                {
+                    pastedStart = finalIndex;
+                }
+
+                pastedEnd = finalIndex + 1;
+            }
+
+            if (ConsumesProposed (operation))
+            {
+                proposedIndex++;
+
+                if (proposedIndex == pasteEnd)
+                {
+                    boundaryAfterPaste = finalIndex + (ConsumesFinal (operation) ? 1 : 0);
+                }
+            }
+            if (ConsumesFinal (operation))
+            {
+                finalIndex++;
+            }
+        }
+
+        insertionPoint = boundaryAfterPaste == -1 ? finalIndex : boundaryAfterPaste;
+
+        if (pastedStart == -1 || pastedEnd == -1 || pastedEnd <= pastedStart)
+        {
+            return string.Empty;
+        }
+
+        return StringExtensions.ToString (finalText.GetRange (pastedStart, pastedEnd - pastedStart));
+    }
+
+    private static List<PasteEditOperation> BuildPasteEditOperations (List<string> proposedText, List<string> finalText)
+    {
+        int [,] costs = new int [proposedText.Count + 1, finalText.Count + 1];
+
+        for (int i = 0; i <= proposedText.Count; i++)
+        {
+            costs [i, 0] = i;
+        }
+
+        for (int j = 0; j <= finalText.Count; j++)
+        {
+            costs [0, j] = j;
+        }
+
+        for (int i = 1; i <= proposedText.Count; i++)
+        {
+            for (int j = 1; j <= finalText.Count; j++)
+            {
+                int substitutionCost = costs [i - 1, j - 1] + (proposedText [i - 1] == finalText [j - 1] ? 0 : 1);
+                int insertionCost = costs [i, j - 1] + 1;
+                int deletionCost = costs [i - 1, j] + 1;
+
+                costs [i, j] = Math.Min (substitutionCost, Math.Min (insertionCost, deletionCost));
+            }
+        }
+
+        List<PasteEditOperation> operations = [];
+        int proposedIndex = proposedText.Count;
+        int finalIndex = finalText.Count;
+
+        while (proposedIndex > 0 || finalIndex > 0)
+        {
+            if (proposedIndex > 0
+                && finalIndex > 0
+                && costs [proposedIndex, finalIndex]
+                == costs [proposedIndex - 1, finalIndex - 1]
+                + (proposedText [proposedIndex - 1] == finalText [finalIndex - 1] ? 0 : 1))
+            {
+                operations.Add (PasteEditOperation.Substitute);
+                proposedIndex--;
+                finalIndex--;
+
+                continue;
+            }
+
+            if (finalIndex > 0 && costs [proposedIndex, finalIndex] == costs [proposedIndex, finalIndex - 1] + 1)
+            {
+                operations.Add (PasteEditOperation.Insert);
+                finalIndex--;
+
+                continue;
+            }
+
+            operations.Add (PasteEditOperation.Delete);
+            proposedIndex--;
+        }
+
+        operations.Reverse ();
+
+        return operations;
+    }
+
+    private enum PasteEditOperation
+    {
+        Insert,
+        Delete,
+        Substitute
+    }
+
+    private static bool AreEqual (List<string> first, List<string> second)
+    {
+        if (first.Count != second.Count)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < first.Count; i++)
+        {
+            if (first [i] != second [i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ConsumesFinal (PasteEditOperation operation) => operation is PasteEditOperation.Insert or PasteEditOperation.Substitute;
+
+    private static bool ConsumesProposed (PasteEditOperation operation) => operation is PasteEditOperation.Delete or PasteEditOperation.Substitute;
+
+    private static bool IsWithinPasteRange (PasteEditOperation operation, int proposedIndex, int pasteStart, int pasteEnd)
+    {
+        if (operation == PasteEditOperation.Insert)
+        {
+            return proposedIndex > pasteStart && proposedIndex < pasteEnd;
+        }
+
+        return proposedIndex >= pasteStart && proposedIndex < pasteEnd;
     }
 
     /// <summary>Raises the <see cref="TextChanging"/> event, enabling canceling the change or adjusting the text.</summary>

--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Commands.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Commands.cs
@@ -97,7 +97,9 @@ public partial class TextView
         AddCommand (Command.SelectAll, () => ProcessSelectAll ());
         AddCommand (Command.CutToEndOfLine, () => CutToEndOfLine ());
         AddCommand (Command.CutToStartOfLine, () => CutToStartOfLine ());
-        AddCommand (Command.Paste, () => ProcessPaste ());
+
+        // Command.Paste uses the default View base handler — sanitization via OnSanitizingPaste,
+        // insertion via OnPaste. ProcessPaste's column-track reset happens inside OnPaste.
         AddCommand (Command.Copy, () => ProcessCopy ());
         AddCommand (Command.Cut, () => ProcessCut ());
         AddCommand (Command.DeleteCharLeft, () => ProcessDeleteCharLeft ());
@@ -225,52 +227,12 @@ public partial class TextView
     }
 
     /// <summary>Paste the clipboard contents into the current selected position.</summary>
-    public bool Paste ()
-    {
-        if (_isReadOnly)
-        {
-            return true;
-        }
-
-        SetWrapModel ();
-        string? contents = App?.Clipboard?.GetClipboardData ();
-
-        if (_copyWithoutSelection && contents!.FirstOrDefault (x => x is '\n' or '\r') == 0)
-        {
-            List<Cell> runeList = contents is null ? [] : Cell.ToCellList (contents);
-            List<Cell> currentLine = GetCurrentLine ();
-            _historyText.Add ([[.. currentLine]], InsertionPoint);
-            List<List<Cell>> addedLine = [[.. currentLine], runeList];
-            _historyText.Add ([.. addedLine], InsertionPoint, TextEditingLineStatus.Added);
-            _model.AddLine (CurrentRow, runeList);
-            SetNeedsDraw ();
-            CurrentRow++;
-            _historyText.Add ([[.. GetCurrentLine ()]], InsertionPoint, TextEditingLineStatus.Replaced);
-
-            OnContentsChanged ();
-        }
-        else
-        {
-            if (IsSelecting)
-            {
-                ClearRegion ();
-            }
-
-            _copyWithoutSelection = false;
-            InsertAllText (contents!, true);
-
-            if (IsSelecting)
-            {
-                _historyText.ReplaceLast ([[.. GetCurrentLine ()]], InsertionPoint, TextEditingLineStatus.Original);
-            }
-        }
-
-        UpdateWrapModel ();
-        IsSelecting = false;
-        DoNeededAction ();
-
-        return true;
-    }
+    /// <remarks>
+    ///     Routes through <see cref="Command.Paste"/> with a <see langword="null"/> payload, so the
+    ///     default <see cref="View"/> handler reads from <see cref="IApplication.Clipboard"/>,
+    ///     sanitizes via <see cref="OnSanitizingPaste"/>, and inserts via <see cref="OnPaste"/>.
+    /// </remarks>
+    public bool Paste () => InvokeCommand (Command.Paste) is true;
 
     private void AppendClipboard (string text) => App?.Clipboard?.SetClipboardData (App?.Clipboard?.GetClipboardData () + text);
 
@@ -918,18 +880,6 @@ public partial class TextView
         StopSelecting ();
 
         return KillWordRight ();
-    }
-
-    private bool ProcessPaste ()
-    {
-        ResetColumnTrack ();
-
-        if (_isReadOnly)
-        {
-            return true;
-        }
-
-        return Paste ();
     }
 
     private bool ProcessEnterKey (ICommandContext? commandContext)

--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
@@ -253,42 +253,24 @@ public partial class TextView
     }
 
     /// <inheritdoc/>
-    protected override bool OnPasted (PasteEventArgs args)
+    /// <remarks>
+    ///     Normalizes line endings (CR and CRLF → LF) so the text model sees a single newline form,
+    ///     and strips C0/C1 control chars except tab and newline. Mirrors Windows Terminal's
+    ///     <c>FilterStringForPaste</c>.
+    /// </remarks>
+    protected override string OnSanitizingPaste (string raw)
     {
-        if (_isReadOnly || string.IsNullOrEmpty (args.Text))
+        StringBuilder sb = new (raw.Length);
+
+        for (var i = 0; i < raw.Length; i++)
         {
-            return false;
-        }
-
-        // Normalize newlines (terminals send \r for paste line breaks, some send \r\n) and strip
-        // C0/C1 control chars except tab/newline. Mirrors Windows Terminal's FilterStringForPaste.
-        string sanitized = SanitizeMultiLinePaste (args.Text);
-
-        if (sanitized.Length == 0)
-        {
-            return false;
-        }
-
-        InsertText (sanitized);
-        args.Handled = true;
-
-        return true;
-    }
-
-    private static string SanitizeMultiLinePaste (string text)
-    {
-        StringBuilder sb = new (text.Length);
-
-        for (var i = 0; i < text.Length; i++)
-        {
-            char c = text [i];
+            char c = raw [i];
 
             if (c == '\r')
             {
-                // Collapse CR and CRLF into LF so the text model sees a single newline form.
                 sb.Append ('\n');
 
-                if (i + 1 < text.Length && text [i + 1] == '\n')
+                if (i + 1 < raw.Length && raw [i + 1] == '\n')
                 {
                     i++;
                 }
@@ -303,6 +285,63 @@ public partial class TextView
         }
 
         return sb.ToString ();
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    ///     Returns <see langword="true"/> even when <see cref="ReadOnly"/> so that <c>Ctrl+V</c>
+    ///     does not bubble to a parent view that might also bind paste. The
+    ///     <see cref="View.Pasted"/> event still fires in that case; subscribers that care should
+    ///     check <see cref="ReadOnly"/>.
+    /// </remarks>
+    protected override bool OnPaste (string text)
+    {
+        if (_isReadOnly)
+        {
+            return true;
+        }
+
+        ResetColumnTrack ();
+        SetWrapModel ();
+
+        // Preserves the legacy clipboard "Copy without selection → Paste inserts as new line above"
+        // behavior. _copyWithoutSelection is set only by this view's own Copy() command, so
+        // bracketed paste (which has no preceding Copy) naturally skips this branch.
+        if (_copyWithoutSelection && text.FirstOrDefault (x => x is '\n' or '\r') == 0)
+        {
+            List<Cell> runeList = Cell.ToCellList (text);
+            List<Cell> currentLine = GetCurrentLine ();
+            _historyText.Add ([[.. currentLine]], InsertionPoint);
+            List<List<Cell>> addedLine = [[.. currentLine], runeList];
+            _historyText.Add ([.. addedLine], InsertionPoint, TextEditingLineStatus.Added);
+            _model.AddLine (CurrentRow, runeList);
+            SetNeedsDraw ();
+            CurrentRow++;
+            _historyText.Add ([[.. GetCurrentLine ()]], InsertionPoint, TextEditingLineStatus.Replaced);
+
+            OnContentsChanged ();
+        }
+        else
+        {
+            if (IsSelecting)
+            {
+                ClearRegion ();
+            }
+
+            _copyWithoutSelection = false;
+            InsertAllText (text, true);
+
+            if (IsSelecting)
+            {
+                _historyText.ReplaceLast ([[.. GetCurrentLine ()]], InsertionPoint, TextEditingLineStatus.Original);
+            }
+        }
+
+        UpdateWrapModel ();
+        IsSelecting = false;
+        DoNeededAction ();
+
+        return true;
     }
 
     /// <summary>Replaces all the text based on the match case.</summary>

--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
@@ -252,6 +252,20 @@ public partial class TextView
         }
     }
 
+    /// <inheritdoc/>
+    protected override bool OnPasted (PasteEventArgs args)
+    {
+        if (_isReadOnly || string.IsNullOrEmpty (args.Text))
+        {
+            return false;
+        }
+
+        InsertText (args.Text);
+        args.Handled = true;
+
+        return true;
+    }
+
     /// <summary>Replaces all the text based on the match case.</summary>
     /// <param name="textToFind">The text to find.</param>
     /// <param name="matchCase">The match case setting.</param>

--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
@@ -260,10 +260,49 @@ public partial class TextView
             return false;
         }
 
-        InsertText (args.Text);
+        // Normalize newlines (terminals send \r for paste line breaks, some send \r\n) and strip
+        // C0/C1 control chars except tab/newline. Mirrors Windows Terminal's FilterStringForPaste.
+        string sanitized = SanitizeMultiLinePaste (args.Text);
+
+        if (sanitized.Length == 0)
+        {
+            return false;
+        }
+
+        InsertText (sanitized);
         args.Handled = true;
 
         return true;
+    }
+
+    private static string SanitizeMultiLinePaste (string text)
+    {
+        StringBuilder sb = new (text.Length);
+
+        for (var i = 0; i < text.Length; i++)
+        {
+            char c = text [i];
+
+            if (c == '\r')
+            {
+                // Collapse CR and CRLF into LF so the text model sees a single newline form.
+                sb.Append ('\n');
+
+                if (i + 1 < text.Length && text [i + 1] == '\n')
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            if (c == '\n' || c == '\t' || (c >= 0x20 && c < 0x7F) || c >= 0xA0)
+            {
+                sb.Append (c);
+            }
+        }
+
+        return sb.ToString ();
     }
 
     /// <summary>Replaces all the text based on the match case.</summary>

--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
@@ -290,9 +290,7 @@ public partial class TextView
     /// <inheritdoc/>
     /// <remarks>
     ///     Returns <see langword="true"/> even when <see cref="ReadOnly"/> so that <c>Ctrl+V</c>
-    ///     does not bubble to a parent view that might also bind paste. The
-    ///     <see cref="View.Pasted"/> event still fires in that case; subscribers that care should
-    ///     check <see cref="ReadOnly"/>.
+    ///     does not bubble to a parent view that might also bind paste.
     /// </remarks>
     protected override bool OnPaste (string text)
     {
@@ -307,7 +305,7 @@ public partial class TextView
         // Preserves the legacy clipboard "Copy without selection → Paste inserts as new line above"
         // behavior. _copyWithoutSelection is set only by this view's own Copy() command, so
         // bracketed paste (which has no preceding Copy) naturally skips this branch.
-        if (_copyWithoutSelection && text.FirstOrDefault (x => x is '\n' or '\r') == 0)
+        if (!CurrentPasteUsesPayload && _copyWithoutSelection && text.FirstOrDefault (x => x is '\n' or '\r') == 0)
         {
             List<Cell> runeList = Cell.ToCellList (text);
             List<Cell> currentLine = GetCurrentLine ();
@@ -343,6 +341,9 @@ public partial class TextView
 
         return true;
     }
+
+    /// <inheritdoc/>
+    protected override bool ShouldRaisePastedEvent (string text) => !_isReadOnly;
 
     /// <summary>Replaces all the text based on the match case.</summary>
     /// <param name="textToFind">The text to find.</param>

--- a/Tests/StressTests/BracketedPasteDemoTests.cs
+++ b/Tests/StressTests/BracketedPasteDemoTests.cs
@@ -1,0 +1,44 @@
+using UICatalog.Scenarios;
+
+namespace StressTests;
+
+public class BracketedPasteDemoTests
+{
+    // Copilot
+    [Fact]
+    public void BracketedPasteDemo_Categories_IncludeTextAndFormatting_NotInput ()
+    {
+        BracketedPasteDemo scenario = new ();
+
+        List<string> categories = scenario.GetCategories ();
+
+        Assert.Contains ("Text and Formatting", categories);
+        Assert.DoesNotContain ("Input", categories);
+    }
+
+    // Copilot
+    [Fact]
+    public void FormatPasteLogEntry_IndicatesBracketedPasteEvent ()
+    {
+        string message = BracketedPasteDemo.FormatPasteLogEntry (1, "abc");
+
+        Assert.Equal ("[1] Bracketed paste event: 3 chars: abc", message);
+    }
+
+    // Copilot
+    [Fact]
+    public void CreateHintLabel_InNarrowWindow_WrapsToMultipleLines ()
+    {
+        Window window = new ()
+        {
+            Width = 20,
+            Height = 10
+        };
+        Label hint = BracketedPasteDemo.CreateHintLabel ();
+
+        window.Add (hint);
+        window.Layout ();
+
+        Assert.True (hint.Frame.Height > 1);
+    }
+}

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiBracketedPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiBracketedPasteTests.cs
@@ -77,11 +77,11 @@ public class AnsiBracketedPasteTests
         string? captured = null;
         _parser.Paste += (_, text) => captured = text;
 
-        string trickyPayload = "[201"; // looks like the start of the end marker but missing '~'
+        string trickyPayload = "\u001b[201"; // looks like the start of the end marker but missing '~'
 
         string output = _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}{trickyPayload}rest{EscSeqUtils.CSI_BracketedPasteEnd}");
 
-        Assert.Equal ("[201rest", captured);
+        Assert.Equal ("\u001b[201rest", captured);
         Assert.Equal (string.Empty, output);
     }
 
@@ -98,18 +98,63 @@ public class AnsiBracketedPasteTests
     }
 
     [Fact]
-    public void Paste_OversizedPayload_TruncatesAndReturnsToNormal ()
+    public void Paste_OversizedPayload_TruncatesAndWaitsForEndMarker ()
     {
         string? captured = null;
         _parser.Paste += (_, text) => captured = text;
 
         // Build a payload larger than the max paste length so the parser must flush mid-paste.
-        var longBody = new string ('x', AnsiResponseParserBase.MaxBracketedPasteLength + 100);
+        string longBody = new ('x', AnsiResponseParserBase.MaxBracketedPasteLength + 100);
 
         _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}{longBody}");
 
         Assert.NotNull (captured);
         Assert.Equal (AnsiResponseParserBase.MaxBracketedPasteLength, captured!.Length);
+        Assert.Equal (AnsiResponseParserState.DiscardingBracketedPasteRemainder, _parser.State);
+    }
+
+    [Fact]
+    public void Paste_OversizedPayload_DiscardsRemainderUntilEndMarker ()
+    {
+        List<string> captured = [];
+        _parser.Paste += (_, text) => captured.Add (text);
+
+        string payload = new ('x', AnsiResponseParserBase.MaxBracketedPasteLength);
+        string expectedPayload = new ('x', AnsiResponseParserBase.MaxBracketedPasteLength);
+
+        string firstOutput = _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}{payload}");
+        string secondOutput = _parser.ProcessInput ($"tail{EscSeqUtils.CSI_BracketedPasteEnd}typed");
+
+        Assert.Equal ([expectedPayload], captured);
+        Assert.Equal (string.Empty, firstOutput);
+        Assert.Equal ("typed", secondOutput);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
+    }
+
+    [Theory]
+    [InlineData (1)]
+    [InlineData (2)]
+    [InlineData (3)]
+    [InlineData (4)]
+    [InlineData (5)]
+    public void Paste_EndMarkerStraddlingSizeBoundary_DoesNotLeakMarkerBytesOrStayDiscarding (int markerBytesInBuffer)
+    {
+        List<string> captured = [];
+        _parser.Paste += (_, text) => captured.Add (text);
+
+        string endMarker = EscSeqUtils.CSI_BracketedPasteEnd;
+        string body = new ('x', AnsiResponseParserBase.MaxBracketedPasteLength - markerBytesInBuffer);
+        string partialMarker = endMarker [..markerBytesInBuffer];
+        string remainingMarker = endMarker [markerBytesInBuffer..];
+
+        _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}{body}{partialMarker}");
+
+        Assert.Equal ([body], captured);
+        Assert.Equal (AnsiResponseParserState.DiscardingBracketedPasteRemainder, _parser.State);
+
+        string output = _parser.ProcessInput ($"{remainingMarker}typed");
+
+        Assert.Equal ("typed", output);
         Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
     }
 
@@ -177,10 +222,10 @@ public class AnsiBracketedPasteTests
         // First chunk legitimately contains "ESC[20" at the end (a near-end-marker prefix).
         // Second chunk supplies a different char so the prefix is rejected, then the real body
         // and end marker.
-        _parser.ProcessInput (EscSeqUtils.CSI_BracketedPasteStart + "head[20");
+        _parser.ProcessInput (EscSeqUtils.CSI_BracketedPasteStart + "head\u001b[20");
         _parser.ProcessInput ($"X-tail{EscSeqUtils.CSI_BracketedPasteEnd}");
 
-        Assert.Equal ("head[20X-tail", captured);
+        Assert.Equal ("head\u001b[20X-tail", captured);
     }
 
     [Fact]
@@ -207,9 +252,9 @@ public class AnsiBracketedPasteTests
         string? captured = null;
         _parser.Paste += (_, text) => captured = text;
 
-        _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}before[200~after{EscSeqUtils.CSI_BracketedPasteEnd}");
+        _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}before{EscSeqUtils.CSI_BracketedPasteStart}after{EscSeqUtils.CSI_BracketedPasteEnd}");
 
-        Assert.Equal ("before[200~after", captured);
+        Assert.Equal ($"before{EscSeqUtils.CSI_BracketedPasteStart}after", captured);
     }
 
     [Fact]
@@ -232,5 +277,25 @@ public class AnsiBracketedPasteTests
 
         string output = _parser.ProcessInput ("typed");
         Assert.Equal ("typed", output);
+    }
+
+    [Fact]
+    public void FlushStaleBracketedPaste_WhenDiscarding_ReturnsToNormalWithoutAnotherPasteEvent ()
+    {
+        List<string> captured = [];
+        _parser.Paste += (_, text) => captured.Add (text);
+
+        string payload = new ('x', AnsiResponseParserBase.MaxBracketedPasteLength);
+
+        _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}{payload}");
+
+        Assert.Equal (AnsiResponseParserState.DiscardingBracketedPasteRemainder, _parser.State);
+        Assert.Single (captured);
+
+        bool flushed = _parser.FlushStaleBracketedPaste ();
+
+        Assert.True (flushed);
+        Assert.Single (captured);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
     }
 }

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiBracketedPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiBracketedPasteTests.cs
@@ -20,6 +20,20 @@ public class AnsiBracketedPasteTests
     }
 
     [Fact]
+    public void Paste_FullSequence_RaisesEventOutsideParserLock ()
+    {
+        object lockState = typeof (AnsiResponseParserBase)
+                           .GetField ("_lockState", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+                           .GetValue (_parser)!;
+        bool? lockHeld = null;
+        _parser.Paste += (_, _) => lockHeld = Monitor.IsEntered (lockState);
+
+        _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}hello world{EscSeqUtils.CSI_BracketedPasteEnd}");
+
+        Assert.False (lockHeld);
+    }
+
+    [Fact]
     public void Paste_SurroundedByNormalInput_OnlyPastedTextIsDelivered ()
     {
         string? captured = null;

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiBracketedPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiBracketedPasteTests.cs
@@ -1,0 +1,125 @@
+namespace DriverTests.AnsiHandling;
+
+// Claude - Opus 4.7
+[Collection ("Driver Tests")]
+public class AnsiBracketedPasteTests
+{
+    private readonly AnsiResponseParser _parser = new (new SystemTimeProvider ());
+
+    [Fact]
+    public void Paste_FullSequence_RaisesEventWithStrippedMarkers ()
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        string output = _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}hello world{EscSeqUtils.CSI_BracketedPasteEnd}");
+
+        Assert.Equal ("hello world", captured);
+        Assert.Equal (string.Empty, output);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
+    }
+
+    [Fact]
+    public void Paste_SurroundedByNormalInput_OnlyPastedTextIsDelivered ()
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        string output = _parser.ProcessInput ($"before{EscSeqUtils.CSI_BracketedPasteStart}PASTE{EscSeqUtils.CSI_BracketedPasteEnd}after");
+
+        Assert.Equal ("PASTE", captured);
+        Assert.Equal ("beforeafter", output);
+    }
+
+    [Fact]
+    public void Paste_SplitAcrossProcessInputCalls_AccumulatesAndDelivers ()
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        // Start marker arrives by itself
+        string output1 = _parser.ProcessInput (EscSeqUtils.CSI_BracketedPasteStart);
+        Assert.Null (captured);
+        Assert.Equal (string.Empty, output1);
+        Assert.Equal (AnsiResponseParserState.InBracketedPaste, _parser.State);
+
+        // Body arrives in the middle
+        string output2 = _parser.ProcessInput ("multi-line\npaste\rbody");
+        Assert.Null (captured);
+        Assert.Equal (string.Empty, output2);
+
+        // End marker arrives by itself
+        string output3 = _parser.ProcessInput (EscSeqUtils.CSI_BracketedPasteEnd);
+        Assert.Equal ("multi-line\npaste\rbody", captured);
+        Assert.Equal (string.Empty, output3);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
+    }
+
+    [Fact]
+    public void Paste_ContainingControlChars_PreservesBytesVerbatim ()
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        string payload = "tab\there\nnewline\rcr";
+
+        string output = _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}{payload}{EscSeqUtils.CSI_BracketedPasteEnd}");
+
+        Assert.Equal (payload, captured);
+        Assert.Equal (string.Empty, output);
+    }
+
+    [Fact]
+    public void Paste_ContainingPartialEndMarkerPrefix_DoesNotTerminateEarly ()
+    {
+        // Payload contains "ESC[201" without the trailing tilde — must NOT be treated as the end
+        // marker. The real end marker arrives later.
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        string trickyPayload = "[201"; // looks like the start of the end marker but missing '~'
+
+        string output = _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}{trickyPayload}rest{EscSeqUtils.CSI_BracketedPasteEnd}");
+
+        Assert.Equal ("[201rest", captured);
+        Assert.Equal (string.Empty, output);
+    }
+
+    [Fact]
+    public void Paste_EmptyPayload_RaisesEventWithEmptyString ()
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        string output = _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}{EscSeqUtils.CSI_BracketedPasteEnd}");
+
+        Assert.Equal (string.Empty, captured);
+        Assert.Equal (string.Empty, output);
+    }
+
+    [Fact]
+    public void Paste_OversizedPayload_TruncatesAndReturnsToNormal ()
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        // Build a payload larger than the max paste length so the parser must flush mid-paste.
+        var longBody = new string ('x', AnsiResponseParserBase.MaxBracketedPasteLength + 100);
+
+        _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}{longBody}");
+
+        Assert.NotNull (captured);
+        Assert.Equal (AnsiResponseParserBase.MaxBracketedPasteLength, captured!.Length);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
+    }
+
+    [Fact]
+    public void Paste_WithoutEnableEvent_StillBuffersUntilEndMarker ()
+    {
+        // No subscriber on Paste — parser still consumes the markers without leaking to output.
+        string output = _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}body{EscSeqUtils.CSI_BracketedPasteEnd}");
+
+        Assert.Equal (string.Empty, output);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
+    }
+}

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiBracketedPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/AnsiBracketedPasteTests.cs
@@ -122,4 +122,115 @@ public class AnsiBracketedPasteTests
         Assert.Equal (string.Empty, output);
         Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
     }
+
+    [Theory]
+    [InlineData (1)]
+    [InlineData (2)]
+    [InlineData (3)]
+    [InlineData (4)]
+    [InlineData (5)]
+    [InlineData (6)]
+    public void Paste_StartMarkerSplitAtEveryByteBoundary_StillDetected (int splitAt)
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        string startMarker = EscSeqUtils.CSI_BracketedPasteStart;
+        string firstChunk = startMarker [..splitAt];
+        string secondChunk = startMarker [splitAt..] + "PAYLOAD" + EscSeqUtils.CSI_BracketedPasteEnd;
+
+        _parser.ProcessInput (firstChunk);
+        _parser.ProcessInput (secondChunk);
+
+        Assert.Equal ("PAYLOAD", captured);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
+    }
+
+    [Theory]
+    [InlineData (1)]
+    [InlineData (2)]
+    [InlineData (3)]
+    [InlineData (4)]
+    [InlineData (5)]
+    [InlineData (6)]
+    public void Paste_EndMarkerSplitAtEveryByteBoundary_StillDetected (int splitAt)
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        string endMarker = EscSeqUtils.CSI_BracketedPasteEnd;
+
+        _parser.ProcessInput (EscSeqUtils.CSI_BracketedPasteStart + "body");
+        _parser.ProcessInput (endMarker [..splitAt]);
+        _parser.ProcessInput (endMarker [splitAt..]);
+
+        Assert.Equal ("body", captured);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
+    }
+
+    [Fact]
+    public void Paste_BodyEndsWithPartialEndMarkerAcrossCalls_DoesNotTerminateEarly ()
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        // First chunk legitimately contains "ESC[20" at the end (a near-end-marker prefix).
+        // Second chunk supplies a different char so the prefix is rejected, then the real body
+        // and end marker.
+        _parser.ProcessInput (EscSeqUtils.CSI_BracketedPasteStart + "head[20");
+        _parser.ProcessInput ($"X-tail{EscSeqUtils.CSI_BracketedPasteEnd}");
+
+        Assert.Equal ("head[20X-tail", captured);
+    }
+
+    [Fact]
+    public void Paste_TwoConsecutivePastes_BothDelivered ()
+    {
+        List<string> captured = [];
+        _parser.Paste += (_, text) => captured.Add (text);
+
+        string input = $"{EscSeqUtils.CSI_BracketedPasteStart}A{EscSeqUtils.CSI_BracketedPasteEnd}"
+                       + $"between"
+                       + $"{EscSeqUtils.CSI_BracketedPasteStart}B{EscSeqUtils.CSI_BracketedPasteEnd}";
+
+        string output = _parser.ProcessInput (input);
+
+        Assert.Equal (["A", "B"], captured);
+        Assert.Equal ("between", output);
+    }
+
+    [Fact]
+    public void Paste_BodyContainsLiteralStartMarker_AppendedAsContent ()
+    {
+        // A well-behaved terminal won't emit a nested start marker, but a hostile or buggy one might.
+        // We treat any bytes between the outer start and end markers as paste content.
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}before[200~after{EscSeqUtils.CSI_BracketedPasteEnd}");
+
+        Assert.Equal ("before[200~after", captured);
+    }
+
+    [Fact]
+    public void Paste_ResetMidPaste_DiscardsBufferAndReturnsToNormal ()
+    {
+        string? captured = null;
+        _parser.Paste += (_, text) => captured = text;
+
+        _parser.ProcessInput ($"{EscSeqUtils.CSI_BracketedPasteStart}partial");
+        Assert.Equal (AnsiResponseParserState.InBracketedPaste, _parser.State);
+
+        // Release/Reset is the parser's escape hatch for stale escape sequences. While in
+        // bracketed-paste mode it must not silently drop the buffer — but the documented
+        // behavior here is that Release returns to Normal. Verify state, and verify that
+        // input flow resumes cleanly afterward.
+        _parser.Release ();
+
+        Assert.Null (captured);
+        Assert.Equal (AnsiResponseParserState.Normal, _parser.State);
+
+        string output = _parser.ProcessInput ("typed");
+        Assert.Equal ("typed", output);
+    }
 }

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/EscSeqUtilsTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/EscSeqUtilsTests.cs
@@ -22,6 +22,12 @@ public class EscSeqUtilsTests
         Assert.Equal ("\x1b[?1003l\x1b[?1015l\u001b[?1006l", EscSeqUtils.CSI_DisableMouseEvents);
         Assert.Equal ($"{EscSeqUtils.CSI}6n", EscSeqUtils.CSI_RequestCursorPositionReport.Request);
         Assert.Equal ("R", EscSeqUtils.CSI_RequestCursorPositionReport.Terminator);
+
+        // Claude - Opus 4.7
+        Assert.Equal ("\x1b[?2004h", EscSeqUtils.CSI_EnableBracketedPaste);
+        Assert.Equal ("\x1b[?2004l", EscSeqUtils.CSI_DisableBracketedPaste);
+        Assert.Equal ("\x1b[200~", EscSeqUtils.CSI_BracketedPasteStart);
+        Assert.Equal ("\x1b[201~", EscSeqUtils.CSI_BracketedPasteEnd);
     }
 
     [Fact]

--- a/Tests/UnitTestsParallelizable/Input/InputProcessorImplTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/InputProcessorImplTests.cs
@@ -115,6 +115,64 @@ public class InputProcessorImplTests (ITestOutputHelper output)
         Assert.False (fired);
     }
 
+    [Fact]
+    public void ProcessQueue_BracketedPaste_DoesNotFlushWhileBytesContinueArriving ()
+    {
+        VirtualTimeProvider timeProvider = new ();
+        ConcurrentQueue<ConsoleKeyInfo> queue = new ();
+        TestInputProcessor processor = new (queue, true, timeProvider);
+
+        string? captured = null;
+        processor.Paste += (_, text) => captured = text;
+
+        TestInputQueueHelper.EnqueueString (queue, EscSeqUtils.CSI_BracketedPasteStart + "ab");
+        processor.ProcessQueue ();
+
+        Assert.Equal (AnsiResponseParserState.InBracketedPaste, processor.Parser.State);
+        Assert.Null (captured);
+
+        timeProvider.Advance (TimeSpan.FromSeconds (4));
+        TestInputQueueHelper.EnqueueString (queue, "cd");
+        processor.ProcessQueue ();
+
+        Assert.Null (captured);
+
+        timeProvider.Advance (TimeSpan.FromSeconds (4));
+        processor.ProcessQueue ();
+
+        Assert.Null (captured);
+        Assert.Equal (AnsiResponseParserState.InBracketedPaste, processor.Parser.State);
+
+        TestInputQueueHelper.EnqueueString (queue, EscSeqUtils.CSI_BracketedPasteEnd);
+        processor.ProcessQueue ();
+
+        Assert.Equal ("abcd", captured);
+        Assert.Equal (AnsiResponseParserState.Normal, processor.Parser.State);
+    }
+
+    [Fact]
+    public void ProcessQueue_BracketedPaste_FlushesAfterIdleTimeout ()
+    {
+        VirtualTimeProvider timeProvider = new ();
+        ConcurrentQueue<ConsoleKeyInfo> queue = new ();
+        TestInputProcessor processor = new (queue, true, timeProvider);
+
+        string? captured = null;
+        processor.Paste += (_, text) => captured = text;
+
+        TestInputQueueHelper.EnqueueString (queue, EscSeqUtils.CSI_BracketedPasteStart + "stranded");
+        processor.ProcessQueue ();
+
+        Assert.Equal (AnsiResponseParserState.InBracketedPaste, processor.Parser.State);
+        Assert.Null (captured);
+
+        timeProvider.Advance (TimeSpan.FromSeconds (6));
+        processor.ProcessQueue ();
+
+        Assert.Equal ("stranded", captured);
+        Assert.Equal (AnsiResponseParserState.Normal, processor.Parser.State);
+    }
+
     #endregion
 
     #region Surrogate Pair Tests
@@ -649,7 +707,7 @@ internal class TestInputProcessor : InputProcessorImpl<ConsoleKeyInfo>
 {
     private readonly bool _useParser;
 
-    public TestInputProcessor (ConcurrentQueue<ConsoleKeyInfo> inputBuffer, bool useParser = false) : base (inputBuffer, new TestKeyConverter ()) =>
+    public TestInputProcessor (ConcurrentQueue<ConsoleKeyInfo> inputBuffer, bool useParser = false, ITimeProvider? timeProvider = null) : base (inputBuffer, new TestKeyConverter (), timeProvider) =>
         _useParser = useParser;
 
     protected override void Process (ConsoleKeyInfo input)
@@ -663,6 +721,17 @@ internal class TestInputProcessor : InputProcessorImpl<ConsoleKeyInfo>
         {
             // For surrogate pair tests, process directly
             ProcessAfterParsing (input);
+        }
+    }
+}
+
+internal static class TestInputQueueHelper
+{
+    public static void EnqueueString (ConcurrentQueue<ConsoleKeyInfo> queue, string text)
+    {
+        foreach (char c in text)
+        {
+            queue.Enqueue (new ConsoleKeyInfo (c, 0, false, false, false));
         }
     }
 }

--- a/Tests/UnitTestsParallelizable/Input/InputProcessorImplTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/InputProcessorImplTests.cs
@@ -74,6 +74,49 @@ public class InputProcessorImplTests (ITestOutputHelper output)
 
     #endregion
 
+    #region Bracketed Paste Stale Flush
+
+    // Claude - Opus 4.7
+    [Fact]
+    public void FlushStaleBracketedPaste_WhenInPasteState_DispatchesPartialBufferAndResetsToNormal ()
+    {
+        AnsiResponseParser parser = new (new SystemTimeProvider ());
+
+        string? captured = null;
+        parser.Paste += (_, text) => captured = text;
+
+        parser.ProcessInput (EscSeqUtils.CSI_BracketedPasteStart + "stranded");
+        Assert.Equal (AnsiResponseParserState.InBracketedPaste, parser.State);
+        Assert.Null (captured);
+
+        bool flushed = parser.FlushStaleBracketedPaste ();
+
+        Assert.True (flushed);
+        Assert.Equal ("stranded", captured);
+        Assert.Equal (AnsiResponseParserState.Normal, parser.State);
+
+        // Subsequent input flows normally.
+        string output = parser.ProcessInput ("typed");
+        Assert.Equal ("typed", output);
+    }
+
+    // Claude - Opus 4.7
+    [Fact]
+    public void FlushStaleBracketedPaste_WhenNotInPasteState_IsNoOp ()
+    {
+        AnsiResponseParser parser = new (new SystemTimeProvider ());
+
+        var fired = false;
+        parser.Paste += (_, _) => fired = true;
+
+        bool flushed = parser.FlushStaleBracketedPaste ();
+
+        Assert.False (flushed);
+        Assert.False (fired);
+    }
+
+    #endregion
+
     #region Surrogate Pair Tests
 
     // CoPilot: claude-3-7-sonnet-20250219

--- a/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
@@ -10,7 +10,7 @@ public class ViewPasteTests
             Routing = CommandRouting.BubblingUp
         };
 
-        return view.InvokeCommand (Command.Paste, ctx.WithValue (payload));
+        return view.InvokeCommand (Command.Paste, ctx.WithValue (new PastePayload (payload)));
     }
 
     [Fact]
@@ -108,6 +108,19 @@ public class ViewPasteTests
     }
 
     [Fact]
+    public void TextField_Paste_ReadOnly_DoesNotRaisePasted ()
+    {
+        TextField field = new () { Text = "abc", ReadOnly = true };
+        var pastedFired = false;
+        field.Pasted += (_, _) => pastedFired = true;
+
+        bool? handled = InvokePaste (field, "XYZ");
+
+        Assert.True (handled);
+        Assert.False (pastedFired);
+    }
+
+    [Fact]
     public void TextField_Paste_TakesFirstLineOnly ()
     {
         TextField field = new () { Text = string.Empty };
@@ -167,6 +180,19 @@ public class ViewPasteTests
     }
 
     [Fact]
+    public void TextView_Paste_ReadOnly_DoesNotRaisePasted ()
+    {
+        TextView textView = new () { Text = "abc", ReadOnly = true };
+        var pastedFired = false;
+        textView.Pasted += (_, _) => pastedFired = true;
+
+        bool? handled = InvokePaste (textView, "XYZ");
+
+        Assert.True (handled);
+        Assert.False (pastedFired);
+    }
+
+    [Fact]
     public void TextView_Paste_NormalizesCarriageReturnsToLogicalLineBreaks ()
     {
         TextView textView = new () { Text = string.Empty };
@@ -190,6 +216,20 @@ public class ViewPasteTests
     }
 
     [Fact]
+    public void TextView_BracketedPaste_Ignores_CopyWithoutSelection_Mode ()
+    {
+        TextView textView = new () { Text = "abc" };
+        textView.MoveEnd ();
+
+        Assert.True (textView.Copy ());
+
+        bool? handled = InvokePaste (textView, "Z");
+
+        Assert.True (handled);
+        Assert.Equal ("abcZ", textView.Text);
+    }
+
+    [Fact]
     public void EmptyPayload_DoesNotRaisePastingOrPasted ()
     {
         TextField field = new () { Text = string.Empty };
@@ -202,5 +242,46 @@ public class ViewPasteTests
 
         Assert.False (handled);
         Assert.False (anyFired);
+    }
+
+    [Fact]
+    public void ApplicationPaste_Handled_DoesNotDispatchToFocusedView ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        using Runnable runnable = new ();
+        TextField field = new () { Text = string.Empty };
+        var anyFired = false;
+        field.Pasting += (_, _) => anyFired = true;
+        field.Pasted += (_, _) => anyFired = true;
+        runnable.Add (field);
+        app.Begin (runnable);
+        field.SetFocus ();
+        app.Paste += (_, args) => args.Handled = true;
+
+        bool handled = app.RaisePasteEvent ("hello");
+
+        Assert.True (handled);
+        Assert.Equal (string.Empty, field.Text);
+        Assert.False (anyFired);
+    }
+
+    [Fact]
+    public void MenuInitiatedPaste_UsesClipboardText_NotMenuTitle ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.Clipboard = new FakeClipboard ();
+        using Runnable runnable = new ();
+        TextView textView = new () { Text = string.Empty, Width = 20, Height = 5 };
+        runnable.Add (textView);
+        app.Begin (runnable);
+        app.Driver.Clipboard.SetClipboardData ("Hello ");
+        MenuItem menuItem = new (textView, Command.Paste);
+
+        bool? handled = menuItem.InvokeCommand (Command.Activate);
+
+        Assert.False (handled);
+        Assert.Equal ("Hello ", textView.Text);
     }
 }

--- a/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
@@ -153,7 +153,7 @@ public class ViewPasteTests
         TextField field = new () { Text = string.Empty };
 
         // Embed an ESC[31m color sequence and a literal bell character — both must be stripped.
-        bool handled = field.NewPasteEvent (new ("ab[31mcd"));
+        bool handled = field.NewPasteEvent (new ("ab\u001b[31mc\u0007d"));
 
         Assert.True (handled);
         Assert.Equal ("ab[31mcd", field.Text);
@@ -164,22 +164,22 @@ public class ViewPasteTests
     {
         TextField field = new () { Text = "x" };
 
-        bool handled = field.NewPasteEvent (new (""));
+        bool handled = field.NewPasteEvent (new ("\u001b\u0007\u0003"));
 
         Assert.False (handled);
         Assert.Equal ("x", field.Text);
     }
 
     [Fact]
-    public void TextView_OnPasted_NormalizesCarriageReturnToLineFeed ()
+    public void TextView_OnPasted_NormalizesCarriageReturnsToLogicalLineBreaks ()
     {
         TextView textView = new () { Text = string.Empty };
 
-        // Mix of CR (terminal default), CRLF, and bare LF — all should become \n in the model.
+        // Mix of CR (terminal default), CRLF, and bare LF — all should become logical line breaks.
         bool handled = textView.NewPasteEvent (new ("a\rb\r\nc\nd"));
 
         Assert.True (handled);
-        Assert.Equal ("a\nb\nc\nd", textView.Text);
+        Assert.Equal ($"a{Environment.NewLine}b{Environment.NewLine}c{Environment.NewLine}d", textView.Text);
     }
 
     [Fact]
@@ -187,7 +187,7 @@ public class ViewPasteTests
     {
         TextView textView = new () { Text = string.Empty };
 
-        bool handled = textView.NewPasteEvent (new ("a[31mbc\td"));
+        bool handled = textView.NewPasteEvent (new ("a\u001b[31mb\u0007c\td"));
 
         Assert.True (handled);
         Assert.Equal ("a[31mbc\td", textView.Text);

--- a/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
@@ -1,0 +1,151 @@
+namespace ViewBaseTests;
+
+// Claude - Opus 4.7
+public class ViewPasteTests
+{
+    [Fact]
+    public void NewPasteEvent_RaisesPasteEvent ()
+    {
+        View view = new ();
+
+        string? captured = null;
+        view.Pasted += (_, args) => captured = args.Text;
+
+        bool handled = view.NewPasteEvent (new ("hello"));
+
+        Assert.Equal ("hello", captured);
+        Assert.False (handled);
+    }
+
+    [Fact]
+    public void NewPasteEvent_OnPasted_CalledBeforeEvent ()
+    {
+        var subject = new TrackingView ();
+        var raiseOrder = new List<string> ();
+
+        subject.Pasted += (_, _) => raiseOrder.Add ("event");
+        subject.OnPastedCalled = () => raiseOrder.Add ("virtual");
+
+        subject.NewPasteEvent (new ("body"));
+
+        Assert.Equal (["virtual", "event"], raiseOrder);
+    }
+
+    [Fact]
+    public void NewPasteEvent_OnPastedReturnsTrue_ShortCircuits ()
+    {
+        var subject = new TrackingView { OnPastedReturn = true };
+        var eventFired = false;
+        subject.Pasted += (_, _) => eventFired = true;
+
+        bool handled = subject.NewPasteEvent (new ("body"));
+
+        Assert.True (handled);
+        Assert.False (eventFired);
+    }
+
+    [Fact]
+    public void NewPasteEvent_HandledByEvent_BlocksBubbling ()
+    {
+        View parent = new ();
+        View child = new ();
+        parent.Add (child);
+
+        var parentSawPaste = false;
+        parent.Pasted += (_, _) => parentSawPaste = true;
+        child.Pasted += (_, args) => args.Handled = true;
+
+        bool handled = child.NewPasteEvent (new ("x"));
+
+        Assert.True (handled);
+        Assert.False (parentSawPaste);
+    }
+
+    [Fact]
+    public void NewPasteEvent_NotHandled_BubblesToSuperView ()
+    {
+        View parent = new ();
+        View child = new ();
+        parent.Add (child);
+
+        string? parentText = null;
+        parent.Pasted += (_, args) => parentText = args.Text;
+
+        child.NewPasteEvent (new ("bubble"));
+
+        Assert.Equal ("bubble", parentText);
+    }
+
+    [Fact]
+    public void NewPasteEvent_DisabledView_ShortCircuits ()
+    {
+        View view = new () { Enabled = false };
+
+        var fired = false;
+        view.Pasted += (_, _) => fired = true;
+
+        bool handled = view.NewPasteEvent (new ("x"));
+
+        Assert.False (fired);
+        Assert.False (handled);
+    }
+
+    [Fact]
+    public void TextField_OnPasted_InsertsTextAtCursor ()
+    {
+        TextField field = new () { Text = "abc", ReadOnly = false };
+        field.MoveEnd ();
+
+        bool handled = field.NewPasteEvent (new ("XYZ"));
+
+        Assert.True (handled);
+        Assert.Equal ("abcXYZ", field.Text);
+    }
+
+    [Fact]
+    public void TextField_OnPasted_ReadOnly_DoesNotInsert ()
+    {
+        TextField field = new () { Text = "abc", ReadOnly = true };
+
+        bool handled = field.NewPasteEvent (new ("XYZ"));
+
+        Assert.False (handled);
+        Assert.Equal ("abc", field.Text);
+    }
+
+    [Fact]
+    public void TextView_OnPasted_InsertsText ()
+    {
+        TextView textView = new () { Text = "abc", ReadOnly = false };
+        textView.MoveEnd ();
+
+        bool handled = textView.NewPasteEvent (new ("XYZ"));
+
+        Assert.True (handled);
+        Assert.Contains ("XYZ", textView.Text);
+    }
+
+    [Fact]
+    public void TextView_OnPasted_ReadOnly_DoesNotInsert ()
+    {
+        TextView textView = new () { Text = "abc", ReadOnly = true };
+
+        bool handled = textView.NewPasteEvent (new ("XYZ"));
+
+        Assert.False (handled);
+        Assert.Equal ("abc", textView.Text);
+    }
+
+    private class TrackingView : View
+    {
+        public Action? OnPastedCalled { get; set; }
+        public bool OnPastedReturn { get; set; }
+
+        protected override bool OnPasted (PasteEventArgs args)
+        {
+            OnPastedCalled?.Invoke ();
+
+            return OnPastedReturn;
+        }
+    }
+}

--- a/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
@@ -3,206 +3,204 @@ namespace ViewBaseTests;
 // Claude - Opus 4.7
 public class ViewPasteTests
 {
+    private static bool? InvokePaste (View view, string payload)
+    {
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (view), binding: null)
+        {
+            Routing = CommandRouting.BubblingUp
+        };
+
+        return view.InvokeCommand (Command.Paste, ctx.WithValue (payload));
+    }
+
     [Fact]
-    public void NewPasteEvent_RaisesPasteEvent ()
+    public void CommandPaste_RaisesPastingAndPasted_WhenConsumed ()
+    {
+        TextField field = new () { Text = string.Empty };
+
+        var raiseOrder = new List<string> ();
+        field.Pasting += (_, _) => raiseOrder.Add ("pasting");
+        field.Pasted += (_, _) => raiseOrder.Add ("pasted");
+
+        bool? handled = InvokePaste (field, "hello");
+
+        Assert.True (handled);
+        Assert.Equal (["pasting", "pasted"], raiseOrder);
+        Assert.Equal ("hello", field.Text);
+    }
+
+    [Fact]
+    public void Pasting_Cancelled_DoesNotInsertOrRaisePasted ()
+    {
+        TextField field = new () { Text = "x" };
+
+        var pastedFired = false;
+        field.Pasting += (_, args) => args.Handled = true;
+        field.Pasted += (_, _) => pastedFired = true;
+
+        bool? handled = InvokePaste (field, "yz");
+
+        Assert.True (handled);
+        Assert.False (pastedFired);
+        Assert.Equal ("x", field.Text);
+    }
+
+    [Fact]
+    public void Pasting_RewritesText_BeforeInsertion ()
+    {
+        TextField field = new () { Text = string.Empty };
+
+        field.Pasting += (_, args) => args.Text = args.Text.ToUpperInvariant ();
+
+        InvokePaste (field, "abc");
+
+        Assert.Equal ("ABC", field.Text);
+    }
+
+    [Fact]
+    public void View_OnPaste_Default_ReturnsFalse_AndPastedNotRaised ()
     {
         View view = new ();
+        var pastedFired = false;
+        view.Pasted += (_, _) => pastedFired = true;
 
-        string? captured = null;
-        view.Pasted += (_, args) => captured = args.Text;
+        bool? handled = InvokePaste (view, "hello");
 
-        bool handled = view.NewPasteEvent (new ("hello"));
-
-        Assert.Equal ("hello", captured);
+        // Plain View's OnPaste returns false → handler returns false, Pasted not raised.
         Assert.False (handled);
+        Assert.False (pastedFired);
     }
 
     [Fact]
-    public void NewPasteEvent_OnPasted_CalledBeforeEvent ()
+    public void DisabledView_DoesNotPaste ()
     {
-        var subject = new TrackingView ();
-        var raiseOrder = new List<string> ();
+        TextField field = new () { Text = string.Empty, Enabled = false };
 
-        subject.Pasted += (_, _) => raiseOrder.Add ("event");
-        subject.OnPastedCalled = () => raiseOrder.Add ("virtual");
+        bool? handled = InvokePaste (field, "x");
 
-        subject.NewPasteEvent (new ("body"));
-
-        Assert.Equal (["virtual", "event"], raiseOrder);
-    }
-
-    [Fact]
-    public void NewPasteEvent_OnPastedReturnsTrue_ShortCircuits ()
-    {
-        var subject = new TrackingView { OnPastedReturn = true };
-        var eventFired = false;
-        subject.Pasted += (_, _) => eventFired = true;
-
-        bool handled = subject.NewPasteEvent (new ("body"));
-
-        Assert.True (handled);
-        Assert.False (eventFired);
-    }
-
-    [Fact]
-    public void NewPasteEvent_HandledByEvent_BlocksBubbling ()
-    {
-        View parent = new ();
-        View child = new ();
-        parent.Add (child);
-
-        var parentSawPaste = false;
-        parent.Pasted += (_, _) => parentSawPaste = true;
-        child.Pasted += (_, args) => args.Handled = true;
-
-        bool handled = child.NewPasteEvent (new ("x"));
-
-        Assert.True (handled);
-        Assert.False (parentSawPaste);
-    }
-
-    [Fact]
-    public void NewPasteEvent_NotHandled_BubblesToSuperView ()
-    {
-        View parent = new ();
-        View child = new ();
-        parent.Add (child);
-
-        string? parentText = null;
-        parent.Pasted += (_, args) => parentText = args.Text;
-
-        child.NewPasteEvent (new ("bubble"));
-
-        Assert.Equal ("bubble", parentText);
-    }
-
-    [Fact]
-    public void NewPasteEvent_DisabledView_ShortCircuits ()
-    {
-        View view = new () { Enabled = false };
-
-        var fired = false;
-        view.Pasted += (_, _) => fired = true;
-
-        bool handled = view.NewPasteEvent (new ("x"));
-
-        Assert.False (fired);
         Assert.False (handled);
+        Assert.Equal (string.Empty, field.Text);
     }
 
     [Fact]
-    public void TextField_OnPasted_InsertsTextAtCursor ()
+    public void TextField_Paste_InsertsTextAtCursor ()
     {
         TextField field = new () { Text = "abc", ReadOnly = false };
         field.MoveEnd ();
 
-        bool handled = field.NewPasteEvent (new ("XYZ"));
+        bool? handled = InvokePaste (field, "XYZ");
 
         Assert.True (handled);
         Assert.Equal ("abcXYZ", field.Text);
     }
 
     [Fact]
-    public void TextField_OnPasted_ReadOnly_DoesNotInsert ()
+    public void TextField_Paste_ReadOnly_DoesNotInsert ()
     {
         TextField field = new () { Text = "abc", ReadOnly = true };
 
-        bool handled = field.NewPasteEvent (new ("XYZ"));
+        bool? handled = InvokePaste (field, "XYZ");
 
-        Assert.False (handled);
+        // ReadOnly views consume the paste (return true) so Ctrl+V does not bubble, but the text
+        // model is not modified.
+        Assert.True (handled);
         Assert.Equal ("abc", field.Text);
     }
 
     [Fact]
-    public void TextView_OnPasted_InsertsText ()
-    {
-        TextView textView = new () { Text = "abc", ReadOnly = false };
-        textView.MoveEnd ();
-
-        bool handled = textView.NewPasteEvent (new ("XYZ"));
-
-        Assert.True (handled);
-        Assert.Contains ("XYZ", textView.Text);
-    }
-
-    [Fact]
-    public void TextView_OnPasted_ReadOnly_DoesNotInsert ()
-    {
-        TextView textView = new () { Text = "abc", ReadOnly = true };
-
-        bool handled = textView.NewPasteEvent (new ("XYZ"));
-
-        Assert.False (handled);
-        Assert.Equal ("abc", textView.Text);
-    }
-
-    [Fact]
-    public void TextField_OnPasted_TakesFirstLineOnly ()
+    public void TextField_Paste_TakesFirstLineOnly ()
     {
         TextField field = new () { Text = string.Empty };
 
-        bool handled = field.NewPasteEvent (new ("first\nsecond\rthird"));
+        bool? handled = InvokePaste (field, "first\nsecond\rthird");
 
         Assert.True (handled);
         Assert.Equal ("first", field.Text);
     }
 
     [Fact]
-    public void TextField_OnPasted_StripsControlCharsIncludingEscape ()
+    public void TextField_Paste_StripsControlCharsIncludingEscape ()
     {
         TextField field = new () { Text = string.Empty };
 
-        // Embed an ESC[31m color sequence and a literal bell character — both must be stripped.
-        bool handled = field.NewPasteEvent (new ("ab\u001b[31mc\u0007d"));
+        // ESC[31m color sequence and a literal bell — both must be stripped.
+        bool? handled = InvokePaste (field, "ab[31mcd");
 
         Assert.True (handled);
         Assert.Equal ("ab[31mcd", field.Text);
     }
 
     [Fact]
-    public void TextField_OnPasted_AllControlChars_DoesNotInsert ()
+    public void TextField_Paste_AllControlChars_DoesNotInsert ()
     {
         TextField field = new () { Text = "x" };
 
-        bool handled = field.NewPasteEvent (new ("\u001b\u0007\u0003"));
+        bool? handled = InvokePaste (field, "");
 
         Assert.False (handled);
         Assert.Equal ("x", field.Text);
     }
 
     [Fact]
-    public void TextView_OnPasted_NormalizesCarriageReturnsToLogicalLineBreaks ()
+    public void TextView_Paste_InsertsText ()
+    {
+        TextView textView = new () { Text = "abc", ReadOnly = false };
+        textView.MoveEnd ();
+
+        bool? handled = InvokePaste (textView, "XYZ");
+
+        Assert.True (handled);
+        Assert.Contains ("XYZ", textView.Text);
+    }
+
+    [Fact]
+    public void TextView_Paste_ReadOnly_DoesNotInsert ()
+    {
+        TextView textView = new () { Text = "abc", ReadOnly = true };
+
+        bool? handled = InvokePaste (textView, "XYZ");
+
+        // ReadOnly views consume the paste (return true) so Ctrl+V does not bubble, but the text
+        // model is not modified.
+        Assert.True (handled);
+        Assert.Equal ("abc", textView.Text);
+    }
+
+    [Fact]
+    public void TextView_Paste_NormalizesCarriageReturnsToLogicalLineBreaks ()
     {
         TextView textView = new () { Text = string.Empty };
 
-        // Mix of CR (terminal default), CRLF, and bare LF — all should become logical line breaks.
-        bool handled = textView.NewPasteEvent (new ("a\rb\r\nc\nd"));
+        // Mix of CR (terminal default), CRLF, and bare LF — all become logical line breaks.
+        bool? handled = InvokePaste (textView, "a\rb\r\nc\nd");
 
         Assert.True (handled);
         Assert.Equal ($"a{Environment.NewLine}b{Environment.NewLine}c{Environment.NewLine}d", textView.Text);
     }
 
     [Fact]
-    public void TextView_OnPasted_StripsEscapeAndOtherControlChars ()
+    public void TextView_Paste_StripsEscapeAndOtherControlChars ()
     {
         TextView textView = new () { Text = string.Empty };
 
-        bool handled = textView.NewPasteEvent (new ("a\u001b[31mb\u0007c\td"));
+        bool? handled = InvokePaste (textView, "a[31mbc\td");
 
         Assert.True (handled);
         Assert.Equal ("a[31mbc\td", textView.Text);
     }
 
-    private sealed class TrackingView : View
+    [Fact]
+    public void EmptyPayload_DoesNotRaisePastingOrPasted ()
     {
-        public Action? OnPastedCalled { get; set; }
-        public bool OnPastedReturn { get; set; }
+        TextField field = new () { Text = string.Empty };
 
-        protected override bool OnPasted (PasteEventArgs args)
-        {
-            OnPastedCalled?.Invoke ();
+        var anyFired = false;
+        field.Pasting += (_, _) => anyFired = true;
+        field.Pasted += (_, _) => anyFired = true;
 
-            return OnPastedReturn;
-        }
+        bool? handled = InvokePaste (field, string.Empty);
+
+        Assert.False (handled);
+        Assert.False (anyFired);
     }
 }

--- a/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
@@ -136,7 +136,64 @@ public class ViewPasteTests
         Assert.Equal ("abc", textView.Text);
     }
 
-    private class TrackingView : View
+    [Fact]
+    public void TextField_OnPasted_TakesFirstLineOnly ()
+    {
+        TextField field = new () { Text = string.Empty };
+
+        bool handled = field.NewPasteEvent (new ("first\nsecond\rthird"));
+
+        Assert.True (handled);
+        Assert.Equal ("first", field.Text);
+    }
+
+    [Fact]
+    public void TextField_OnPasted_StripsControlCharsIncludingEscape ()
+    {
+        TextField field = new () { Text = string.Empty };
+
+        // Embed an ESC[31m color sequence and a literal bell character — both must be stripped.
+        bool handled = field.NewPasteEvent (new ("ab[31mcd"));
+
+        Assert.True (handled);
+        Assert.Equal ("ab[31mcd", field.Text);
+    }
+
+    [Fact]
+    public void TextField_OnPasted_AllControlChars_DoesNotInsert ()
+    {
+        TextField field = new () { Text = "x" };
+
+        bool handled = field.NewPasteEvent (new (""));
+
+        Assert.False (handled);
+        Assert.Equal ("x", field.Text);
+    }
+
+    [Fact]
+    public void TextView_OnPasted_NormalizesCarriageReturnToLineFeed ()
+    {
+        TextView textView = new () { Text = string.Empty };
+
+        // Mix of CR (terminal default), CRLF, and bare LF — all should become \n in the model.
+        bool handled = textView.NewPasteEvent (new ("a\rb\r\nc\nd"));
+
+        Assert.True (handled);
+        Assert.Equal ("a\nb\nc\nd", textView.Text);
+    }
+
+    [Fact]
+    public void TextView_OnPasted_StripsEscapeAndOtherControlChars ()
+    {
+        TextView textView = new () { Text = string.Empty };
+
+        bool handled = textView.NewPasteEvent (new ("a[31mbc\td"));
+
+        Assert.True (handled);
+        Assert.Equal ("a[31mbc\td", textView.Text);
+    }
+
+    private sealed class TrackingView : View
     {
         public Action? OnPastedCalled { get; set; }
         public bool OnPastedReturn { get; set; }

--- a/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
@@ -1458,6 +1458,286 @@ public class TextFieldTests (ITestOutputHelper output) : TestDriverBase
 
     // Copilot
     [Fact]
+    public void Paste_Uses_Clipboard_Text ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.Clipboard = new FakeClipboard ();
+        using Runnable runnable = new ();
+
+        TextField tf = new () { Width = 40, Text = string.Empty };
+        runnable.Add (tf);
+        app.Begin (runnable);
+
+        app.Driver.Clipboard!.SetClipboardData ("Hello ");
+
+        bool result = tf.Paste ();
+
+        Assert.True (result);
+        Assert.Equal ("Hello ", tf.Text);
+    }
+
+    // Copilot
+    [Fact]
+    public void CtrlV_Pastes_From_Clipboard ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.Clipboard = new FakeClipboard ();
+        using Runnable runnable = new ();
+
+        TextField tf = new () { Width = 40, Text = string.Empty };
+        runnable.Add (tf);
+        app.Begin (runnable);
+        tf.SetFocus ();
+
+        app.Driver.Clipboard!.SetClipboardData ("Hello ");
+
+        bool? result = tf.NewKeyDownEvent (Key.V.WithCtrl);
+
+        Assert.True (result);
+        Assert.Equal ("Hello ", tf.Text);
+    }
+
+    // Copilot
+    [Fact]
+    public void Paste_CancelledByValueChanging_DoesNotRaisePasted_OrMoveCursor ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.Clipboard = new FakeClipboard ();
+        using Runnable runnable = new ();
+
+        TextField tf = new () { Width = 40, Text = "abc" };
+        app.Begin (runnable);
+        runnable.Add (tf);
+        tf.InsertionPoint = 1;
+        tf.SelectedStart = -1;
+
+        int pastedCount = 0;
+        tf.Pasted += (_, _) => pastedCount++;
+        tf.ValueChanging += (_, e) => e.Handled = true;
+
+        app.Driver.Clipboard!.SetClipboardData ("ZZ");
+
+        bool result = tf.Paste ();
+
+        Assert.True (result);
+        Assert.Equal ("abc", tf.Text);
+        Assert.Equal (1, tf.InsertionPoint);
+        Assert.Equal (0, pastedCount);
+    }
+
+    // Copilot
+    [Fact]
+    public void Paste_RewrittenByTextChanging_Raises_Pasted_With_ActualInsertedText ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.Clipboard = new FakeClipboard ();
+        using Runnable runnable = new ();
+
+        TextField tf = new () { Width = 40, Text = string.Empty };
+        runnable.Add (tf);
+        app.Begin (runnable);
+
+        string? pastedText = null;
+        tf.Pasted += (_, e) => pastedText = e.Text;
+        tf.TextChanging += (_, e) => e.Result = e.Result!.ToUpperInvariant ();
+
+        app.Driver.Clipboard!.SetClipboardData ("Hello");
+
+        bool result = tf.Paste ();
+
+        Assert.True (result);
+        Assert.Equal ("HELLO", tf.Text);
+        Assert.Equal ("HELLO", pastedText);
+        Assert.Equal (5, tf.InsertionPoint);
+    }
+
+    // Copilot
+    [Fact]
+    public void Paste_RewrittenByTextChanging_With_Existing_Text_Raises_Only_Inserted_Text ()
+    {
+        TextField tf = new () { Width = 40, Text = "abc" };
+        tf.InsertionPoint = 1;
+        tf.SelectedStart = -1;
+
+        string? pastedText = null;
+        tf.Pasted += (_, e) => pastedText = e.Text;
+        tf.TextChanging += (_, e) => e.Result = e.Result!.ToUpperInvariant ();
+
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (tf), binding: null)
+        {
+            Routing = CommandRouting.BubblingUp
+        };
+
+        bool? result = tf.InvokeCommand (Command.Paste, ctx.WithValue (new PastePayload ("zz")));
+
+        Assert.True (result);
+        Assert.Equal ("AZZBC", tf.Text);
+        Assert.Equal ("ZZ", pastedText);
+        Assert.Equal (3, tf.InsertionPoint);
+    }
+
+    // Copilot
+    [Fact]
+    public void Paste_RewrittenByTextChanging_With_AddedPrefixAndSuffix_Raises_Only_Inserted_Text ()
+    {
+        TextField tf = new () { Width = 40, Text = "abcd" };
+        tf.InsertionPoint = 2;
+        tf.SelectedStart = -1;
+
+        string? pastedText = null;
+        tf.Pasted += (_, e) => pastedText = e.Text;
+        tf.TextChanging += (_, e) => e.Result = $"[{e.Result}]";
+
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (tf), binding: null)
+        {
+            Routing = CommandRouting.BubblingUp
+        };
+
+        bool? result = tf.InvokeCommand (Command.Paste, ctx.WithValue (new PastePayload ("X")));
+
+        Assert.True (result);
+        Assert.Equal ("[abXcd]", tf.Text);
+        Assert.Equal ("X", pastedText);
+        Assert.Equal (4, tf.InsertionPoint);
+    }
+
+    // Copilot
+    [Fact]
+    public void Paste_RewrittenByTextChanging_In_Empty_Field_Excludes_Boundary_Wrappers ()
+    {
+        TextField tf = new () { Width = 40, Text = string.Empty };
+        tf.SelectedStart = -1;
+
+        string? pastedText = null;
+        tf.Pasted += (_, e) => pastedText = e.Text;
+        tf.TextChanging += (_, e) => e.Result = $"[{e.Result}]";
+
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (tf), binding: null)
+        {
+            Routing = CommandRouting.BubblingUp
+        };
+
+        bool? result = tf.InvokeCommand (Command.Paste, ctx.WithValue (new PastePayload ("Hello")));
+
+        Assert.True (result);
+        Assert.Equal ("[Hello]", tf.Text);
+        Assert.Equal ("Hello", pastedText);
+        Assert.Equal (6, tf.InsertionPoint);
+    }
+
+    // Copilot
+    [Fact]
+    public void Paste_Replacing_Selection_With_No_Inserted_Text_Moves_Cursor_To_Selection_Start ()
+    {
+        TextField tf = new () { Width = 40, Text = "abcd" };
+        tf.InsertionPoint = 4;
+        tf.SelectedStart = 2;
+
+        int pastedCount = 0;
+        tf.Pasted += (_, _) => pastedCount++;
+        tf.TextChanging += (_, e) => e.Result = "ab";
+
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (tf), binding: null)
+        {
+            Routing = CommandRouting.BubblingUp
+        };
+
+        bool? result = tf.InvokeCommand (Command.Paste, ctx.WithValue (new PastePayload ("X")));
+
+        Assert.True (result);
+        Assert.Equal ("ab", tf.Text);
+        Assert.Equal (2, tf.InsertionPoint);
+        Assert.Equal (0, pastedCount);
+    }
+
+    // Copilot
+    [Fact]
+    public void Paste_RewrittenWithoutLengthChange_Does_Not_Allocate_Quadratic_Memory ()
+    {
+        const int pasteLength = 3000;
+        const long allocationBudget = 10_000_000;
+
+        TextField tf = new () { Width = 4000, Text = string.Empty };
+        string pasted = new ('a', pasteLength);
+        tf.TextChanging += (_, e) => e.Result = e.Result!.ToUpperInvariant ();
+
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (tf), binding: null)
+        {
+            Routing = CommandRouting.BubblingUp
+        };
+
+        GC.Collect ();
+        GC.WaitForPendingFinalizers ();
+        GC.Collect ();
+
+        long before = GC.GetAllocatedBytesForCurrentThread ();
+
+        bool? result = tf.InvokeCommand (Command.Paste, ctx.WithValue (new PastePayload (pasted)));
+
+        long allocated = GC.GetAllocatedBytesForCurrentThread () - before;
+
+        Assert.True (result);
+        Assert.Equal (pasted.ToUpperInvariant (), tf.Text);
+        Assert.Equal (pasteLength, tf.InsertionPoint);
+        Assert.True (allocated < allocationBudget, $"Allocated {allocated:N0} bytes.");
+    }
+
+    // Copilot
+    [Fact]
+    public void Paste_Pasting_Event_Text_Matches_TextField_Insertable_Text ()
+    {
+        TextField tf = new () { Width = 40, Text = string.Empty };
+
+        string? pastingText = null;
+        string? pastedText = null;
+        tf.Pasting += (_, e) => pastingText = e.Text;
+        tf.Pasted += (_, e) => pastedText = e.Text;
+
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (tf), binding: null)
+        {
+            Routing = CommandRouting.BubblingUp
+        };
+
+        bool? result = tf.InvokeCommand (Command.Paste, ctx.WithValue (new PastePayload ("A\tB")));
+
+        Assert.True (result);
+        Assert.Equal ("AB", tf.Text);
+        Assert.Equal ("AB", pastingText);
+        Assert.Equal ("AB", pastedText);
+    }
+
+    // Copilot
+    [Fact]
+    public void Paste_Replacing_Selection_With_Identical_Text_Clears_Selection_And_Raises_Pasted ()
+    {
+        TextField tf = new () { Width = 40, Text = "abcd" };
+        tf.InsertionPoint = 3;
+        tf.SelectedStart = 1;
+
+        string? pastedText = null;
+        tf.Pasted += (_, e) => pastedText = e.Text;
+
+        CommandContext ctx = new (Command.Paste, new WeakReference<View> (tf), binding: null)
+        {
+            Routing = CommandRouting.BubblingUp
+        };
+
+        bool? result = tf.InvokeCommand (Command.Paste, ctx.WithValue (new PastePayload ("bc")));
+
+        Assert.True (result);
+        Assert.Equal ("abcd", tf.Text);
+        Assert.Equal (3, tf.InsertionPoint);
+        Assert.Equal (0, tf.SelectedLength);
+        Assert.Null (tf.SelectedText);
+        Assert.Equal ("bc", pastedText);
+    }
+
+    // Copilot
+    [Fact]
     public void UnifiedKeyBindings_NonWindows_Undo_Redo ()
     {
         if (PlatformDetection.IsWindows ())

--- a/docfx/docs/bracketed-paste.md
+++ b/docfx/docs/bracketed-paste.md
@@ -1,0 +1,55 @@
+# Bracketed Paste
+
+Terminal.Gui supports the ANSI [bracketed paste mode](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-Functions-using-CSI-_-ordered-by-the-final-character-s) (`DECSET 2004`). When the terminal has bracketed paste enabled, the terminal wraps clipboard pastes with the marker pair `ESC[200~` and `ESC[201~`. This lets the application distinguish a paste from typed input — useful for performance (a 10 KB paste arrives as one event instead of 10,000 keystrokes) and for security (the application does not have to interpret pasted text as commands or shortcuts).
+
+Bracketed paste mode is enabled automatically by the driver when the application initializes and disabled on shutdown. Applications do not need to opt in.
+
+## Receiving paste events
+
+Subscribe to <xref:Terminal.Gui.App.IApplication.Paste> to receive paste payloads at the application level:
+
+```csharp
+app.Paste += (sender, args) =>
+              {
+                  myLog.AppendLine ($"Pasted {args.Text.Length} characters");
+                  // Set args.Handled = true to stop further dispatch.
+              };
+```
+
+The <xref:Terminal.Gui.Input.PasteEventArgs.Text> property contains the raw text the terminal delivered between the start and end markers. The bracketing markers themselves are stripped by the parser.
+
+If the application event is not handled, the paste is dispatched to the focused view via <xref:Terminal.Gui.ViewBase.View.NewPasteEvent(Terminal.Gui.Input.PasteEventArgs)>. Views can override <xref:Terminal.Gui.ViewBase.View.OnPasted(Terminal.Gui.Input.PasteEventArgs)> to provide default paste handling, or subscribe to the <xref:Terminal.Gui.ViewBase.View.Pasted> event. Unhandled pastes bubble up to the SuperView.
+
+## Default behavior in TextField / TextView
+
+`TextField` is a single-line control. When it receives a paste it takes the first line only (splitting on `\r` or `\n`) and strips C0 / C1 control characters except tab. This matches the behavior of the existing clipboard-paste command.
+
+`TextView` is multi-line. It accepts the full payload, normalizing `\r` and `\r\n` line breaks to `\n`, and strips C0 / C1 control characters except tab and newline. This mirrors [Windows Terminal's `FilterStringForPaste`](https://github.com/microsoft/terminal/blob/main/src/types/utils.cpp).
+
+To pass the raw payload through unmodified, subscribe to <xref:Terminal.Gui.ViewBase.View.Pasted> instead of relying on the default `OnPasted` — the event is raised after the virtual method, so a subscriber that sets `Handled = true` after the default insertion will only stop further bubbling, not undo the insertion. To override the default, subclass the view and override `OnPasted`.
+
+## Terminals without bracketed paste support
+
+On terminals that do not support bracketed paste mode (older versions of `xterm` without the feature compiled in, or terminals where the user has explicitly disabled it), the markers never arrive. The paste flows through as ordinary key events and the `Paste` event never fires. No probing or fallback is needed.
+
+## Stranded pastes
+
+If the terminal sends `ESC[200~` but the matching `ESC[201~` is dropped (broken connection, terminated remote shell), the parser would otherwise hold the buffered paste content forever. Terminal.Gui flushes the partial buffer as a `Paste` event after a 5-second idle timeout so input flow resumes. There is also a hard cap of 1 MiB on the paste buffer size; payloads exceeding it are truncated.
+
+## Security considerations
+
+Terminal.Gui trusts the *terminal* to sanitize the paste payload. Terminals such as xterm, Windows Terminal, Alacritty, and kitty already strip dangerous control sequences from the clipboard before bracketing — see [`xterm` `allowPasteControls`](https://invisible-island.net/xterm/xterm-paste64.html), [Windows Terminal `FilterStringForPaste`](https://github.com/microsoft/terminal/blob/main/src/types/utils.cpp), and [Alacritty's pre-bracket filter](https://github.com/alacritty/alacritty/blob/master/alacritty/src/event.rs).
+
+For defense in depth, Terminal.Gui's default `OnPasted` implementations on `TextField` and `TextView` strip C0 / C1 control characters before inserting. Applications that consume the raw `Application.Paste` event are responsible for their own sanitization.
+
+## Disabling bracketed paste
+
+To opt out, intercept the driver setup and skip the enable sequence. The relevant constant is <xref:Terminal.Gui.Drivers.EscSeqUtils.CSI_EnableBracketedPaste>. There is no built-in application-level toggle; if you have a need for one, file a feature request.
+
+## Related
+
+- <xref:Terminal.Gui.App.IApplication.Paste> — application-level event
+- <xref:Terminal.Gui.ViewBase.View.Pasted> — view-level event
+- <xref:Terminal.Gui.ViewBase.View.OnPasted(Terminal.Gui.Input.PasteEventArgs)> — view virtual method
+- <xref:Terminal.Gui.Input.PasteEventArgs> — event arguments
+- <xref:Terminal.Gui.Drivers.EscSeqUtils.CSI_EnableBracketedPaste> / <xref:Terminal.Gui.Drivers.EscSeqUtils.CSI_DisableBracketedPaste> — driver-level constants

--- a/docfx/docs/bracketed-paste.md
+++ b/docfx/docs/bracketed-paste.md
@@ -4,29 +4,90 @@ Terminal.Gui supports the ANSI [bracketed paste mode](https://invisible-island.n
 
 Bracketed paste mode is enabled automatically by the driver when the application initializes and disabled on shutdown. Applications do not need to opt in.
 
+## Architecture: bracketed paste shares the `Command.Paste` pipeline
+
+Bracketed paste and keyboard-driven paste (`Ctrl+V`) route through the same command pipeline:
+
+```
+driver bytes  ──►  AnsiResponseParser ──►  IApplication.Paste (event, raw payload)
+                                       │
+                                       ▼
+                              focused view.InvokeCommand (Command.Paste, ctx.WithValue (payload))
+                                       │
+                                       ▼
+              ┌─────────────────  default Command.Paste handler  ─────────────────┐
+              │  payload = ctx.Value as string  ??  App.Clipboard.GetClipboardData()│
+              │  sanitized = OnSanitizingPaste (payload)                            │
+              │  raise  Pasting  (cancellable, mutable Text)                        │
+              │  if not cancelled:  consumed = OnPaste (sanitized)                  │
+              │  if consumed:  raise  Pasted                                        │
+              └─────────────────────────────────────────────────────────────────────┘
+```
+
+The same handler serves both bracketed paste (payload travels via `CommandContext.Values`) and keyboard `Ctrl+V` (no payload → clipboard fallback). Bubbling, cancellation, and command routing come from the existing `View.InvokeCommand` machinery — there is no parallel paste dispatch path.
+
 ## Receiving paste events
 
-Subscribe to <xref:Terminal.Gui.App.IApplication.Paste> to receive paste payloads at the application level:
+There are three places to hook in, in order of dispatch:
+
+### 1. `Application.Paste` — raw, app-wide
 
 ```csharp
-app.Paste += (sender, args) =>
+app.Paste += (_, args) =>
               {
                   myLog.AppendLine ($"Pasted {args.Text.Length} characters");
                   // Set args.Handled = true to stop further dispatch.
               };
 ```
 
-The <xref:Terminal.Gui.Input.PasteEventArgs.Text> property contains the raw text the terminal delivered between the start and end markers. The bracketing markers themselves are stripped by the parser.
+Subscribers see the raw terminal-delivered payload before any sanitization. Cancelling here prevents the paste from reaching any view.
 
-If the application event is not handled, the paste is dispatched to the focused view via <xref:Terminal.Gui.ViewBase.View.NewPasteEvent(Terminal.Gui.Input.PasteEventArgs)>. Views can override <xref:Terminal.Gui.ViewBase.View.OnPasted(Terminal.Gui.Input.PasteEventArgs)> to provide default paste handling, or subscribe to the <xref:Terminal.Gui.ViewBase.View.Pasted> event. Unhandled pastes bubble up to the SuperView.
+### 2. `View.Pasting` — sanitized, cancellable, mutable
+
+```csharp
+field.Pasting += (_, args) =>
+                  {
+                      // args.Text is already sanitized. Rewrite it, or cancel.
+                      args.Text = args.Text.Trim ();
+                      // args.Handled = true   // cancel insertion
+                  };
+```
+
+Raised after the default handler resolves the payload and calls `OnSanitizingPaste`. Subscribers may rewrite `args.Text` to alter what gets inserted, or set `Handled` to cancel.
+
+### 3. `View.Pasted` — observation only
+
+```csharp
+field.Pasted += (_, args) => log.AppendLine ($"Inserted: {args.Text}");
+```
+
+Raised after `OnPaste` has consumed the paste.
+
+## Customizing paste behavior in a custom view
+
+The default `View` declines pastes (its `OnPaste` returns `false`). Text-input views override two virtual methods:
+
+```csharp
+protected override string OnSanitizingPaste (string raw)
+{
+    // Return the text you want inserted. Strip controls, normalize line
+    // endings, etc. Default implementation strips C0/C1 controls except \t \n \r.
+}
+
+protected override bool OnPaste (string sanitized)
+{
+    // Insert the sanitized text. Return true if you consumed the paste.
+}
+```
 
 ## Default behavior in TextField / TextView
 
-`TextField` is a single-line control. When it receives a paste it takes the first line only (splitting on `\r` or `\n`) and strips C0 / C1 control characters except tab. This matches the behavior of the existing clipboard-paste command.
+| View        | `OnSanitizingPaste`                                                          | `OnPaste`                                  |
+|-------------|------------------------------------------------------------------------------|--------------------------------------------|
+| `TextField` | First line only, strip C0/C1 controls (tab kept).                            | Insert at cursor; respects `ReadOnly`.     |
+| `TextView`  | Normalize `\r` and `\r\n` to `\n`; strip C0/C1 controls except tab/newline. | Insert (multi-line aware); respects `ReadOnly`. |
 
-`TextView` is multi-line. It accepts the full payload, normalizing `\r` and `\r\n` into logical line breaks in the text model, and strips C0 / C1 control characters except tab and newline. This mirrors [Windows Terminal's `FilterStringForPaste`](https://github.com/microsoft/terminal/blob/main/src/types/utils.cpp).
-
-To pass the raw payload through unmodified, subscribe to <xref:Terminal.Gui.ViewBase.View.Pasted> instead of relying on the default `OnPasted` — the event is raised after the virtual method, so a subscriber that sets `Handled = true` after the default insertion will only stop further bubbling, not undo the insertion. To override the default, subclass the view and override `OnPasted`.
+`TextField`'s "first line only" matches the legacy clipboard `Paste` command. `TextView`'s line-ending normalization mirrors [Windows Terminal's `FilterStringForPaste`](https://github.com/microsoft/terminal/blob/main/src/types/utils.cpp).
 
 ## Terminals without bracketed paste support
 
@@ -40,7 +101,7 @@ If the terminal sends `ESC[200~` but the matching `ESC[201~` is dropped (broken 
 
 Terminal.Gui trusts the *terminal* to sanitize the paste payload. Terminals such as xterm, Windows Terminal, Alacritty, and kitty already strip dangerous control sequences from the clipboard before bracketing — see [`xterm` `allowPasteControls`](https://invisible-island.net/xterm/xterm-paste64.html), [Windows Terminal `FilterStringForPaste`](https://github.com/microsoft/terminal/blob/main/src/types/utils.cpp), and [Alacritty's pre-bracket filter](https://github.com/alacritty/alacritty/blob/master/alacritty/src/event.rs).
 
-For defense in depth, Terminal.Gui's default `OnPasted` implementations on `TextField` and `TextView` strip C0 / C1 control characters before inserting. Applications that consume the raw `Application.Paste` event are responsible for their own sanitization.
+For defense in depth, the default `View.OnSanitizingPaste` strips C0/C1 control characters before inserting. `TextField` and `TextView` apply additional view-specific sanitization. Applications that consume the raw `Application.Paste` event are responsible for their own sanitization.
 
 ## Disabling bracketed paste
 
@@ -48,8 +109,13 @@ To opt out, intercept the driver setup and skip the enable sequence. The relevan
 
 ## Related
 
-- <xref:Terminal.Gui.App.IApplication.Paste> — application-level event
-- <xref:Terminal.Gui.ViewBase.View.Pasted> — view-level event
-- <xref:Terminal.Gui.ViewBase.View.OnPasted(Terminal.Gui.Input.PasteEventArgs)> — view virtual method
-- <xref:Terminal.Gui.Input.PasteEventArgs> — event arguments
+- <xref:Terminal.Gui.App.IApplication.Paste> — application-level event (raw payload)
+- <xref:Terminal.Gui.ViewBase.View.Pasting> — cancellable view event, mutable `Text`
+- <xref:Terminal.Gui.ViewBase.View.Pasted> — view event after insertion
+- <xref:Terminal.Gui.ViewBase.View.OnSanitizingPaste(System.String)> — view virtual hook for filtering
+- <xref:Terminal.Gui.ViewBase.View.OnPaste(System.String)> — view virtual hook for insertion
+- <xref:Terminal.Gui.Input.Command.Paste> — the canonical paste command
+- <xref:Terminal.Gui.Input.PasteEventArgs> — `IApplication.Paste` arguments
+- <xref:Terminal.Gui.Input.PastingEventArgs> — `View.Pasting` arguments
+- <xref:Terminal.Gui.Input.PastedEventArgs> — `View.Pasted` arguments
 - <xref:Terminal.Gui.Drivers.EscSeqUtils.CSI_EnableBracketedPaste> / <xref:Terminal.Gui.Drivers.EscSeqUtils.CSI_DisableBracketedPaste> — driver-level constants

--- a/docfx/docs/bracketed-paste.md
+++ b/docfx/docs/bracketed-paste.md
@@ -24,7 +24,7 @@ If the application event is not handled, the paste is dispatched to the focused 
 
 `TextField` is a single-line control. When it receives a paste it takes the first line only (splitting on `\r` or `\n`) and strips C0 / C1 control characters except tab. This matches the behavior of the existing clipboard-paste command.
 
-`TextView` is multi-line. It accepts the full payload, normalizing `\r` and `\r\n` line breaks to `\n`, and strips C0 / C1 control characters except tab and newline. This mirrors [Windows Terminal's `FilterStringForPaste`](https://github.com/microsoft/terminal/blob/main/src/types/utils.cpp).
+`TextView` is multi-line. It accepts the full payload, normalizing `\r` and `\r\n` into logical line breaks in the text model, and strips C0 / C1 control characters except tab and newline. This mirrors [Windows Terminal's `FilterStringForPaste`](https://github.com/microsoft/terminal/blob/main/src/types/utils.cpp).
 
 To pass the raw payload through unmodified, subscribe to <xref:Terminal.Gui.ViewBase.View.Pasted> instead of relying on the default `OnPasted` — the event is raised after the virtual method, so a subscriber that sets `Handled = true` after the default insertion will only stop further bubbling, not undo the insertion. To override the default, subclass the view and override `OnPasted`.
 
@@ -34,7 +34,7 @@ On terminals that do not support bracketed paste mode (older versions of `xterm`
 
 ## Stranded pastes
 
-If the terminal sends `ESC[200~` but the matching `ESC[201~` is dropped (broken connection, terminated remote shell), the parser would otherwise hold the buffered paste content forever. Terminal.Gui flushes the partial buffer as a `Paste` event after a 5-second idle timeout so input flow resumes. There is also a hard cap of 1 MiB on the paste buffer size; payloads exceeding it are truncated.
+If the terminal sends `ESC[200~` but the matching `ESC[201~` is dropped (broken connection, terminated remote shell), the parser would otherwise hold the buffered paste content forever. Terminal.Gui flushes the partial buffer as a `Paste` event after a 5-second idle timeout measured from the most recent paste byte so an active slow paste is not cut off prematurely. There is also a hard cap of 1 MiB on the paste buffer size; payloads exceeding it are truncated, and the remaining bytes are discarded until the matching end marker arrives so tail bytes do not leak into normal input processing.
 
 ## Security considerations
 

--- a/docfx/docs/bracketed-paste.md
+++ b/docfx/docs/bracketed-paste.md
@@ -12,19 +12,19 @@ Bracketed paste and keyboard-driven paste (`Ctrl+V`) route through the same comm
 driver bytes  ──►  AnsiResponseParser ──►  IApplication.Paste (event, raw payload)
                                        │
                                        ▼
-                              focused view.InvokeCommand (Command.Paste, ctx.WithValue (payload))
+                              focused view.InvokeCommand (Command.Paste, ctx.WithValue (PastePayload (payload)))
                                        │
                                        ▼
               ┌─────────────────  default Command.Paste handler  ─────────────────┐
-              │  payload = ctx.Value as string  ??  App.Clipboard.GetClipboardData()│
+              │  payload = ctx.Value is PastePayload p ? p.Text : clipboard        │
               │  sanitized = OnSanitizingPaste (payload)                            │
               │  raise  Pasting  (cancellable, mutable Text)                        │
               │  if not cancelled:  consumed = OnPaste (sanitized)                  │
-              │  if consumed:  raise  Pasted                                        │
+              │  if inserted:  raise  Pasted                                        │
               └─────────────────────────────────────────────────────────────────────┘
 ```
 
-The same handler serves both bracketed paste (payload travels via `CommandContext.Values`) and keyboard `Ctrl+V` (no payload → clipboard fallback). Bubbling, cancellation, and command routing come from the existing `View.InvokeCommand` machinery — there is no parallel paste dispatch path.
+The same handler serves both bracketed paste (payload travels in a dedicated command-context paste payload) and keyboard `Ctrl+V` (no payload → clipboard fallback). There is no parallel paste dispatch path.
 
 ## Receiving paste events
 
@@ -84,7 +84,7 @@ protected override bool OnPaste (string sanitized)
 
 | View        | `OnSanitizingPaste`                                                          | `OnPaste`                                  |
 |-------------|------------------------------------------------------------------------------|--------------------------------------------|
-| `TextField` | First line only, strip C0/C1 controls (tab kept).                            | Insert at cursor; respects `ReadOnly`.     |
+| `TextField` | First line only, strip C0/C1 controls (including tab).                      | Insert at cursor; respects `ReadOnly`.     |
 | `TextView`  | Normalize `\r` and `\r\n` to `\n`; strip C0/C1 controls except tab/newline. | Insert (multi-line aware); respects `ReadOnly`. |
 
 `TextField`'s "first line only" matches the legacy clipboard `Paste` command. `TextView`'s line-ending normalization mirrors [Windows Terminal's `FilterStringForPaste`](https://github.com/microsoft/terminal/blob/main/src/types/utils.cpp).

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -20,6 +20,8 @@
   href: arrangement.md
 - name: Borders
   href: borders.md
+- name: Bracketed Paste
+  href: bracketed-paste.md
 - name: Cancellable Work Pattern
   href: cancellable-work-pattern.md
 - name: Command


### PR DESCRIPTION
- Fixes #5144

## Summary

Adds support for the ANSI bracketed-paste mode (DECSET 2004) so apps can distinguish a clipboard paste from typed input. Pastes arrive as a single event instead of N synthetic keystrokes.

The driver enables `ESC[?2004h` at startup and disables it on shutdown / suspend / alt-screen exit. The existing `AnsiResponseParser` gains a new `InBracketedPaste` state that detects `ESC[200~`, accumulates raw bytes (including escapes and control chars) until `ESC[201~`, and raises a `Paste` event with the stripped payload. The event flows: parser → `InputProcessor` → `IDriver.Paste` → `IApplication.Paste` (via cancellable `PasteEventArgs`) → focused `View.NewPasteEvent` → `View.OnPasted` → `View.Pasted` event → bubble to `SuperView`.

`TextField.OnPasted` and `TextView.OnPasted` are wired with sensible defaults that match Windows Terminal's `FilterStringForPaste`: `TextField` takes the first line and strips C0/C1 control characters; `TextView` normalizes `\r` and `\r\n` to `\n` and strips control characters except tab and newline. Apps that want raw payloads can subscribe to `Application.Paste` directly — sanitization lives in the widget defaults, not the event.

A 5-second idle flush in `InputProcessorImpl.ProcessQueue` recovers from terminals that drop the end marker. A 1 MiB hard cap protects against runaway buffers.

On terminals that don't support 2004, the markers never arrive and pastes flow through the normal key pipeline as before — no probing, no fallback configuration needed.

## Design

The behavior was cross-checked against other libraries and terminals to get best practices, including Bubble Tea (`charmbracelet/x/input`), Windows Terminal (`Utils::FilterStringForPaste`), xterm.js, Alacritty, kitty, and the xterm spec. 

Findings:
- Application-side libraries trust the terminal to sanitize and deliver raw bytes — same model here at the `Application.Paste` layer.
- Terminals (WT, Alacritty, xterm.js) sanitize before bracketing — defense-in-depth at the widget layer mirrors that.
- Newline normalization is required because terminals send `\r` for paste line breaks (some send `\r\n`); xterm.js, WT, and `TextView` here all normalize. - `TextField`'s "first line only" matches the existing clipboard `Paste()` command on the same control.

See `docfx/docs/bracketed-paste.md` for the full user-facing model and security notes.

## What's in the PR

- Parser: `AnsiResponseParserBase` state machine + `Paste` event + `FlushStaleBracketedPaste`
- Driver: enable/disable wiring in `AnsiOutput`, `NetInput`, `NetOutput.Suspend`, `UnixTerminalHelper.Suspend`
- API: `IDriver.Paste`, `IInputProcessor.Paste`, `IApplication.Paste`, `PasteEventArgs`, `View.NewPasteEvent` / `OnPasted` / `Pasted`
- Defaults: `TextField.OnPasted`, `TextView.OnPasted`
- Tests: 26 new tests in `UnitTests.Parallelizable` covering parser state machine (start/end split at every byte boundary, back-to-back pastes, nested literal start markers, mid-paste reset, oversize truncation, stale flush) and view dispatch (CWP order, handled short-circuit, bubbling, disabled views, `TextField`/`TextView` sanitization)
- UICatalog: `BracketedPasteDemo` scenario in the Input category
- Docs: `docfx/docs/bracketed-paste.md` linked from the TOC

## Verification

- `dotnet build` clean — 0 warnings, 0 errors
- `dotnet test --project Tests/UnitTestsParallelizable` — 16,871 passed, 17 skipped, 0 failed

# To pull down this PR locally:
git remote add copilot https://github.com/harder/Terminal.Gui.git
git fetch copilot feat/5144-bracketed-paste
git checkout copilot/feat/5144-bracketed-paste
