### PR TITLE
Fixes #5273. Code block partial selection should not include fence delimiters

### DIFF
--- a/Terminal.Gui/Views/Markdown/MarkdownView.Selection.cs
+++ b/Terminal.Gui/Views/Markdown/MarkdownView.Selection.cs
@@ -131,8 +131,19 @@ public partial class Markdown
         (Point start, Point end) = GetNormalizedSelection ();
         List<string> outputLines = [];
         var inCodeBlock = false;
-
         string? currentCodeLanguage = null;
+
+        // Fences are injected only when the selection crosses a code-block boundary:
+        //   • Opening fence: only when the selection already contains non-code content
+        //     before the code block (the selection crosses from outside into the block).
+        //   • Closing fence: always when the selection crosses out of the code block into
+        //     non-code content — regardless of whether an opening fence was emitted.
+        //   • No trailing fence: when the selection ends inside a code block, no closing
+        //     fence is added; the selection ends mid-block.
+        // This produces no fences for a selection entirely within a code block, matching
+        // the behaviour of the copy-button on MarkdownCodeBlock.
+        var selectionHasNonCodeContent = false;
+        var codeOpenFenceEmitted = false;
 
         // Track the last table instance that was output.  All placeholder rows for the
         // same table share the same TableData reference, so we use ReferenceEquals to
@@ -150,26 +161,50 @@ public partial class Markdown
 
                 if (!inCodeBlock)
                 {
-                    // Entering a code block: inject the opening fence with optional language tag
-                    outputLines.Add ($"```{nextCodeLanguage ?? string.Empty}");
                     inCodeBlock = true;
                     currentCodeLanguage = nextCodeLanguage;
+
+                    // Only inject the opening fence when non-code content has already been
+                    // output — that is, the selection crosses from outside into this code block.
+                    if (selectionHasNonCodeContent)
+                    {
+                        outputLines.Add ($"```{nextCodeLanguage ?? string.Empty}");
+                        codeOpenFenceEmitted = true;
+                    }
+                    else
+                    {
+                        codeOpenFenceEmitted = false;
+                    }
                 }
                 else if (!string.Equals (currentCodeLanguage, nextCodeLanguage, StringComparison.Ordinal))
                 {
-                    // Transitioning directly between two code blocks: close the current fence
-                    // and open the next one so adjacent fenced blocks are preserved.
-                    outputLines.Add ("```");
+                    // Transitioning directly between two adjacent code blocks of different
+                    // languages: close the current fence (if opened) and open the next one.
+                    if (codeOpenFenceEmitted)
+                    {
+                        outputLines.Add ("```");
+                    }
+
                     outputLines.Add ($"```{nextCodeLanguage ?? string.Empty}");
+                    codeOpenFenceEmitted = true;
                     currentCodeLanguage = nextCodeLanguage;
                 }
             }
             else if (inCodeBlock)
             {
-                // Leaving a code block: inject the closing fence
+                // Leaving a code block into non-code content: always inject the closing fence.
+                // The selection crosses the block's end boundary regardless of whether the
+                // opening fence was emitted (e.g., when the selection started inside the block).
                 outputLines.Add ("```");
+
                 inCodeBlock = false;
+                codeOpenFenceEmitted = false;
                 currentCodeLanguage = null;
+                selectionHasNonCodeContent = true;
+            }
+            else
+            {
+                selectionHasNonCodeContent = true;
             }
 
             if (line is { IsTable: true, TableData: { } tableData })
@@ -195,11 +230,6 @@ public partial class Markdown
             StringBuilder lineSb = new ();
             AppendLineText (lineSb, line, lineStartX, lineEndX);
             outputLines.Add (lineSb.ToString ());
-        }
-
-        if (inCodeBlock)
-        {
-            outputLines.Add ("```");
         }
 
         return string.Join ("\n", outputLines);

--- a/Terminal.Gui/Views/Markdown/MarkdownView.Selection.cs
+++ b/Terminal.Gui/Views/Markdown/MarkdownView.Selection.cs
@@ -134,14 +134,16 @@ public partial class Markdown
         string? currentCodeLanguage = null;
 
         // Fences are injected only when the selection crosses a code-block boundary:
-        //   • Opening fence: only when the selection already contains non-code content
-        //     before the code block (the selection crosses from outside into the block).
+        //   • Opening fence: emitted when entering a code block after selected non-code
+        //     content, and also when transitioning directly to an adjacent selected code
+        //     block whose opening fence has not yet been written.
         //   • Closing fence: always when the selection crosses out of the code block into
         //     non-code content — regardless of whether an opening fence was emitted.
         //   • No trailing fence: when the selection ends inside a code block, no closing
         //     fence is added; the selection ends mid-block.
         // This produces no fences for a selection entirely within a code block, matching
-        // the behaviour of the copy-button on MarkdownCodeBlock.
+        // the behaviour of the copy-button on MarkdownCodeBlock. codeOpenFenceEmitted
+        // tracks whether the current selected code block already has its opening fence.
         var selectionHasNonCodeContent = false;
         var codeOpenFenceEmitted = false;
 

