### PR TITLE
Fixes #5127. Anchor button delimiters to edges; fix highlight continuity

### DIFF
--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -241,13 +241,62 @@ public class Button : View, IDesignable, IAcceptTarget
         Attribute hotAttr = HasFocus ? GetAttributeForRole (VisualRole.HotFocus) : GetAttributeForRole (VisualRole.HotNormal);
         string interiorText = GetInteriorText ();
 
-        _interiorTextFormatter.Text = interiorText;
-        _interiorTextFormatter.Alignment = TextAlignment;
-        _interiorTextFormatter.VerticalAlignment = VerticalTextAlignment;
-        _interiorTextFormatter.Direction = TextDirection;
-        _interiorTextFormatter.PreserveTrailingSpaces = PreserveTrailingSpaces;
-        _interiorTextFormatter.ConstrainToWidth = interiorRect.Width;
-        _interiorTextFormatter.ConstrainToHeight = interiorRect.Height;
+        // Mirror all TextFormatter settings onto _interiorTextFormatter. Guard each assignment
+        // so NeedsFormat is not set when a value is unchanged.
+        if (_interiorTextFormatter.Text != interiorText)
+        {
+            _interiorTextFormatter.Text = interiorText;
+        }
+
+        if (_interiorTextFormatter.Alignment != TextAlignment)
+        {
+            _interiorTextFormatter.Alignment = TextAlignment;
+        }
+
+        if (_interiorTextFormatter.VerticalAlignment != VerticalTextAlignment)
+        {
+            _interiorTextFormatter.VerticalAlignment = VerticalTextAlignment;
+        }
+
+        if (_interiorTextFormatter.Direction != TextDirection)
+        {
+            _interiorTextFormatter.Direction = TextDirection;
+        }
+
+        if (_interiorTextFormatter.PreserveTrailingSpaces != PreserveTrailingSpaces)
+        {
+            _interiorTextFormatter.PreserveTrailingSpaces = PreserveTrailingSpaces;
+        }
+
+        if (_interiorTextFormatter.MultiLine != TextFormatter.MultiLine)
+        {
+            _interiorTextFormatter.MultiLine = TextFormatter.MultiLine;
+        }
+
+        if (_interiorTextFormatter.WordWrap != TextFormatter.WordWrap)
+        {
+            _interiorTextFormatter.WordWrap = TextFormatter.WordWrap;
+        }
+
+        if (_interiorTextFormatter.TabWidth != TextFormatter.TabWidth)
+        {
+            _interiorTextFormatter.TabWidth = TextFormatter.TabWidth;
+        }
+
+        if (_interiorTextFormatter.PreserveTabs != TextFormatter.PreserveTabs)
+        {
+            _interiorTextFormatter.PreserveTabs = TextFormatter.PreserveTabs;
+        }
+
+        if (_interiorTextFormatter.ConstrainToWidth != interiorRect.Width)
+        {
+            _interiorTextFormatter.ConstrainToWidth = interiorRect.Width;
+        }
+
+        if (_interiorTextFormatter.ConstrainToHeight != interiorRect.Height)
+        {
+            _interiorTextFormatter.ConstrainToHeight = interiorRect.Height;
+        }
 
         Region? interiorDrawRegion = (interiorRect.Width > 0 && !string.IsNullOrEmpty (interiorText))
             ? _interiorTextFormatter.GetDrawRegion (interiorRect)

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -268,6 +268,13 @@ public class Button : View, IDesignable, IAcceptTarget
         Driver.SetAttribute (normalAttr);
         Driver.AddRune (_rightBracket);
 
