### PR TITLE
Add hui to showcase

### DIFF
--- a/docfx/docs/showcase.md
+++ b/docfx/docs/showcase.md
@@ -23,6 +23,9 @@
 - **[TerminalGuiDesigner](https://github.com/tznind/TerminalGuiDesigner)** - Cross platform view designer for building Terminal.Gui applications.
   ![TerminalGuiDesigner](../images/TerminalGuiDesigner.gif)
 
+- **[hui](https://github.com/YourRobotOverlord/hui)** - Syncs Philips Hue entertainment lights to system audio on Windows, with an interactive Terminal.Gui UI and a CLI mode.
+  ![hui](https://github.com/user-attachments/assets/8b4a493d-ac74-4876-88e4-fa56a6ff40f7)
+
 - **[Capital and Cargo](https://github.com/dhorions/Capital-and-Cargo)** - A retro console game where you buy, sell, produce and transport goods built with Terminal.Gui
   ![image](https://github.com/gui-cs/Terminal.Gui/assets/1682004/ed89f3d6-020f-4a8a-ae18-e057514f4c43)
  


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>[0deee370-69a7-4043-b432-59cff5ea5005]</p></details>

Adds **[hui](https://github.com/YourRobotOverlord/hui)** to the showcase.

`hui` syncs Philips Hue entertainment lights to system audio on Windows, with an interactive Terminal.Gui UI and a CLI mode. It uses the Hue Entertainment API DTLS stream and is available as a `dotnet tool`.