--- a/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewSelectionTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewSelectionTests.cs
@@ -462,20 +462,23 @@ public class MarkdownViewSelectionTests
     }
 
     // Copilot - partial drag selection spanning lines inside a csharp code block (with 🌍)
+    // The selection covers all code lines but no non-code content, so no fence delimiters
+    // should appear in the output (mirrors the copy-button behaviour on MarkdownCodeBlock).
     [Fact]
-    public void PartialSelection_FencedCodeBlock_SelectedText_Preserves_Fence_Context ()
+    public void PartialSelection_FencedCodeBlock_SelectedText_DoesNotIncludeFence ()
     {
         string md = "```csharp\nConsole.WriteLine (\"Hello, Terminal.Gui! 🌍\");\nvar x = 42;\n```";
         (IApplication app, Runnable window, Terminal.Gui.Views.Markdown mv) = CreateMv (md, width: 60, height: 10);
 
-        // Select both code lines (rendered as lines 0 and 1 — fence lines are not in _renderedLines)
+        // Select both code lines (rendered as lines 0 and 1 — fence lines are not in _renderedLines).
+        // End at x=10 (one short of "var x = 42;" width=11) so IsFullDocumentSelected() returns false.
         mv.NewMouseEvent (new Mouse { Position = new Point (0, 0), Flags = MouseFlags.LeftButtonPressed });
-        mv.NewMouseEvent (new Mouse { Position = new Point (12, 1), Flags = MouseFlags.LeftButtonPressed | MouseFlags.PositionReport });
+        mv.NewMouseEvent (new Mouse { Position = new Point (10, 1), Flags = MouseFlags.LeftButtonPressed | MouseFlags.PositionReport });
 
         string? selected = mv.SelectedText;
 
         Assert.NotNull (selected);
-        Assert.Contains ("```csharp", selected);
+        Assert.DoesNotContain ("```", selected);
         Assert.Contains ("Console.WriteLine", selected);
         Assert.Contains ("🌍", selected);
 
@@ -759,6 +762,122 @@ public class MarkdownViewSelectionTests
 
         // Should NOT equal the full source markdown because the selection started at col 1
         Assert.NotEqual (md, selected);
+
+        window.Dispose ();
+        app.Dispose ();
+    }
+
+    // --- Issue #5273: partial selection inside a code block must not include fence delimiters ---
+
+    // Copilot - Claude Sonnet 4.6
+    // Selecting only middle lines of a multi-line code block should not produce fence delimiters.
+    [Fact]
+    public void PartialSelection_InsideCodeBlock_DoesNotIncludeFenceDelimiters ()
+    {
+        // 4 code lines; select only the middle two (lines 1 and 2)
+        string md = "```csharp\nline A\nline B\nline C\nline D\n```";
+        (IApplication app, Runnable window, Terminal.Gui.Views.Markdown mv) = CreateMv (md, width: 60, height: 10);
+
+        // Rendered lines 0-3 are the four code lines (fence lines are stripped during parse).
+        // Press on line 1, drag to end of line 2.
+        mv.NewMouseEvent (new Mouse { Position = new Point (0, 1), Flags = MouseFlags.LeftButtonPressed });
+        mv.NewMouseEvent (new Mouse { Position = new Point (60, 2), Flags = MouseFlags.LeftButtonPressed | MouseFlags.PositionReport });
+
+        string? selected = mv.SelectedText;
+
+        Assert.NotNull (selected);
+        Assert.Contains ("line B", selected);
+        Assert.Contains ("line C", selected);
+        Assert.DoesNotContain ("```", selected);
+
+        window.Dispose ();
+        app.Dispose ();
+    }
+
+    // Copilot - Claude Sonnet 4.6
+    // Selection starts before the code block (on a paragraph line) and ends inside it.
+    // Only the opening fence should be present; the closing fence must be omitted.
+    [Fact]
+    public void PartialSelection_StartBeforeCodeBlock_EndInside_HasOpeningFenceOnly ()
+    {
+        string md = "Before\n```csharp\nline A\nline B\nline C\n```";
+        (IApplication app, Runnable window, Terminal.Gui.Views.Markdown mv) = CreateMv (md, width: 60, height: 10);
+
+        // Rendered line 0 = "Before", lines 1-3 = code lines.
+        // Press on line 0, drag to line 2 (mid-block).
+        mv.NewMouseEvent (new Mouse { Position = new Point (0, 0), Flags = MouseFlags.LeftButtonPressed });
+        mv.NewMouseEvent (new Mouse { Position = new Point (60, 2), Flags = MouseFlags.LeftButtonPressed | MouseFlags.PositionReport });
+
+        string? selected = mv.SelectedText;
+
+        Assert.NotNull (selected);
+        Assert.Contains ("Before", selected);
+        Assert.Contains ("```csharp", selected);
+        Assert.Contains ("line A", selected);
+        Assert.Contains ("line B", selected);
+        Assert.DoesNotContain ("line C", selected);
+
+        // Opening fence present; closing fence absent because selection ends mid-block.
+        int fenceCount = CountOccurrences (selected, "```");
+        Assert.Equal (1, fenceCount);
+
+        window.Dispose ();
+        app.Dispose ();
+    }
+
+    // Copilot - Claude Sonnet 4.6
+    // Selection starts inside a code block and ends after it (on a paragraph line).
+    // A closing fence is expected because the selection crosses the block's end, even
+    // though no opening fence was emitted (the selection began inside the block).
+    [Fact]
+    public void PartialSelection_StartInsideCodeBlock_EndAfter_HasClosingFenceOnly ()
+    {
+        string md = "```csharp\nline A\nline B\nline C\n```\nAfter";
+        (IApplication app, Runnable window, Terminal.Gui.Views.Markdown mv) = CreateMv (md, width: 60, height: 10);
+
+        // Rendered lines 0-2 = code lines, line 3 = "After".
+        // Press on line 1 (mid-block), drag to line 3 (after block).
+        mv.NewMouseEvent (new Mouse { Position = new Point (0, 1), Flags = MouseFlags.LeftButtonPressed });
+        mv.NewMouseEvent (new Mouse { Position = new Point (60, 3), Flags = MouseFlags.LeftButtonPressed | MouseFlags.PositionReport });
+
+        string? selected = mv.SelectedText;
+
+        Assert.NotNull (selected);
+        Assert.Contains ("line B", selected);
+        Assert.Contains ("line C", selected);
+        Assert.Contains ("After", selected);
+        Assert.DoesNotContain ("line A", selected);
+
+        // Closing fence present because selection crosses out of the code block; no opening fence.
+        int fenceCount = CountOccurrences (selected, "```");
+        Assert.Equal (1, fenceCount);
+
+        window.Dispose ();
+        app.Dispose ();
+    }
+
+    // Copilot - Claude Sonnet 4.6
+    // Regression guard: selecting all lines of a code block starting from its first line should
+    // produce NO fence delimiters — the selection is entirely within the fenced region.
+    [Fact]
+    public void PartialSelection_AllLinesOfCodeBlock_FromFirstLine_NoFences ()
+    {
+        // Three code lines; select only the first two to avoid triggering IsFullDocumentSelected().
+        string md = "```csharp\nline A\nline B\nline C\n```";
+        (IApplication app, Runnable window, Terminal.Gui.Views.Markdown mv) = CreateMv (md, width: 60, height: 10);
+
+        // Press on line 0 (first code line), drag to end of line 1.
+        // end.Y=1 < lastLine=2, so IsFullDocumentSelected() returns false and partial-selection runs.
+        mv.NewMouseEvent (new Mouse { Position = new Point (0, 0), Flags = MouseFlags.LeftButtonPressed });
+        mv.NewMouseEvent (new Mouse { Position = new Point (6, 1), Flags = MouseFlags.LeftButtonPressed | MouseFlags.PositionReport });
+
+        string? selected = mv.SelectedText;
+
+        Assert.NotNull (selected);
+        Assert.Contains ("line A", selected);
+        Assert.Contains ("line B", selected);
+        Assert.DoesNotContain ("line C", selected);
+        Assert.DoesNotContain ("```", selected);
 
         window.Dispose ();
         app.Dispose ();


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>cc36ca80-1ae3-4e1c-a9f7-6230152a804e</p></details>

## Summary

Fixes #5273. When copying a partial selection from inside a fenced code block in `MarkdownView`, the copied text should not include fence delimiters (`` ```lang `` / `` ``` ``) unless the selection actually crosses a code-block boundary.

## Behavior

| Selection | Result |
|---|---|
| Entirely inside code block | No fences |
| Starts before block, ends inside | Opening fence only |
| Starts inside block, ends after | Closing fence only |
| Spans the full block | Both fences |

## Root Cause

In `GetSelectedText()`, the opening fence was unconditionally injected when first entering a code block, and a trailing closing fence was always appended at the end. This caused partial selections inside a block to include unwanted fence delimiters.

## Fix

Rewrote the fence-injection logic in `MarkdownView.Selection.cs`:
- Added `selectionHasNonCodeContent` flag: the opening fence is only emitted when entering a code block **after** non-code content has been seen.
- Mid-loop closing fence (code→non-code transition) is now unconditional.
- Trailing fence (selection ends inside code block) was removed entirely.

## Tests

Added/updated tests in `MarkdownViewSelectionTests.cs` covering all four scenarios:
- `PartialSelection_InsideCodeBlock_DoesNotIncludeFenceDelimiters`
- `PartialSelection_StartBeforeCodeBlock_EndInside_HasOpeningFenceOnly`
- `PartialSelection_StartInsideCodeBlock_EndAfter_HasClosingFenceOnly`
- `PartialSelection_AllLinesOfCodeBlock_FromFirstLine_NoFences`