### PR TITLE
Fixes #5272. Ctrl+Click on link in Markdown no longer shows context menu

### DIFF
--- a/Terminal.Gui/Views/Markdown/MarkdownView.Mouse.cs
+++ b/Terminal.Gui/Views/Markdown/MarkdownView.Mouse.cs
@@ -59,7 +59,10 @@ public partial class Markdown
 
         // The base class binds LeftButtonReleased → Activate; remove that so Activate
         // fires only on LeftButtonClicked (not twice per click which would clear selection).
+        // Also remove the base class Ctrl+LeftButtonReleased → Context binding so that
+        // Ctrl+Click can follow links without triggering the context menu popover.
         MouseBindings.Remove (MouseFlags.LeftButtonReleased);
+        MouseBindings.Remove (MouseFlags.LeftButtonReleased | MouseFlags.Ctrl);
         MouseBindings.ReplaceCommands (MouseFlags.LeftButtonClicked, Command.Activate);
 
         // Right-click is handled directly in OnMouseEvent so that the view can be focused

--- a/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewSelectionTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewSelectionTests.cs
@@ -250,6 +250,49 @@ public class MarkdownViewSelectionTests
         mv.Dispose ();
     }
 
+    // Copilot - Regression: #5272 — Ctrl+LeftButtonReleased must NOT be bound to Context
+    // The base View class adds this binding; Markdown must remove it so Ctrl+Click can follow
+    // links without triggering the context menu popover.
+    [Fact]
+    public void MouseBindings_CtrlLeftButtonReleased_IsNotBoundTo_Context ()
+    {
+        Terminal.Gui.Views.Markdown mv = new ();
+
+        bool found = mv.MouseBindings.TryGet (MouseFlags.LeftButtonReleased | MouseFlags.Ctrl, out _);
+
+        Assert.False (found);
+
+        mv.Dispose ();
+    }
+
+    // Copilot - Regression: #5272 — Ctrl+Click on a link opens the link and does NOT show context menu
+    [Fact]
+    public void CtrlClick_On_Link_Opens_Link_And_Does_Not_Show_Context_Menu ()
+    {
+        (IApplication app, Runnable window, Terminal.Gui.Views.Markdown mv) = CreateMv ("[Click](https://example.com)");
+
+        mv.SetFocus ();
+
+        var linkClicked = false;
+
+        mv.LinkClicked += (_, e) =>
+                          {
+                              linkClicked = true;
+                              e.Handled = true;
+                          };
+
+        // Simulate Ctrl+Click: press, Ctrl+release, Ctrl+clicked
+        mv.NewMouseEvent (new Mouse { Position = new Point (0, 0), Flags = MouseFlags.LeftButtonPressed });
+        mv.NewMouseEvent (new Mouse { Position = new Point (0, 0), Flags = MouseFlags.LeftButtonReleased | MouseFlags.Ctrl });
+        mv.NewMouseEvent (new Mouse { Position = new Point (0, 0), Flags = MouseFlags.LeftButtonClicked });
+
+        Assert.True (linkClicked);
+        Assert.True (mv.ContextMenu is null || !mv.ContextMenu.Visible);
+
+        window.Dispose ();
+        app.Dispose ();
+    }
+
     // Copilot - verifies that a drag (press + position-report) activates the selection
     [Fact]
     public void Drag_Mouse_Creates_Selection ()


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>8584c489-d2b5-4dd6-bee4-a114a5d0665d</p></details>

## Summary

Fixes #5272.

When `Ctrl+Click` was used to follow a link in a `Markdown` view, the Select All/Copy context menu popover incorrectly appeared at the upper-left corner of the viewer (in addition to the link opening correctly).

## Root Cause

`View.Mouse.cs` registers a default binding:
```csharp
MouseBindings.Add(MouseFlags.LeftButtonReleased | MouseFlags.Ctrl, Command.Context);
```

`Markdown.SetupBindingsAndCommands()` already removes the `LeftButtonReleased → Activate` binding to prevent double-firing, but did not remove the `LeftButtonReleased | Ctrl → Context` binding. So during Ctrl+Click:

1. `LeftButtonReleased | Ctrl` → `Command.Context` → `ShowContextMenu()` with no position → falls back to `Point(0,0)` → popover at upper-left ← **bug**
2. `LeftButtonClicked` → `OnActivated` → link opens correctly

## Fix

One line added in `SetupBindingsAndCommands()`:

```csharp
MouseBindings.Remove(MouseFlags.LeftButtonReleased | MouseFlags.Ctrl);
```

Right-click (handled in `OnMouseEvent`) still shows the context menu as before.

## Tests

Two regression tests added to `MarkdownViewSelectionTests`:
- `MouseBindings_CtrlLeftButtonReleased_IsNotBoundTo_Context` — binding-level check
- `CtrlClick_On_Link_Opens_Link_And_Does_Not_Show_Context_Menu` — end-to-end check
