### PR TITLE
Fixes #5284. Right-clicking a link in MarkdownView adds Copy Link to context menu

### DIFF
--- a/Terminal.Gui/Views/Markdown/Markdown.cs
+++ b/Terminal.Gui/Views/Markdown/Markdown.cs
@@ -36,7 +36,7 @@ namespace Terminal.Gui.Views;
 ///         </item>
 ///         <item>
 ///             <term>Shift+F10 / Right-click</term>
-///             <description>Opens a context menu with <b>Select All</b> and <b>Copy</b> items.</description>
+///             <description>Opens a context menu with <b>Select All</b> and <b>Copy</b> items. Right-clicking on a hyperlink also adds a <b>Copy Link</b> item that copies the URL to the clipboard.</description>
 ///         </item>
 ///     </list>
 ///     <para>Default mouse bindings:</para>
@@ -74,6 +74,7 @@ public partial class Markdown : View, IDesignable
     private int _layoutWidth = -1;
     private int _maxLineWidth;
     private int _activeLinkIndex = -1;
+    private string? _contextMenuLinkUrl;
     private bool _inLayout;
     private bool _scrollToTopPending;
     private int _externalContentWidth;

--- a/Terminal.Gui/Views/Markdown/MarkdownView.Mouse.cs
+++ b/Terminal.Gui/Views/Markdown/MarkdownView.Mouse.cs
@@ -276,6 +276,28 @@ public partial class Markdown
     }
 
     /// <summary>
+    ///     Returns the URL of the link region at content coordinates (<paramref name="contentX"/>,
+    ///     <paramref name="contentY"/>), or <see langword="null"/> if no link covers that position.
+    /// </summary>
+    private string? FindLinkUrlAt (int contentX, int contentY)
+    {
+        foreach (MarkdownLinkRegion region in _linkRegions)
+        {
+            if (region.Line != contentY)
+            {
+                continue;
+            }
+
+            if (contentX >= region.StartX && contentX < region.EndXExclusive)
+            {
+                return region.Url;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
     ///     Builds the deduplicated list of link regions by scanning rendered lines.
     ///     Called at the end of <see cref="BuildRenderedLines"/>.
     /// </summary>

--- a/Terminal.Gui/Views/Markdown/MarkdownView.Selection.cs
+++ b/Terminal.Gui/Views/Markdown/MarkdownView.Selection.cs
@@ -326,7 +326,15 @@ public partial class Markdown
     {
         DisposeContextMenu ();
 
-        PopoverMenu menu = new ([new MenuItem (this, Command.SelectAll), new MenuItem (this, Command.Copy)])
+        List<View?> menuItems = [new MenuItem (this, Command.SelectAll), new MenuItem (this, Command.Copy)];
+
+        if (_contextMenuLinkUrl is { } url)
+        {
+            menuItems.Insert (0, null);
+            menuItems.Insert (0, new MenuItem ("Copy _Link", action: () => App?.Clipboard?.TrySetClipboardData (url)));
+        }
+
+        PopoverMenu menu = new (menuItems)
         {
 #if DEBUG
             Id = "markdownContextMenu"
@@ -366,6 +374,15 @@ public partial class Markdown
 
     private bool ShowContextMenu (Point? screenPosition = null)
     {
+        if (screenPosition is { } pos)
+        {
+            Point viewportPos = ScreenToViewport (pos);
+            int contentX = Viewport.X + viewportPos.X;
+            int contentY = Viewport.Y + viewportPos.Y;
+            _contextMenuLinkUrl = FindLinkUrlAt (contentX, contentY);
+            CreateContextMenu ();
+        }
+
         Point menuPosition = screenPosition ?? GetContextMenuScreenPosition ();
         ContextMenu?.MakeVisible (menuPosition);
 


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>[17d4aecc-2df2-4114-8f1e-0e0b0c717688]</p></details>

Fixes #5284

## Summary

Right-clicking on a hyperlink in the Markdown view now adds a **Copy Link** item to the context menu. Clicking it copies only the raw URL to the clipboard — not the display text.

**Menu layout when right-clicking a link:**
```
Copy Link        ← copies URL only
──────────
Select All
Copy
```

Right-clicking on a non-link area continues to show only **Select All** and **Copy**. The keyboard context menu (Shift+F10) is also unaffected.

## Changes

| File | Change |
|------|--------|
| Markdown.cs | Add _contextMenuLinkUrl field; update XML doc |
| MarkdownView.Mouse.cs | Add FindLinkUrlAt(contentX, contentY) helper that scans _linkRegions |
| MarkdownView.Selection.cs | ShowContextMenu detects link under right-click and rebuilds menu; CreateContextMenu prepends "Copy Link" + separator when a link URL is found |

## Testing

- All 334 existing Markdown unit tests pass
- dotnet build --no-restore — 0 errors, 0 warnings