+        if (interiorRect.Width > 0)
+        {
+            Driver.Move (interiorRect.X, delimiterRow);
+            Driver.SetAttribute (normalAttr);
+            Driver.AddStr (new string (' ', interiorRect.Width));
+        }
+
         if (interiorRect.Width > 0 && !string.IsNullOrEmpty (interiorText))
         {
             _interiorTextFormatter.Draw (Driver, interiorRect, normalAttr, hotAttr, Rectangle.Empty);

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -43,6 +43,7 @@
 /// </remarks>
 public class Button : View, IDesignable, IAcceptTarget
 {
+    private readonly TextFormatter _interiorTextFormatter = new ();
     private readonly Rune _leftBracket;
     private readonly Rune _leftDefault;
     private readonly Rune _rightBracket;
@@ -70,6 +71,10 @@ public class Button : View, IDesignable, IAcceptTarget
         _rightBracket = Glyphs.RightBracket;
         _leftDefault = Glyphs.LeftDefaultIndicator;
         _rightDefault = Glyphs.RightDefaultIndicator;
+
+        _interiorTextFormatter.Alignment = Alignment.Center;
+        _interiorTextFormatter.VerticalAlignment = Alignment.Center;
+        _interiorTextFormatter.HotKeySpecifier = HotKeySpecifier;
 
         Height = Dim.Auto (DimAutoStyle.Text);
         Width = Dim.Auto (DimAutoStyle.Text);
@@ -167,13 +172,18 @@ public class Button : View, IDesignable, IAcceptTarget
     {
         base.Text = e.Value;
         TextFormatter.HotKeySpecifier = HotKeySpecifier;
+        _interiorTextFormatter.HotKeySpecifier = HotKeySpecifier;
     }
 
     /// <inheritdoc/>
     public override string Text { get => Title; set => base.Text = Title = value; }
 
     /// <inheritdoc/>
-    public override Rune HotKeySpecifier { get => base.HotKeySpecifier; set => TextFormatter.HotKeySpecifier = base.HotKeySpecifier = value; }
+    public override Rune HotKeySpecifier
+    {
+        get => base.HotKeySpecifier;
+        set => _interiorTextFormatter.HotKeySpecifier = TextFormatter.HotKeySpecifier = base.HotKeySpecifier = value;
+    }
 
     /// <inheritdoc/>
     public bool IsDefault
@@ -208,26 +218,64 @@ public class Button : View, IDesignable, IAcceptTarget
     protected override void UpdateTextFormatterText ()
     {
         base.UpdateTextFormatterText ();
+        TextFormatter.Text = GetDecoratedText ();
+    }
 
-        if (NoDecorations)
+    /// <inheritdoc/>
+    protected override bool OnDrawingText (DrawContext? context)
+    {
+        if (NoDecorations || Driver is null)
         {
-            TextFormatter.Text = Text;
+            return base.OnDrawingText (context);
         }
-        else if (IsDefault)
+
+        Rectangle drawRect = new (ContentToScreen (Point.Empty), GetContentSize ());
+
+        if (drawRect.Width < 2 || drawRect.Height < 1)
         {
-            TextFormatter.Text = $"{_leftBracket}{_leftDefault} {Text} {_rightDefault}{_rightBracket}";
+            return base.OnDrawingText (context);
         }
-        else
+
+        Rectangle interiorRect = new (drawRect.X + 1, drawRect.Y, drawRect.Width - 2, drawRect.Height);
+        Attribute normalAttr = HasFocus ? GetAttributeForRole (VisualRole.Focus) : GetAttributeForRole (VisualRole.Normal);
+        Attribute hotAttr = HasFocus ? GetAttributeForRole (VisualRole.HotFocus) : GetAttributeForRole (VisualRole.HotNormal);
+        string interiorText = GetInteriorText ();
+
+        _interiorTextFormatter.Text = interiorText;
+        _interiorTextFormatter.Alignment = TextAlignment;
+        _interiorTextFormatter.VerticalAlignment = VerticalTextAlignment;
+        _interiorTextFormatter.Direction = TextDirection;
+        _interiorTextFormatter.PreserveTrailingSpaces = PreserveTrailingSpaces;
+        _interiorTextFormatter.ConstrainToWidth = interiorRect.Width;
+        _interiorTextFormatter.ConstrainToHeight = interiorRect.Height;
+
+        Region drawRegion = new (drawRect);
+
+        if (interiorRect.Width > 0 && !string.IsNullOrEmpty (interiorText))
         {
-            if (NoPadding)
-            {
-                TextFormatter.Text = $"{_leftBracket}{Text}{_rightBracket}";
-            }
-            else
-            {
-                TextFormatter.Text = $"{_leftBracket} {Text} {_rightBracket}";
-            }
+            drawRegion.Combine (_interiorTextFormatter.GetDrawRegion (interiorRect), RegionOp.Union);
         }
+
+        context?.AddDrawnRegion (drawRegion);
+
+        int delimiterRow = GetDelimiterRow (drawRect, interiorRect, interiorText);
+
+        Driver.Move (drawRect.X, delimiterRow);
+        Driver.SetAttribute (normalAttr);
+        Driver.AddRune (_leftBracket);
+
+        Driver.Move (drawRect.X + drawRect.Width - 1, delimiterRow);
+        Driver.SetAttribute (normalAttr);
+        Driver.AddRune (_rightBracket);
+
+        if (interiorRect.Width > 0 && !string.IsNullOrEmpty (interiorText))
+        {
+            _interiorTextFormatter.Draw (Driver, interiorRect, normalAttr, hotAttr, Rectangle.Empty);
+        }
+
+        SetSubViewNeedsDrawDownHierarchy ();
+
+        return true;
     }
 
     /// <inheritdoc/>
@@ -236,5 +284,50 @@ public class Button : View, IDesignable, IAcceptTarget
         Title = "_Button";
 
         return true;
+    }
+
+    private string GetDecoratedText ()
+    {
+        if (NoDecorations)
+        {
+            return Text;
+        }
+
+        return $"{_leftBracket}{GetInteriorText ()}{_rightBracket}";
+    }
+
+    private string GetInteriorText ()
+    {
+        if (IsDefault)
+        {
+            return $"{_leftDefault} {Text} {_rightDefault}";
+        }
+
+        if (NoPadding)
+        {
+            return Text;
+        }
+
+        return $" {Text} ";
+    }
+
+    private int GetDelimiterRow (Rectangle drawRect, Rectangle interiorRect, string interiorText)
+    {
+        if (interiorRect.Width > 0 && !string.IsNullOrEmpty (interiorText))
+        {
+            Rectangle interiorBounds = _interiorTextFormatter.GetDrawRegion (interiorRect).GetBounds ();
+
+            if (!interiorBounds.IsEmpty)
+            {
+                return interiorBounds.Y;
+            }
+        }
+
+        return VerticalTextAlignment switch
+        {
+            Alignment.End => drawRect.Y + drawRect.Height - 1,
+            Alignment.Center => drawRect.Y + (drawRect.Height - 1) / 2,
+            _ => drawRect.Y
+        };
     }
 }

--- a/Terminal.Gui/Views/Button.cs
+++ b/Terminal.Gui/Views/Button.cs
@@ -249,33 +249,26 @@ public class Button : View, IDesignable, IAcceptTarget
         _interiorTextFormatter.ConstrainToWidth = interiorRect.Width;
         _interiorTextFormatter.ConstrainToHeight = interiorRect.Height;
 
-        Region drawRegion = new (drawRect);
+        Region? interiorDrawRegion = (interiorRect.Width > 0 && !string.IsNullOrEmpty (interiorText))
+            ? _interiorTextFormatter.GetDrawRegion (interiorRect)
+            : null;
 
-        if (interiorRect.Width > 0 && !string.IsNullOrEmpty (interiorText))
-        {
-            drawRegion.Combine (_interiorTextFormatter.GetDrawRegion (interiorRect), RegionOp.Union);
-        }
+        context?.AddDrawnRegion (new Region (drawRect));
 
-        context?.AddDrawnRegion (drawRegion);
+        int delimiterRow = GetDelimiterRow (drawRect, interiorDrawRegion);
 
-        int delimiterRow = GetDelimiterRow (drawRect, interiorRect, interiorText);
+        // Fill the entire content area with the focus/normal attribute to ensure continuous
+        // highlight across all rows and across the bracket columns.
+        Driver.SetAttribute (normalAttr);
+        Driver.FillRect (drawRect);
 
         Driver.Move (drawRect.X, delimiterRow);
-        Driver.SetAttribute (normalAttr);
         Driver.AddRune (_leftBracket);
 
         Driver.Move (drawRect.X + drawRect.Width - 1, delimiterRow);
-        Driver.SetAttribute (normalAttr);
         Driver.AddRune (_rightBracket);
 
-        if (interiorRect.Width > 0)
-        {
-            Driver.Move (interiorRect.X, delimiterRow);
-            Driver.SetAttribute (normalAttr);
-            Driver.AddStr (new string (' ', interiorRect.Width));
-        }
-
-        if (interiorRect.Width > 0 && !string.IsNullOrEmpty (interiorText))
+        if (interiorDrawRegion is not null)
         {
             _interiorTextFormatter.Draw (Driver, interiorRect, normalAttr, hotAttr, Rectangle.Empty);
         }
@@ -293,6 +286,8 @@ public class Button : View, IDesignable, IAcceptTarget
         return true;
     }
 
+    // GetDecoratedText (called by UpdateTextFormatterText for Dim.Auto sizing) and GetInteriorText
+    // (called by OnDrawingText for rendering) must remain in sync when modifying button text formatting.
     private string GetDecoratedText ()
     {
         if (NoDecorations)
@@ -318,11 +313,11 @@ public class Button : View, IDesignable, IAcceptTarget
         return $" {Text} ";
     }
 
-    private int GetDelimiterRow (Rectangle drawRect, Rectangle interiorRect, string interiorText)
+    private int GetDelimiterRow (Rectangle drawRect, Region? interiorDrawRegion)
     {
-        if (interiorRect.Width > 0 && !string.IsNullOrEmpty (interiorText))
+        if (interiorDrawRegion is not null)
         {
-            Rectangle interiorBounds = _interiorTextFormatter.GetDrawRegion (interiorRect).GetBounds ();
+            Rectangle interiorBounds = interiorDrawRegion.GetBounds ();
 
             if (!interiorBounds.IsEmpty)
             {

--- a/Tests/Benchmarks/Views/ButtonDrawBenchmark.cs
+++ b/Tests/Benchmarks/Views/ButtonDrawBenchmark.cs
@@ -1,0 +1,126 @@
+using BenchmarkDotNet.Attributes;
+using Terminal.Gui.App;
+using Terminal.Gui.Drivers;
+using Terminal.Gui.Drawing;
+using Terminal.Gui.ViewBase;
+using Terminal.Gui.Views;
+
+namespace Terminal.Gui.Benchmarks.Views;
+
+/// <summary>
+///     Benchmarks for <see cref="Button"/> draw performance, focused on the cost of
+///     <c>_interiorTextFormatter</c> property assignments in <c>OnDrawingText</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Prior to the guards introduced in PR #5279, every call to <c>OnDrawingText</c> set all
+///         <c>_interiorTextFormatter</c> properties unconditionally, which always set
+///         <c>NeedsFormat = true</c> and forced the formatter to re-allocate on the next access —
+///         even when nothing had changed.  After the fix, unchanged values are skipped.
+///     </para>
+///     <para>
+///         <b>How to read results:</b>
+///         <list type="bullet">
+///             <item><see cref="DrawButton_Unchanged"/> represents the guard-optimized steady-state path.</item>
+///             <item><see cref="DrawButton_TextChanging"/> forces a real reformat each iteration,
+///             approximating the old unguarded behaviour.</item>
+///         </list>
+///         The allocation difference between the two methods shows the overhead that the guards eliminate.
+///     </para>
+///     <para>
+///         Run:
+///         <code>dotnet run --project Tests/Benchmarks -c Release -- --filter "*ButtonDraw*"</code>
+///     </para>
+/// </remarks>
+[MemoryDiagnoser]
+[BenchmarkCategory ("Views", "Button")]
+public class ButtonDrawBenchmark
+{
+    // Four interior texts of equal display width so layout stays stable between iterations.
+    private static readonly string [] _changingTexts = ["_OK", "_No", "_Go", "_Up"];
+
+    private IApplication _app = null!;
+    private Button _button = null!;
+    private int _textIndex;
+    private SessionToken? _session;
+
+    /// <summary>Fixed width of the button under test.</summary>
+    [Params (10, 40)]
+    public int Width { get; set; }
+
+    /// <summary>Whether the button is the default button (adds extra decoration characters).</summary>
+    [Params (false, true)]
+    public bool IsDefault { get; set; }
+
+    /// <summary>Create the application and button once per parameter combination.</summary>
+    [GlobalSetup]
+    public void Setup ()
+    {
+        _app = Application.Create ();
+        _app.Init (DriverRegistry.Names.ANSI);
+        _app.Driver!.SetScreenSize (Width, 1);
+
+        Runnable runnable = new () { Width = Width, Height = 1 };
+        _session = _app.Begin (runnable);
+
+        _button = new ()
+        {
+            Text = "_OK",
+            X = 0,
+            Y = 0,
+            Width = Width,
+            Height = 1,
+            IsDefault = IsDefault,
+            ShadowStyle = ShadowStyles.None
+        };
+
+        runnable.Add (_button);
+
+        // Warm-up draw so caches and JIT paths are primed before measurement.
+        _app.LayoutAndDraw ();
+    }
+
+    /// <summary>Mark the button as needing a redraw before each iteration.</summary>
+    /// <remarks>This ensures <c>OnDrawingText</c> is always called, while keeping all
+    /// formatter property values identical to the previous draw — isolating the guard benefit.</remarks>
+    [IterationSetup]
+    public void MarkNeedsDraw ()
+    {
+        _button.SetNeedsDraw ();
+    }
+
+    /// <summary>
+    ///     Draws the button with no property changes since the last draw.
+    ///     Guards on <c>_interiorTextFormatter</c> skip all assignments, so <c>NeedsFormat</c>
+    ///     is not set and the formatter does not re-allocate.
+    /// </summary>
+    [Benchmark (Baseline = true)]
+    public void DrawButton_Unchanged ()
+    {
+        _app.LayoutAndDraw ();
+    }
+
+    /// <summary>
+    ///     Rotates the button <see cref="View.Text"/> before each draw.
+    ///     The interior text changes, so the <c>Text</c> guard fires, <c>NeedsFormat</c> is
+    ///     set, and the formatter re-allocates — approximating the old unguarded behaviour.
+    /// </summary>
+    [Benchmark]
+    public void DrawButton_TextChanging ()
+    {
+        _button.Text = _changingTexts [_textIndex++ % _changingTexts.Length];
+        _app.LayoutAndDraw ();
+    }
+
+    /// <summary>Dispose the application after all iterations.</summary>
+    [GlobalCleanup]
+    public void Cleanup ()
+    {
+        if (_session is not null)
+        {
+            _app.End (_session);
+        }
+
+        _app.Dispose ();
+    }
+}

--- a/Tests/UnitTestsParallelizable/Views/ButtonDrawingTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ButtonDrawingTests.cs
@@ -41,6 +41,49 @@ public class ButtonDrawingTests (ITestOutputHelper output) : TestDriverBase
 
     // Copilot
     [Fact]
+    public void Focused_FixedWidth_Button_MultiRow_Highlight_Is_Continuous ()
+    {
+        const int width = 10;
+        const int height = 3;
+
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (width, height);
+
+        Runnable runnable = new () { Width = width, Height = height };
+        app.Begin (runnable);
+
+        Button button = new ()
+        {
+            Text = "_OK",
+            X = 0,
+            Y = 0,
+            Width = width,
+            Height = height,
+            ShadowStyle = null
+        };
+
+        runnable.Add (button);
+        button.SetFocus ();
+        app.LayoutAndDraw ();
+
+        // All rows must carry the Focus attribute — verifies the highlight is continuous
+        // across rows above and below the text (not just the delimiter row).
+        DriverAssert.AssertDriverAttributesAre (
+            """
+            0000000000
+            0000100000
+            0000000000
+            """,
+            output,
+            app.Driver,
+            button.GetAttributeForRole (VisualRole.Focus),
+            button.GetAttributeForRole (VisualRole.HotFocus)
+        );
+    }
+
+    // Copilot
+    [Fact]
     public void Focused_FixedWidth_Button_Highlight_Is_Continuous ()
     {
         const int width = 10;

--- a/Tests/UnitTestsParallelizable/Views/ButtonDrawingTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ButtonDrawingTests.cs
@@ -38,4 +38,41 @@ public class ButtonDrawingTests (ITestOutputHelper output) : TestDriverBase
 
         DriverAssert.AssertDriverContentsWithFrameAre (expected, output, app.Driver);
     }
+
+    // Copilot
+    [Fact]
+    public void Focused_FixedWidth_Button_Highlight_Is_Continuous ()
+    {
+        const int width = 10;
+
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (width, 1);
+
+        Runnable runnable = new () { Width = width, Height = 1 };
+        app.Begin (runnable);
+
+        Button button = new ()
+        {
+            Text = "_OK",
+            X = 0,
+            Y = 0,
+            Width = width,
+            Height = 1,
+            ShadowStyle = null
+        };
+
+        runnable.Add (button);
+        button.SetFocus ();
+        app.LayoutAndDraw ();
+
+        DriverAssert.AssertDriverContentsWithFrameAre ($"{Glyphs.LeftBracket}   OK   {Glyphs.RightBracket}", output, app.Driver);
+        DriverAssert.AssertDriverAttributesAre (
+            "0000100000",
+            output,
+            app.Driver,
+            button.GetAttributeForRole (VisualRole.Focus),
+            button.GetAttributeForRole (VisualRole.HotFocus)
+        );
+    }
 }

--- a/Tests/UnitTestsParallelizable/Views/ButtonDrawingTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ButtonDrawingTests.cs
@@ -1,0 +1,41 @@
+using UnitTests;
+
+namespace ViewsTests;
+
+public class ButtonDrawingTests (ITestOutputHelper output) : TestDriverBase
+{
+    // Copilot
+    [Theory]
+    [InlineData (false)]
+    [InlineData (true)]
+    public void FixedWidth_Anchors_Delimiters_To_Edges (bool isDefault)
+    {
+        const int width = 10;
+        string expected = isDefault
+                              ? $"{Glyphs.LeftBracket} {Glyphs.LeftDefaultIndicator} OK {Glyphs.RightDefaultIndicator} {Glyphs.RightBracket}"
+                              : $"{Glyphs.LeftBracket}   OK   {Glyphs.RightBracket}";
+
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (width, 1);
+
+        Runnable runnable = new () { Width = width, Height = 1 };
+        app.Begin (runnable);
+
+        Button button = new ()
+        {
+            Text = "_OK",
+            X = 0,
+            Y = 0,
+            Width = width,
+            Height = 1,
+            IsDefault = isDefault,
+            ShadowStyle = null
+        };
+
+        runnable.Add (button);
+        app.LayoutAndDraw ();
+
+        DriverAssert.AssertDriverContentsWithFrameAre (expected, output, app.Driver);
+    }
+}


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>a98f7d36-f362-457b-8f86-885ba3e011bc</p></details>

Fixes #5127.

## Problem

When a `Button` has a fixed `Width` wider than its natural size:
- The `[` and `]` delimiters were centered with the text instead of pinned to the view edges.
- When focused, the highlight attribute had gaps — cells before/after the centered text used the default attribute rather than `Focus`.

## Solution

Override `OnDrawingText` to take direct control of rendering:
- Draw `[` explicitly at `drawRect.X` (left edge) and `]` at `drawRect.X + Width - 1` (right edge).
- Call `Driver.FillRect(drawRect)` with the `normalAttr` (which resolves to `Focus` when focused) before drawing text, ensuring continuous highlight across the entire button area including all rows.
- Center only the interior text (between the brackets) using a dedicated `_interiorTextFormatter`.
- `UpdateTextFormatterText` still sets `TextFormatter.Text` to the full decorated string so `Dim.Auto` sizing continues to work correctly.

## Tests

Two new tests in `ButtonDrawingTests`:
- `FixedWidth_Anchors_Delimiters_To_Edges` — verifies `[` and `]` appear at columns 0 and 9 for a `Width=10` button, for both `IsDefault=false` and `IsDefault=true`.
- `Focused_FixedWidth_Button_Highlight_Is_Continuous` — verifies all 10 cells carry `Focus` or `HotFocus` attribute with no gaps.
