### PR TITLE
Fixes #5291: add ImageView support with Sixel rendering and optimize re-rendering

### DIFF
--- a/Examples/UICatalog/Scenarios/Images.cs
+++ b/Examples/UICatalog/Scenarios/Images.cs
@@ -563,7 +563,8 @@ public class Images : Scenario
         encoder.Quantizer.DistanceAlgorithm = GetDistanceAlgorithm ();
         _sixelView.SixelEncoder = encoder;
 
-        _sixelView.Image = ConvertToColorArray (_fullResImage);
+        Size targetSize = _sixelView.FitImageInViewportInPixels (new Size (_fullResImage.Width, _fullResImage.Height));
+        _sixelView.Image = ConvertToColorArray (_fullResImage.Clone (i => i.Resize (targetSize.Width, targetSize.Height)));
 
         if (openDialog)
         {

--- a/Examples/UICatalog/Scenarios/Images.cs
+++ b/Examples/UICatalog/Scenarios/Images.cs
@@ -13,8 +13,7 @@ namespace UICatalog.Scenarios;
 public class Images : Scenario
 {
     private ImageView _imageView;
-    private Point _screenLocationForSixel;
-    private string _encodedSixelData;
+    private Image<Rgba32> _fullResImage;
     private Window _win;
 
     /// <summary>
@@ -42,7 +41,7 @@ public class Images : Scenario
     /// <summary>
     ///     The view into which the currently opened sixel image is bounded
     /// </summary>
-    private View _sixelView;
+    private ImageView _sixelView;
 
     private DoomFire _fire;
     private SixelEncoder _fireEncoder;
@@ -54,7 +53,7 @@ public class Images : Scenario
     private NumericUpDown _popularityThreshold;
     private SixelToRender _sixelImage;
 
-    // Start by assuming no support
+    // Start by assuming no support — updated from driver-level detection
     private SixelSupportResult _sixelSupportResult = new ();
     private CheckBox _cbSupportsSixel;
     private IApplication _app;
@@ -153,10 +152,6 @@ public class Images : Scenario
         _win.Add (tabBasic);
         _win.Add (_tabSixel);
 
-        // Start trying to detect sixel support
-        SixelSupportDetector sixelSupportDetector = new (app.Driver);
-        sixelSupportDetector.Detect (UpdateSixelSupportState);
-
         _win.SubViewsLaidOut += Win_SubViewsLaidOut;
         app.Run (_win);
         _win.Dispose ();
@@ -166,6 +161,12 @@ public class Images : Scenario
 
     private void Win_SubViewsLaidOut (object sender, LayoutEventArgs e)
     {
+        // // Use driver-level sixel support detection (detected during driver initialization)
+        if (_app?.Driver?.SixelSupport is { IsSupported: true })
+        {
+            UpdateSixelSupportState (_app.Driver.SixelSupport);
+        }
+
         if (_winSize == e.OldContentSize)
         {
             return;
@@ -273,7 +274,7 @@ public class Images : Scenario
 
         if (_fireSixel == null)
         {
-            _fireSixel = new SixelToRender { SixelData = sixelFireData, ScreenPosition = new Point (0, 0), Id = "fireSixel" };
+            _fireSixel = new SixelToRender { SixelData = sixelFireData, ScreenPosition = new Point (0, 0), Id = "fireSixel", IsDirty = true };
 
             _app.Driver?.GetOutput ().GetSixels ().Enqueue (_fireSixel);
         }
@@ -281,6 +282,7 @@ public class Images : Scenario
         {
             _fireSixel.SixelData = sixelFireData;
             _fireSixel.ScreenPosition = new Point (0, 0);
+            _fireSixel.IsDirty = true;
         }
 
         _win.SetNeedsDraw ();
@@ -339,7 +341,8 @@ public class Images : Scenario
             return;
         }
 
-        _imageView.SetImage (img);
+        _fullResImage = img;
+        _imageView.Image = ConvertToColorArray (img);
         ApplyShowTabViewHack ();
         _app?.LayoutAndDraw ();
     }
@@ -355,7 +358,8 @@ public class Images : Scenario
         {
             Width = Dim.Fill (),
             Height = Dim.Fill (),
-            CanFocus = true
+            CanFocus = true,
+            UseSixel = false // Basic tab uses cell-based rendering
         };
 
         tabBasic.Add (_imageView);
@@ -387,11 +391,12 @@ public class Images : Scenario
                                     VerticalTextAlignment = Alignment.Center
                                 });
 
-        _sixelView = new View
+        _sixelView = new ImageView
         {
             Width = Dim.Percent (50),
             Height = Dim.Fill (),
-            BorderStyle = LineStyle.Dotted
+            BorderStyle = LineStyle.Dotted,
+            UseSixel = true
         };
         _sixelView.SubViewsLaidOut += SixelView_SubViewsLaidOut;
         _sixelSupported.Add (_sixelView);
@@ -568,7 +573,7 @@ public class Images : Scenario
 
     private void OutputSixelButtonClick (object sender, CommandEventArgs e)
     {
-        if (_imageView.FullResImage == null)
+        if (_fullResImage == null)
         {
             MessageBox.Query (_app!, "No Image Loaded", "You must first open an image.  Use the 'Open Image' button above.", "Ok");
 
@@ -582,70 +587,13 @@ public class Images : Scenario
 
     private void GenerateSixelImage (bool openDialog)
     {
-        _screenLocationForSixel = _sixelView.ViewportToScreen ().Location;
-
-        _encodedSixelData = GenerateSixelData (_imageView.FullResImage,
-                                               _sixelView.Viewport.Size,
-                                               _pxX.Value,
-                                               _pxY.Value,
-                                               openDialog);
-
-        if (_sixelImage == null)
-        {
-            _sixelImage = new SixelToRender { SixelData = _encodedSixelData, ScreenPosition = _screenLocationForSixel, Id = "sixelImage"};
-
-            _app.Driver?.GetOutput ().GetSixels ().Enqueue (_sixelImage);
-        }
-        else
-        {
-            _sixelImage.ScreenPosition = _screenLocationForSixel;
-            _sixelImage.SixelData = _encodedSixelData;
-        }
-
-        _sixelView.SetNeedsDraw ();
-    }
-
-    //private void SixelViewOnDrawingContent (object sender, DrawEventArgs e)
-    //{
-    //    if (!string.IsNullOrWhiteSpace (_encodedSixelData))
-    //    {
-    //        // Does not work (see https://github.com/gui-cs/Terminal.Gui/issues/3763)
-    //        _app.Driver?.Move (_screenLocationForSixel.X, _screenLocationForSixel.Y);
-    //        _app.Driver?.AddStr (_encodedSixelData);
-
-    //        // Works in DotNetDriver but results in screen flicker when moving mouse but vanish instantly
-    //        Console.SetCursorPosition (_screenLocationForSixel.X, _screenLocationForSixel.Y);
-    //        Console.Write (_encodedSixelData);
-    //    }
-    //}
-
-    public string GenerateSixelData (Image<Rgba32> fullResImage, Size maxSize, int pixelsPerCellX, int pixelsPerCellY, bool openDialog)
-    {
         SixelEncoder encoder = new ();
         encoder.Quantizer.MaxColors = Math.Min (encoder.Quantizer.MaxColors, _sixelSupportResult.MaxPaletteColors);
         encoder.Quantizer.PaletteBuildingAlgorithm = GetPaletteBuilder ();
         encoder.Quantizer.DistanceAlgorithm = GetDistanceAlgorithm ();
+        _sixelView.SixelEncoder = encoder;
 
-        // Calculate the target size in pixels based on console units
-        int targetWidthInPixels = maxSize.Width * pixelsPerCellX;
-        int targetHeightInPixels = encoder.GetHeightInPixels (maxSize.Height, pixelsPerCellY);
-
-        // Get the original image dimensions
-        int originalWidth = fullResImage.Width;
-        int originalHeight = fullResImage.Height;
-
-        // Use the helper function to get the resized dimensions while maintaining the aspect ratio
-        Size newSize = CalculateAspectRatioFit (originalWidth, originalHeight, targetWidthInPixels, targetHeightInPixels);
-
-        if (newSize == Size.Empty)
-        {
-            return string.Empty;
-        }
-
-        // Resize the image to match the console size
-        Image<Rgba32> resizedImage = fullResImage.Clone (x => x.Resize (newSize.Width, newSize.Height));
-
-        string encoded = encoder.EncodeSixel (ConvertToColorArray (resizedImage));
+        _sixelView.Image = ConvertToColorArray (_fullResImage);
 
         if (openDialog)
         {
@@ -658,25 +606,6 @@ public class Images : Scenario
 
             dlg.Dispose ();
         }
-
-        return encoded;
-    }
-
-    private Size CalculateAspectRatioFit (int originalWidth, int originalHeight, int targetWidth, int targetHeight)
-    {
-        // Calculate the scaling factor for width and height
-        double widthScale = (double)targetWidth / originalWidth;
-        double heightScale = (double)targetHeight / originalHeight;
-
-        // Use the smaller scaling factor to maintain the aspect ratio
-        double scale = Math.Min (widthScale, heightScale);
-
-        // Calculate the new width and height while keeping the aspect ratio
-        int newWidth = (int)(originalWidth * scale);
-        int newHeight = (int)(originalHeight * scale);
-
-        // Return the new size as a Size object
-        return new Size (newWidth, newHeight);
     }
 
     public static Color [,] ConvertToColorArray (Image<Rgba32> image)
@@ -696,55 +625,6 @@ public class Images : Scenario
         }
 
         return colors;
-    }
-
-    private class ImageView : View
-    {
-        private readonly ConcurrentDictionary<Rgba32, Attribute> _cache = new ();
-        public Image<Rgba32> FullResImage;
-        private Image<Rgba32> _matchSize;
-
-        protected override bool OnDrawingContent (DrawContext context)
-        {
-            if (FullResImage == null)
-            {
-                return true;
-            }
-
-            // if we have not got a cached resized image of this size
-            if (_matchSize == null || Viewport.Width != _matchSize.Width || Viewport.Height != _matchSize.Height)
-            {
-                // generate one
-                _matchSize = FullResImage.Clone (x => x.Resize (Viewport.Width, Viewport.Height));
-            }
-
-            for (int y = 0; y < Viewport.Height; y++)
-            {
-                for (int x = 0; x < Viewport.Width; x++)
-                {
-                    Rgba32 rgb = _matchSize [x, y];
-
-                    Attribute attr = _cache.GetOrAdd (
-                                                      rgb,
-                                                      rgba32 => new Attribute (
-                                                                               new Color (),
-                                                                               new Color (rgba32.R, rgba32.G, rgba32.B)
-                                                                              )
-                                                     );
-
-                    SetAttribute (attr);
-                    AddRune (x, y, (Rune)' ');
-                }
-            }
-
-            return true;
-        }
-
-        internal void SetImage (Image<Rgba32> image)
-        {
-            FullResImage = image;
-            SetNeedsDraw ();
-        }
     }
 
     public class PaletteView : View

--- a/Examples/UICatalog/Scenarios/Images.cs
+++ b/Examples/UICatalog/Scenarios/Images.cs
@@ -152,6 +152,14 @@ public class Images : Scenario
         _win.Add (_tabSixel);
 
         _win.SubViewsLaidOut += Win_SubViewsLaidOut;
+        _win.Initialized += (_, _) =>
+        {
+            app.Driver?.SixelSupportChanged += (_, args) => UpdateSixelSupportState (args.NewValue);
+            if (app.Driver?.SixelSupport is { } support)
+            {
+                UpdateSixelSupportState (support);
+            }
+        };
         app.Run (_win);
         _win.Dispose ();
     }
@@ -160,13 +168,6 @@ public class Images : Scenario
 
     private void Win_SubViewsLaidOut (object sender, LayoutEventArgs e)
     {
-        // Use driver-level sixel support detection (detected during driver initialization)
-        _app?.Driver?.SixelSupportChanged += (_, args) => UpdateSixelSupportState (args.NewValue);
-        if (_app?.Driver?.SixelSupport is { } support)
-        {
-            UpdateSixelSupportState (support);
-        }
-
         if (_winSize == e.OldContentSize)
         {
             return;

--- a/Examples/UICatalog/Scenarios/Images.cs
+++ b/Examples/UICatalog/Scenarios/Images.cs
@@ -51,7 +51,6 @@ public class Images : Scenario
     private OptionSelector _osPaletteBuilder;
     private OptionSelector _osDistanceAlgorithm;
     private NumericUpDown _popularityThreshold;
-    private SixelToRender _sixelImage;
 
     // Start by assuming no support — updated from driver-level detection
     private SixelSupportResult _sixelSupportResult = new ();
@@ -179,15 +178,7 @@ public class Images : Scenario
             SixelToRender sixelToRender = null;
             _app.Driver?.GetOutput ().GetSixels ().TryDequeue (out sixelToRender);
 
-            if (sixelToRender is { Id: "sixelImage" })
-            {
-                _app.Driver?.GetOutput ().GetSixels ().Enqueue (_sixelImage);
 
-                if (_app.Driver?.GetOutput ().GetSixels ().Count > 1)
-                {
-                    _app.Driver?.GetOutput ().GetSixels ().TryDequeue (out _);
-                }
-            }
 
             GenerateSixelFire (false);
 
@@ -527,28 +518,7 @@ public class Images : Scenario
 
         _sixelImageSize = e.OldContentSize;
 
-        if (_sixelImage is { })
-        {
-            SixelToRender sixelToRender = null;
-            _app.Driver?.GetOutput ().GetSixels ().TryDequeue (out sixelToRender);
 
-            if (sixelToRender is { Id: "fireSixel" })
-            {
-                _app.Driver?.GetOutput ().GetSixels ().Enqueue (_fireSixel);
-
-                if (_app.Driver?.GetOutput ().GetSixels ().Count > 1)
-                {
-                    _app.Driver?.GetOutput ().GetSixels ().TryDequeue (out _);
-                }
-            }
-
-            GenerateSixelImage (false);
-
-            if (!string.IsNullOrEmpty (_sixelImage.SixelData))
-            {
-                _app.Driver?.GetOutput ().GetSixels ().Enqueue (_sixelImage);
-            }
-        }
     }
 
     private IPaletteBuilder GetPaletteBuilder ()

--- a/Examples/UICatalog/Scenarios/Images.cs
+++ b/Examples/UICatalog/Scenarios/Images.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Concurrent;
-using System.Text;
+﻿using System.Text;
 using ColorHelper;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;

--- a/Examples/UICatalog/Scenarios/Images.cs
+++ b/Examples/UICatalog/Scenarios/Images.cs
@@ -160,10 +160,11 @@ public class Images : Scenario
 
     private void Win_SubViewsLaidOut (object sender, LayoutEventArgs e)
     {
-        // // Use driver-level sixel support detection (detected during driver initialization)
-        if (_app?.Driver?.SixelSupport is { IsSupported: true })
+        // Use driver-level sixel support detection (detected during driver initialization)
+        _app?.Driver?.SixelSupportChanged += (_, args) => UpdateSixelSupportState (args.NewValue);
+        if (_app?.Driver?.SixelSupport is { } support)
         {
-            UpdateSixelSupportState (_app.Driver.SixelSupport);
+            UpdateSixelSupportState (support);
         }
 
         if (_winSize == e.OldContentSize)
@@ -175,17 +176,7 @@ public class Images : Scenario
 
         if (_fireSixel is { })
         {
-            SixelToRender sixelToRender = null;
-            _app.Driver?.GetOutput ().GetSixels ().TryDequeue (out sixelToRender);
-
-
-
             GenerateSixelFire (false);
-
-            if (!string.IsNullOrEmpty (_fireSixel.SixelData))
-            {
-                _app.Driver?.GetOutput ().GetSixels ().Enqueue (_fireSixel);
-            }
         }
     }
 
@@ -196,6 +187,7 @@ public class Images : Scenario
         _cbSupportsSixel.Value = newResult.IsSupported ? CheckState.Checked : CheckState.UnChecked;
         _pxX.Value = _sixelSupportResult.Resolution.Width;
         _pxY.Value = _sixelSupportResult.Resolution.Height;
+        SetupSixelSupported (newResult.IsSupported);
     }
 
     private void SetupSixelSupported (bool isSupported)
@@ -265,7 +257,7 @@ public class Images : Scenario
 
         if (_fireSixel == null)
         {
-            _fireSixel = new SixelToRender { SixelData = sixelFireData, ScreenPosition = new Point (0, 0), Id = "fireSixel", IsDirty = true };
+            _fireSixel = new SixelToRender { SixelData = sixelFireData, ScreenPosition = new Point (0, 0), Id = "fireSixel", AlwaysRender = true };
 
             _app.Driver?.GetOutput ().GetSixels ().Enqueue (_fireSixel);
         }
@@ -273,7 +265,6 @@ public class Images : Scenario
         {
             _fireSixel.SixelData = sixelFireData;
             _fireSixel.ScreenPosition = new Point (0, 0);
-            _fireSixel.IsDirty = true;
         }
 
         _win.SetNeedsDraw ();
@@ -286,6 +277,7 @@ public class Images : Scenario
     {
         base.Dispose (disposing);
         _imageView.Dispose ();
+        _fullResImage?.Dispose ();
         _sixelNotSupported.Dispose ();
         _sixelSupported.Dispose ();
         _isDisposed = true;
@@ -332,6 +324,7 @@ public class Images : Scenario
             return;
         }
 
+        _fullResImage?.Dispose ();
         _fullResImage = img;
         _imageView.Image = ConvertToColorArray (img);
         ApplyShowTabViewHack ();
@@ -551,8 +544,10 @@ public class Images : Scenario
         }
 
         _sixelImageSize = _sixelView.Viewport.Size;
+        _sixelView.Visible = false;
 
         GenerateSixelImage (true);
+        _sixelView.Visible = true;
     }
 
     private void GenerateSixelImage (bool openDialog)
@@ -564,7 +559,8 @@ public class Images : Scenario
         _sixelView.SixelEncoder = encoder;
 
         Size targetSize = _sixelView.FitImageInViewportInPixels (new Size (_fullResImage.Width, _fullResImage.Height));
-        _sixelView.Image = ConvertToColorArray (_fullResImage.Clone (i => i.Resize (targetSize.Width, targetSize.Height)));
+        using Image<Rgba32> resized = _fullResImage.Clone (i => i.Resize (targetSize.Width, targetSize.Height));
+        _sixelView.Image = ConvertToColorArray (resized);
 
         if (openDialog)
         {

--- a/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using Terminal.Gui.Tracing;
 
 namespace Terminal.Gui.App;
@@ -221,33 +221,31 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
 
             kittyKeyboardDetector.Detect (result =>
                                           {
-                                               if (!result.IsSupported)
-                                               {
-                                                   if (_inputProcessor is AnsiInputProcessor unsupportedAnsiInputProcessor)
-                                                   {
-                                                       unsupportedAnsiInputProcessor.SetKittyKeyboardEnabled (false);
-                                                   }
+                                              if (!result.IsSupported)
+                                              {
+                                                  if (_inputProcessor is AnsiInputProcessor unsupportedAnsiInputProcessor)
+                                                  {
+                                                      unsupportedAnsiInputProcessor.SetKittyKeyboardEnabled (false);
+                                                  }
 
-                                                   Trace.Lifecycle (app?.MainThreadId?.ToString (), "KittyKeyboard", "Kitty keyboard mode not enabled");
+                                                  Trace.Lifecycle (app?.MainThreadId?.ToString (), "KittyKeyboard", "Kitty keyboard mode not enabled");
 
-                                                   return;
-                                               }
+                                                  return;
+                                              }
 
-                                               // Kitty is supported. Store the capabilities and set the flags we care about.
-                                               _driver?.SetKittyKeyboardCapabilities (result);
+                                              // Kitty is supported. Store the capabilities and set the flags we care about.
+                                              _driver?.SetKittyKeyboardCapabilities (result);
 
-                                               if (_inputProcessor is AnsiInputProcessor supportedAnsiInputProcessor)
-                                               {
-                                                   supportedAnsiInputProcessor.SetKittyKeyboardEnabled (true);
-                                               }
+                                              if (_inputProcessor is AnsiInputProcessor supportedAnsiInputProcessor)
+                                              {
+                                                  supportedAnsiInputProcessor.SetKittyKeyboardEnabled (true);
+                                              }
 
-                                               kittyKeyboardDetector.Enable (EscSeqUtils.KittyKeyboardRequestedFlags);
+                                              kittyKeyboardDetector.Enable (EscSeqUtils.KittyKeyboardRequestedFlags);
 
                                               Trace.Lifecycle (app?.MainThreadId?.ToString (),
                                                                "KittyKeyboard",
-                                                               $"Requested kitty keyboard flags {
-                                                                   EscSeqUtils.KittyKeyboardRequestedFlags
-                                                               }; awaiting confirmation");
+                                                               $"Requested kitty keyboard flags {EscSeqUtils.KittyKeyboardRequestedFlags}; awaiting confirmation");
                                           });
         }
         catch (Exception ex)
@@ -259,6 +257,27 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
         {
             QueueDeviceAttributesProbe (startupGate);
         }
+
+        // Detect sixel support via DAR query.
+        // Follows the same async callback pattern as TerminalColorDetector above.
+        if (!_driver.IsLegacyConsole)
+        {
+            try
+            {
+                SixelSupportDetector sixelDetector = new (_driver);
+
+                sixelDetector.Detect (result =>
+                                      {
+                                          _driver.SetSixelSupport (result);
+                                          Logging.Trace ($"app: Sixel support: {result.IsSupported}, Resolution: {result.Resolution}");
+                                      });
+            }
+            catch (Exception ex)
+            {
+                Logging.Warning ($"Sixel support detection failed: {ex.Message}");
+            }
+        }
+
 
         _startupSemaphore.Release ();
         Trace.Lifecycle (app?.MainThreadId.ToString (), "Driver", $"_input: {_input}, _output: {_output}");

--- a/Terminal.Gui/Drawing/Sixel/SixelToRender.cs
+++ b/Terminal.Gui/Drawing/Sixel/SixelToRender.cs
@@ -1,4 +1,4 @@
-﻿namespace Terminal.Gui.Drawing;
+namespace Terminal.Gui.Drawing;
 
 /// <summary>
 ///     Describes a request to render a given <see cref="SixelData"/> at a given <see cref="ScreenPosition"/>.
@@ -21,4 +21,20 @@ public class SixelToRender
     /// Gets or sets the unique identifier for this sixel render operation.
     /// </summary>
     public string? Id { get; set; }
+
+    /// <summary>
+    ///     Gets or sets whether this sixel needs to be re-rendered to the terminal.
+    ///     When <see langword="false"/>, the output pipeline skips writing this sixel's data.
+    ///     Set to <see langword="true"/> when the owning view's content is invalidated (e.g. via
+    ///     <see cref="ViewBase.View.SetNeedsDraw()"/>).
+    /// </summary>
+    public bool IsDirty { get; set; } = true;
+
+    /// <summary>
+    ///     Gets or sets whether this sixel should always be rendered to the terminal.
+    ///     When <see langword="true"/>, the output pipeline always writes this sixel's data.
+    ///     Set to <see langword="false"/> to only render when the owning view's content is
+    ///     invalidated (e.g. via <see cref="ViewBase.View.SetNeedsDraw()"/>).
+    /// </summary>
+    public bool AlwaysRender { get; set; } = false;
 }

--- a/Terminal.Gui/Drivers/DriverImpl.cs
+++ b/Terminal.Gui/Drivers/DriverImpl.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using Terminal.Gui.Tracing;
 
@@ -269,6 +269,14 @@ internal class DriverImpl : IDriver
     #endregion Screen and Display
 
     #region Color Support
+
+    /// <inheritdoc/>
+    public SixelSupportResult? SixelSupport { get; private set; }
+
+    /// <summary>
+    ///     Sets the terminal's sixel support result (detected during initialization).
+    /// </summary>
+    internal void SetSixelSupport (SixelSupportResult result) => SixelSupport = result;
 
     /// <inheritdoc/>
     public bool SupportsTrueColor => !IsLegacyConsole;

--- a/Terminal.Gui/Drivers/DriverImpl.cs
+++ b/Terminal.Gui/Drivers/DriverImpl.cs
@@ -273,10 +273,18 @@ internal class DriverImpl : IDriver
     /// <inheritdoc/>
     public SixelSupportResult? SixelSupport { get; private set; }
 
+    /// <inheritdoc/>
+    public event EventHandler<ValueChangedEventArgs<SixelSupportResult?>>? SixelSupportChanged;
+
     /// <summary>
     ///     Sets the terminal's sixel support result (detected during initialization).
     /// </summary>
-    internal void SetSixelSupport (SixelSupportResult result) => SixelSupport = result;
+    internal void SetSixelSupport (SixelSupportResult result)
+    {
+        SixelSupportResult? old = SixelSupport;
+        SixelSupport = result;
+        SixelSupportChanged?.Invoke (this, new ValueChangedEventArgs<SixelSupportResult?> (old, result));
+    }
 
     /// <inheritdoc/>
     public bool SupportsTrueColor => !IsLegacyConsole;

--- a/Terminal.Gui/Drivers/IDriver.cs
+++ b/Terminal.Gui/Drivers/IDriver.cs
@@ -128,6 +128,14 @@ public interface IDriver : IDisposable
 
     #region Color Support
 
+    /// <summary>
+    ///     Gets the terminal's sixel support capabilities, detected during driver initialization.
+    /// </summary>
+    /// <remarks>
+    ///     <see langword="null"/> if detection has not been performed.
+    /// </remarks>
+    SixelSupportResult? SixelSupport { get; }
+
     /// <summary>Gets whether the <see cref="IDriver"/> supports TrueColor output.</summary>
     bool SupportsTrueColor { get; }
 

--- a/Terminal.Gui/Drivers/IDriver.cs
+++ b/Terminal.Gui/Drivers/IDriver.cs
@@ -136,6 +136,11 @@ public interface IDriver : IDisposable
     /// </remarks>
     SixelSupportResult? SixelSupport { get; }
 
+    /// <summary>
+    ///     Raised when <see cref="SixelSupport"/> changes (e.g. after terminal color detection completes).
+    /// </summary>
+    event EventHandler<ValueChangedEventArgs<SixelSupportResult?>>? SixelSupportChanged;
+
     /// <summary>Gets whether the <see cref="IDriver"/> supports TrueColor output.</summary>
     bool SupportsTrueColor { get; }
 

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -210,13 +210,14 @@ public abstract class OutputBase
         // Render queued sixel images
         foreach (SixelToRender s in GetSixels ())
         {
-            if (string.IsNullOrWhiteSpace (s.SixelData))
+            if (string.IsNullOrWhiteSpace (s.SixelData) || (!s.IsDirty && !s.AlwaysRender))
             {
                 continue;
             }
 
             SetCursorPositionImpl (s.ScreenPosition.X, s.ScreenPosition.Y);
             Write (new StringBuilder (s.SixelData));
+            s.IsDirty = false;
         }
     }
 

--- a/Terminal.Gui/Views/ImageView.cs
+++ b/Terminal.Gui/Views/ImageView.cs
@@ -124,15 +124,15 @@ public class ImageView : View, IDesignable
     /// <remarks>
     ///     <para>
     ///         This method calculates the largest possible size for the given image that will fit
-    ///         within the current <see cref="Viewport"/> while maintaining its aspect ratio.
+    ///         within the current <see cref="View.Viewport"/> while maintaining its aspect ratio.
     ///     </para>
     ///     <para>
-    ///         The calculation is based on the terminal's cell resolution and the <see cref="Viewport"/>
+    ///         The calculation is based on the terminal's cell resolution and the <see cref="View.Viewport"/>
     ///         size, returning the exact pixel dimensions and position required for the scaled image.
     ///     </para>
     /// </remarks>
     /// <param name="imageSize">The original size of the image to scale.</param>
-    /// <returns>The scaled size of the image that fits within the <see cref="Viewport"/>.</returns>
+    /// <returns>The scaled size of the image that fits within the <see cref="View.Viewport"/>.</returns>
     public Size FitImageInViewportInPixels (Size imageSize)
     {
         Rectangle viewportInPixels = ViewportToScreenInPixels ();

--- a/Terminal.Gui/Views/ImageView.cs
+++ b/Terminal.Gui/Views/ImageView.cs
@@ -1,5 +1,3 @@
-using System.Buffers;
-using System.Collections.Generic;
 namespace Terminal.Gui.Views;
 
 /// <summary>
@@ -30,6 +28,7 @@ public class ImageView : View, IDesignable
 {
     private Color [,]? _image;
     private Color [,]? _scaledImage;
+    private Size? _scaledImageCellSize;
     private SixelToRender? _sixelToRender;
     private string? _cachedSixelData;
 
@@ -53,6 +52,7 @@ public class ImageView : View, IDesignable
             _image = value;
             _scaledImage = null;
             _cachedSixelData = null;
+            _scaledImageCellSize = null;
             _attributeCache.Clear ();
             UpdateSixelData ();
             SetNeedsDraw ();
@@ -101,12 +101,7 @@ public class ImageView : View, IDesignable
     /// <returns>The screen coordinates of the Viewport in pixels.</returns>
     public Rectangle ViewportToScreenInPixels ()
     {
-        SixelSupportResult? support = App?.Driver?.SixelSupport;
-
-        if (support is null)
-        {
-            throw new InvalidOperationException (@"No sixel support available.");
-        }
+        SixelSupportResult? support = (App?.Driver?.SixelSupport) ?? throw new InvalidOperationException (@"No sixel support available.");
 
         int pixelsPerCellX = support.Resolution.Width;
         int pixelsPerCellY = support.Resolution.Height;
@@ -117,6 +112,40 @@ public class ImageView : View, IDesignable
         int targetHeightInPixels = SixelEncoder?.GetHeightInPixels (boundsRect.Height, pixelsPerCellY) ?? boundsRect.Height * pixelsPerCellY;
 
         return new Rectangle (boundsRect.X * pixelsPerCellX, boundsRect.Y * pixelsPerCellY, targetWidthInPixels, targetHeightInPixels);
+    }
+
+    /// <summary>
+    ///     Returns the size in cell terms of the given image resized to fit in the viewport.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This method accounts for the terminal's cell resolution and the viewport's
+    ///         size, returning the exact pixel dimensions and position required for
+    ///         fully cover the viewport without changing the images aspect ratio.
+    ///     </para>
+    /// </remarks>
+    /// <param name="imageSizeInPixels">The size of the image in pixels.</param>
+    /// <returns>The largest possible size of the image in cell terms that fits within the viewport.</returns>
+    public Size FitImageInViewportCells (Size imageSizeInPixels)
+    {
+        if (imageSizeInPixels.Width == 0 || imageSizeInPixels.Height == 0)
+        {
+            return Size.Empty;
+        }
+
+        // Account for the terminal cell aspect ratio
+        double cellAspectRatio = App?.Driver?.SixelSupport is { } support ? (double)support.Resolution.Height / support.Resolution.Width : 2.0;
+        Size imageSize = new (imageSizeInPixels.Width, (int)(imageSizeInPixels.Height / cellAspectRatio));
+
+        // Calculate aspect-ratio-preserving size
+        double widthScale = (double)Viewport.Width / imageSize.Width;
+        double heightScale = (double)Viewport.Height / imageSize.Height;
+        double scale = Math.Min (widthScale, heightScale);
+
+        int newWidth = Math.Max (1, (int)(imageSize.Width * scale));
+        int newHeight = Math.Max (1, (int)(imageSize.Height * scale));
+
+        return new Size (newWidth, newHeight);
     }
 
     /// <summary>
@@ -167,13 +196,42 @@ public class ImageView : View, IDesignable
         if (IsUsingSixel)
         {
             DrawSixel ();
+
+            if (_scaledImageCellSize is { } cellSize)
+            {
+                Rectangle viewport = ViewportToScreen ();
+                Rectangle dirtyRect = new (viewport.X, viewport.Y, Math.Min (viewport.Width, cellSize.Width), Math.Min (viewport.Height, cellSize.Height));
+                context?.AddDrawnRectangle (dirtyRect);
+
+                // Mark the content buffer for the area we will draw as not dirty.
+                // This will avoid redrawing the area of the screen that will
+                // eventually be overwritten by the sixel anyway.
+                if (ScreenContents is { } contents && Driver is { } driver)
+                {
+                    for (int y = dirtyRect.Y; y < dirtyRect.Bottom; y++)
+                    {
+                        for (int x = dirtyRect.X; x < dirtyRect.Right; x++)
+                        {
+                            if (x >= 0 && y >= 0 && x < driver.Cols && y < driver.Rows)
+                            {
+                                contents [y, x].IsDirty = false;
+                            }
+                        }
+                    }
+                }
+            }
         }
         else
         {
             DrawCellBased ();
-        }
 
-        context?.AddDrawnRectangle (ViewportToScreen ());
+            if (_scaledImageCellSize is { } cellSize)
+            {
+                Rectangle viewport = ViewportToScreen ();
+                Rectangle dirtyRect = new (viewport.X, viewport.Y, Math.Min (viewport.Width, cellSize.Width), Math.Min (viewport.Height, cellSize.Height));
+                context?.AddDrawnRectangle (dirtyRect);
+            }
+        }
 
         return true;
     }
@@ -192,21 +250,31 @@ public class ImageView : View, IDesignable
     /// </summary>
     private void DrawCellBased ()
     {
-        Color [,]? scaled = GetScaledImage (Viewport.Width, Viewport.Height);
-
-        if (scaled is null)
+        if (_image is null)
         {
             return;
         }
 
-        int drawWidth = Math.Min (Viewport.Width, scaled.GetLength (0));
-        int drawHeight = Math.Min (Viewport.Height, scaled.GetLength (1));
+        if (_scaledImage is null)
+        {
+            _scaledImage = GetScaledImage (_image, Viewport.Width, Viewport.Height);
+
+            if (_scaledImage is null)
+            {
+                return;
+            }
+
+            _scaledImageCellSize = new Size (_scaledImage.GetLength (0), _scaledImage.GetLength (1));
+        }
+
+        int drawWidth = Math.Min (Viewport.Width, _scaledImage.GetLength (0));
+        int drawHeight = Math.Min (Viewport.Height, _scaledImage.GetLength (1));
 
         for (int y = 0; y < drawHeight; y++)
         {
             for (int x = 0; x < drawWidth; x++)
             {
-                Color pixel = scaled [x, y];
+                Color pixel = _scaledImage [x, y];
 
                 if (!_attributeCache.TryGetValue (pixel, out Attribute attr))
                 {
@@ -262,7 +330,7 @@ public class ImageView : View, IDesignable
 
     private void UpdateSixelData ()
     {
-        if (!IsUsingSixel || App?.Driver?.SixelSupport is not { } support)
+        if (!IsUsingSixel || App?.Driver?.SixelSupport is not { } support || _image is null)
         {
             return;
         }
@@ -276,33 +344,35 @@ public class ImageView : View, IDesignable
         Rectangle targetRect = ViewportToScreenInPixels ();
 
         // Scale the image to the target pixel size while maintaining aspect ratio
-        Color [,]? scaled = GetScaledImage (targetRect.Width, targetRect.Height);
+        _scaledImage = GetScaledImage (_image, targetRect.Width, targetRect.Height);
+        _scaledImageCellSize = FitImageInViewportCells (new Size (_image.GetLength (0), _image.GetLength (1)));
 
-        if (scaled is null)
+        if (_scaledImage is null)
         {
             return;
         }
 
         // Encode sixel data
-        _cachedSixelData = SixelEncoder.EncodeSixel (scaled);
+        _cachedSixelData = SixelEncoder.EncodeSixel (_scaledImage);
     }
 
     /// <summary>
     ///     Scales the source image to the specified target dimensions using nearest-neighbor
     ///     interpolation while maintaining aspect ratio.
     /// </summary>
+    /// <param name="image">The source image to scale.</param>
     /// <param name="targetWidth">The target width in the appropriate unit (cells or pixels).</param>
     /// <param name="targetHeight">The target height in the appropriate unit (cells or pixels).</param>
     /// <returns>The scaled image, or <see langword="null"/> if the source image is null or the target size is invalid.</returns>
-    private Color [,]? GetScaledImage (int targetWidth, int targetHeight)
+    private static Color [,]? GetScaledImage (Color [,] image, int targetWidth, int targetHeight)
     {
-        if (_image is null || targetWidth <= 0 || targetHeight <= 0)
+        if (image is null || targetWidth <= 0 || targetHeight <= 0)
         {
             return null;
         }
 
-        int srcWidth = _image.GetLength (0);
-        int srcHeight = _image.GetLength (1);
+        int srcWidth = image.GetLength (0);
+        int srcHeight = image.GetLength (1);
 
         if (srcWidth == 0 || srcHeight == 0)
         {
@@ -318,19 +388,16 @@ public class ImageView : View, IDesignable
         int newHeight = Math.Max (1, (int)(srcHeight * scale));
 
         // We can start with the input image, maybe it's the correct size already
-        if (_scaledImage is null)
-        {
-            _scaledImage = _image;
-        }
+        Color [,] scaledImage = image;
 
         // Nearest-neighbor scale
-        if (_scaledImage is null || _scaledImage.GetLength (0) != newWidth || _scaledImage.GetLength (1) != newHeight)
+        if (scaledImage.GetLength (0) != newWidth || scaledImage.GetLength (1) != newHeight)
         {
-            _scaledImage = new Color [newWidth, newHeight];
-            ScaleNearestNeighbor (_image, _scaledImage);
+            scaledImage = new Color [newWidth, newHeight];
+            ScaleNearestNeighbor (image, scaledImage);
         }
 
-        return _scaledImage;
+        return scaledImage;
     }
 
     /// <summary>

--- a/Terminal.Gui/Views/ImageView.cs
+++ b/Terminal.Gui/Views/ImageView.cs
@@ -1,5 +1,5 @@
+using System.Buffers;
 using System.Collections.Generic;
-
 namespace Terminal.Gui.Views;
 
 /// <summary>
@@ -53,6 +53,7 @@ public class ImageView : View, IDesignable
             _image = value;
             _scaledImage = null;
             _cachedSixelData = null;
+            _attributeCache.Clear ();
             UpdateSixelData ();
             SetNeedsDraw ();
         }
@@ -231,6 +232,11 @@ public class ImageView : View, IDesignable
             return;
         }
 
+        if (_cachedSixelData is null)
+        {
+            UpdateSixelData ();
+        }
+
         // Get screen position for this view's viewport
         Point screenPos = ViewportToScreen ().Location;
 
@@ -256,19 +262,16 @@ public class ImageView : View, IDesignable
 
     private void UpdateSixelData ()
     {
-        SixelSupportResult? support = App?.Driver?.SixelSupport;
-
-        if (support is null)
+        if (!IsUsingSixel || App?.Driver?.SixelSupport is not { } support)
         {
             return;
         }
 
         // Use caller-provided encoder or create a default one
-        if (SixelEncoder is null)
-        {
-            SixelEncoder = new SixelEncoder ();
-            SixelEncoder.Quantizer.MaxColors = Math.Min (SixelEncoder.Quantizer.MaxColors, support.MaxPaletteColors);
-        }
+        SixelEncoder ??= new SixelEncoder ();
+
+        // Clamp MaxColors regardless of whether the encoder was provided
+        SixelEncoder.Quantizer.MaxColors = Math.Min (SixelEncoder.Quantizer.MaxColors, support.MaxPaletteColors);
 
         Rectangle targetRect = ViewportToScreenInPixels ();
 

--- a/Terminal.Gui/Views/ImageView.cs
+++ b/Terminal.Gui/Views/ImageView.cs
@@ -1,0 +1,348 @@
+using System.Collections.Concurrent;
+
+namespace Terminal.Gui.Views;
+
+/// <summary>
+///     Displays an image represented as a 2D array of <see cref="Color"/> pixels.
+///     Supports two rendering modes: cell-based (one colored space per pixel, works everywhere)
+///     and sixel-based (when the terminal supports it).
+/// </summary>
+/// <remarks>
+///     <para>
+///         The image data is provided via the <see cref="Image"/> property as a <c>Color[,]</c> array
+///         where the first dimension is width (x) and the second is height (y). Image loading and
+///         decoding from file formats (PNG, JPEG, etc.) is the caller's responsibility — this view
+///         has no dependency on any image library.
+///     </para>
+///     <para>
+///         When sixel is available (detected via <see cref="IDriver.SixelSupport"/>) and
+///         <see cref="UseSixel"/> is <see langword="true"/>, the view will encode the image as
+///         sixel escape sequences and render it through the driver's sixel pipeline. Sixel data
+///         is only re-encoded and re-sent to the terminal when <see cref="View.NeedsDraw"/> is true,
+///         avoiding redundant rendering of unchanged images.
+///     </para>
+///     <para>
+///         When sixel is not available, the view falls back to cell-based rendering where each
+///         terminal cell is colored with the background color of the corresponding pixel.
+///     </para>
+/// </remarks>
+public class ImageView : View, IDesignable
+{
+    private Color [,]? _image;
+    private Color [,]? _scaledImage;
+    private SixelToRender? _sixelToRender;
+    private string? _cachedSixelData;
+
+    // Cell-based rendering cache
+    private readonly ConcurrentDictionary<Color, Attribute> _attributeCache = new ();
+
+    /// <summary>
+    ///     Gets or sets the pixel data to display. The array is indexed as [x, y] where
+    ///     the first dimension is width and the second is height.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this property marks the view as needing redraw. The image will be
+    ///     scaled to fit the current <see cref="View.Viewport"/> while maintaining
+    ///     aspect ratio using nearest-neighbor interpolation.
+    /// </remarks>
+    public Color [,]? Image
+    {
+        get => _image;
+        set
+        {
+            _image = value;
+            _scaledImage = null;
+            _cachedSixelData = null;
+            UpdateSixelData ();
+            SetNeedsDraw ();
+        }
+    }
+
+    /// <summary>
+    ///     Gets or sets whether to prefer sixel rendering when the terminal supports it.
+    ///     Default is <see langword="true"/>.
+    /// </summary>
+    /// <remarks>
+    ///     When <see langword="true"/> and the terminal supports sixel
+    ///     (per <see cref="IDriver.SixelSupport"/>), the image is rendered using sixel
+    ///     escape sequences for full-resolution display. When <see langword="false"/>,
+    ///     cell-based rendering is always used.
+    /// </remarks>
+    public bool UseSixel { get; set; } = true;
+
+    /// <summary>
+    ///     Gets or sets the <see cref="Drawing.SixelEncoder"/> used to encode images as sixel data.
+    ///     When <see langword="null"/>, a default encoder is created lazily on first use.
+    /// </summary>
+    /// <remarks>
+    ///     Set this to provide a custom encoder with specific quantizer settings, palette building
+    ///     algorithms, or color distance algorithms. The encoder's
+    ///     <see cref="Drawing.SixelEncoder.Quantizer"/> <c>MaxColors</c> will be clamped to the
+    ///     terminal's <see cref="SixelSupportResult.MaxPaletteColors"/> during rendering.
+    /// </remarks>
+    public SixelEncoder? SixelEncoder { get; set; }
+
+    /// <summary>
+    ///     Gets whether the current rendering mode is using sixel.
+    /// </summary>
+    public bool IsUsingSixel => UseSixel && App?.Driver?.SixelSupport is { IsSupported: true };
+
+    /// <inheritdoc/>
+    protected override bool OnDrawingContent (DrawContext? context)
+    {
+        base.OnDrawingContent (context);
+
+        if (_image is null)
+        {
+            return true;
+        }
+
+        if (IsUsingSixel)
+        {
+            DrawSixel ();
+        }
+        else
+        {
+            DrawCellBased ();
+        }
+
+        context?.AddDrawnRectangle (GetRenderableArea ());
+
+        return true;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnFrameChanged (in Rectangle frame)
+    {
+        base.OnFrameChanged (frame);
+        UpdateSixelData ();
+        SetNeedsDraw ();
+    }
+
+    /// <summary>
+    ///     Renders the image using cell-based rendering where each terminal cell
+    ///     gets the background color of the corresponding pixel.
+    /// </summary>
+    private void DrawCellBased ()
+    {
+        Color [,]? scaled = GetScaledImage (Viewport.Width, Viewport.Height);
+
+        if (scaled is null)
+        {
+            return;
+        }
+
+        int drawWidth = Math.Min (Viewport.Width, scaled.GetLength (0));
+        int drawHeight = Math.Min (Viewport.Height, scaled.GetLength (1));
+
+        for (int y = 0; y < drawHeight; y++)
+        {
+            for (int x = 0; x < drawWidth; x++)
+            {
+                Color pixel = scaled [x, y];
+
+                Attribute attr = _attributeCache.GetOrAdd (
+                                                           pixel,
+                                                           c => new Attribute (
+                                                                              new Color (),
+                                                                              c
+                                                                             )
+                                                          );
+
+                SetAttribute (attr);
+                AddRune (x, y, (Rune)' ');
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Renders the image using sixel escape sequences.
+    /// </summary>
+    private void DrawSixel ()
+    {
+        SixelSupportResult? support = App?.Driver?.SixelSupport;
+
+        if (support is null)
+        {
+            return;
+        }
+
+        // Get screen position for this view's viewport
+        Point screenPos = ViewportToScreen ().Location;
+
+        if (_sixelToRender is null)
+        {
+            _sixelToRender = new SixelToRender
+            {
+                SixelData = _cachedSixelData,
+                ScreenPosition = screenPos,
+                Id = $"ImageView_{GetHashCode ()}",
+                IsDirty = true
+            };
+
+            App?.Driver?.GetOutput ().GetSixels ().Enqueue (_sixelToRender);
+        }
+        else
+        {
+            _sixelToRender.SixelData = _cachedSixelData;
+            _sixelToRender.ScreenPosition = screenPos;
+            _sixelToRender.IsDirty = true;
+        }
+    }
+
+    private Rectangle GetRenderableArea ()
+    {
+        Rectangle frame = FrameToScreen ();
+        return new (
+          frame.X + (Margin?.Thickness.Left ?? 0) + (Border?.Thickness.Left ?? 0),
+          frame.Y + (Margin?.Thickness.Top ?? 0) + (Border?.Thickness.Top ?? 0),
+          frame.Width - (Margin?.Thickness.Horizontal ?? 0) - (Border?.Thickness.Horizontal ?? 0),
+          frame.Height - (Margin?.Thickness.Vertical ?? 0) - (Border?.Thickness.Vertical ?? 0));
+    }
+
+    private void UpdateSixelData ()
+    {
+        SixelSupportResult? support = App?.Driver?.SixelSupport;
+
+        if (support is null)
+        {
+            return;
+        }
+
+        // Use caller-provided encoder or create a default one
+        if (SixelEncoder == null)
+        {
+            SixelEncoder = new SixelEncoder { AvoidBottomScroll = true };
+            SixelEncoder.Quantizer.MaxColors = Math.Min (SixelEncoder.Quantizer.MaxColors, support.MaxPaletteColors);
+        }
+
+        int pixelsPerCellX = support.Resolution.Width;
+        int pixelsPerCellY = support.Resolution.Height;
+        Rectangle boundsRect = GetRenderableArea ();
+
+        // Calculate target size in pixels based on viewport and cell resolution
+        int targetWidthInPixels = boundsRect.Width * pixelsPerCellX;
+        int targetHeightInPixels = SixelEncoder.GetHeightInPixels (boundsRect.Height, pixelsPerCellY);
+
+        // Scale the image to the target pixel size while maintaining aspect ratio
+        Color [,]? scaled = GetScaledImage (targetWidthInPixels, targetHeightInPixels);
+
+        if (scaled is null)
+        {
+            return;
+        }
+
+        // Encode sixel data
+        _cachedSixelData = SixelEncoder.EncodeSixel (scaled);
+    }
+
+    /// <summary>
+    ///     Scales the source image to the specified target dimensions using nearest-neighbor
+    ///     interpolation while maintaining aspect ratio.
+    /// </summary>
+    /// <param name="targetWidth">The target width in the appropriate unit (cells or pixels).</param>
+    /// <param name="targetHeight">The target height in the appropriate unit (cells or pixels).</param>
+    /// <returns>The scaled image, or <see langword="null"/> if the source image is null or the target size is invalid.</returns>
+    private Color [,]? GetScaledImage (int targetWidth, int targetHeight)
+    {
+        if (_image is null || targetWidth <= 0 || targetHeight <= 0)
+        {
+            return null;
+        }
+
+        int srcWidth = _image.GetLength (0);
+        int srcHeight = _image.GetLength (1);
+
+        if (srcWidth == 0 || srcHeight == 0)
+        {
+            return null;
+        }
+
+        // Calculate aspect-ratio-preserving size
+        double widthScale = (double)targetWidth / srcWidth;
+        double heightScale = (double)targetHeight / srcHeight;
+        double scale = Math.Min (widthScale, heightScale);
+
+        int newWidth = Math.Max (1, (int)(srcWidth * scale));
+        int newHeight = Math.Max (1, (int)(srcHeight * scale));
+
+        // Check if cached scaled image is still valid
+        if (_scaledImage is { }
+            && _scaledImage.GetLength (0) == newWidth
+            && _scaledImage.GetLength (1) == newHeight)
+        {
+            return _scaledImage;
+        }
+
+        // Nearest-neighbor scale
+        _scaledImage = ScaleNearestNeighbor (_image, newWidth, newHeight);
+
+        return _scaledImage;
+    }
+
+    /// <summary>
+    ///     Scales a <c>Color[,]</c> pixel array using nearest-neighbor interpolation.
+    /// </summary>
+    /// <param name="source">The source pixel array indexed as [x, y].</param>
+    /// <param name="newWidth">The desired output width.</param>
+    /// <param name="newHeight">The desired output height.</param>
+    /// <returns>A new <c>Color[,]</c> array of the specified dimensions.</returns>
+    public static Color [,] ScaleNearestNeighbor (Color [,] source, int newWidth, int newHeight)
+    {
+        int srcWidth = source.GetLength (0);
+        int srcHeight = source.GetLength (1);
+        Color [,] result = new Color [newWidth, newHeight];
+
+        for (int y = 0; y < newHeight; y++)
+        {
+            int srcY = Math.Min ((int)((double)y / newHeight * srcHeight), srcHeight - 1);
+
+            for (int x = 0; x < newWidth; x++)
+            {
+                int srcX = Math.Min ((int)((double)x / newWidth * srcWidth), srcWidth - 1);
+                result [x, y] = source [srcX, srcY];
+            }
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose (bool disposing)
+    {
+        if (disposing && _sixelToRender is { })
+        {
+            // Clear the sixel data so it's not rendered anymore.
+            // The ConcurrentQueue doesn't support removal, but clearing the data
+            // ensures OutputBase.Write skips it.
+            _sixelToRender.SixelData = null;
+            _sixelToRender.IsDirty = false;
+        }
+
+        base.Dispose (disposing);
+    }
+
+    /// <inheritdoc/>
+    bool IDesignable.EnableForDesign ()
+    {
+        // Create a simple gradient test image for the designer
+        int width = 20;
+        int height = 10;
+        Color [,] testImage = new Color [width, height];
+
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                byte r = (byte)(x * 255 / Math.Max (1, width - 1));
+                byte g = (byte)(y * 255 / Math.Max (1, height - 1));
+                byte b = (byte)(128);
+                testImage [x, y] = new Color (r, g, b);
+            }
+        }
+
+        Image = testImage;
+
+        return true;
+    }
+}

--- a/Terminal.Gui/Views/ImageView.cs
+++ b/Terminal.Gui/Views/ImageView.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Terminal.Gui.Views;
 
@@ -34,7 +34,7 @@ public class ImageView : View, IDesignable
     private string? _cachedSixelData;
 
     // Cell-based rendering cache
-    private readonly ConcurrentDictionary<Color, Attribute> _attributeCache = new ();
+    private readonly Dictionary<Color, Attribute> _attributeCache = new ();
 
     /// <summary>
     ///     Gets or sets the pixel data to display. The array is indexed as [x, y] where
@@ -141,13 +141,11 @@ public class ImageView : View, IDesignable
             {
                 Color pixel = scaled [x, y];
 
-                Attribute attr = _attributeCache.GetOrAdd (
-                                                           pixel,
-                                                           c => new Attribute (
-                                                                              new Color (),
-                                                                              c
-                                                                             )
-                                                          );
+                if (!_attributeCache.TryGetValue (pixel, out Attribute attr))
+                {
+                    attr = new Attribute (new Color (), pixel);
+                    _attributeCache.Add (pixel, attr);
+                }
 
                 SetAttribute (attr);
                 AddRune (x, y, (Rune)' ');
@@ -275,7 +273,12 @@ public class ImageView : View, IDesignable
         }
 
         // Nearest-neighbor scale
-        _scaledImage = ScaleNearestNeighbor (_image, newWidth, newHeight);
+        if (_scaledImage is null || _scaledImage.GetLength (0) != newWidth || _scaledImage.GetLength (1) != newHeight)
+        {
+            _scaledImage = new Color [newWidth, newHeight];
+        }
+
+        ScaleNearestNeighbor (_image, _scaledImage);
 
         return _scaledImage;
     }
@@ -289,22 +292,33 @@ public class ImageView : View, IDesignable
     /// <returns>A new <c>Color[,]</c> array of the specified dimensions.</returns>
     public static Color [,] ScaleNearestNeighbor (Color [,] source, int newWidth, int newHeight)
     {
+        var result = new Color [newWidth, newHeight];
+        ScaleNearestNeighbor (source, result);
+        return result;
+    }
+
+    /// <summary>
+    ///     Scales a <c>Color[,]</c> pixel array into a destination array using nearest-neighbor interpolation.
+    /// </summary>
+    /// <param name="source">The source pixel array indexed as [x, y].</param>
+    /// <param name="destination">The destination pixel array indexed as [x, y].</param>
+    public static void ScaleNearestNeighbor (Color [,] source, Color [,] destination)
+    {
         int srcWidth = source.GetLength (0);
         int srcHeight = source.GetLength (1);
-        Color [,] result = new Color [newWidth, newHeight];
+        int newWidth = destination.GetLength (0);
+        int newHeight = destination.GetLength (1);
 
         for (int y = 0; y < newHeight; y++)
         {
-            int srcY = Math.Min ((int)((double)y / newHeight * srcHeight), srcHeight - 1);
+            int srcY = Math.Min (y * srcHeight / newHeight, srcHeight - 1);
 
             for (int x = 0; x < newWidth; x++)
             {
-                int srcX = Math.Min ((int)((double)x / newWidth * srcWidth), srcWidth - 1);
-                result [x, y] = source [srcX, srcY];
+                int srcX = Math.Min (x * srcWidth / newWidth, srcWidth - 1);
+                destination [x, y] = source [srcX, srcY];
             }
         }
-
-        return result;
     }
 
     /// <inheritdoc/>

--- a/Terminal.Gui/Views/ImageView.cs
+++ b/Terminal.Gui/Views/ImageView.cs
@@ -87,6 +87,72 @@ public class ImageView : View, IDesignable
     /// </summary>
     public bool IsUsingSixel => UseSixel && App?.Driver?.SixelSupport is { IsSupported: true };
 
+    /// <summary>
+    ///     Converts the Viewport to screen coordinates in pixels.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This method accounts for the terminal's cell resolution and the viewport's
+    ///         size, returning the exact pixel dimensions and position required for
+    ///         fully cover the viewport.
+    ///     </para>
+    /// </remarks>
+    /// <returns>The screen coordinates of the Viewport in pixels.</returns>
+    public Rectangle ViewportToScreenInPixels ()
+    {
+        SixelSupportResult? support = App?.Driver?.SixelSupport;
+
+        if (support is null)
+        {
+            throw new InvalidOperationException (@"No sixel support available.");
+        }
+
+        int pixelsPerCellX = support.Resolution.Width;
+        int pixelsPerCellY = support.Resolution.Height;
+        Rectangle boundsRect = ViewportToScreen ();
+
+        // Calculate target size in pixels based on viewport and cell resolution
+        int targetWidthInPixels = boundsRect.Width * pixelsPerCellX;
+        int targetHeightInPixels = SixelEncoder.GetHeightInPixels (boundsRect.Height, pixelsPerCellY);
+
+        return new Rectangle (boundsRect.X * pixelsPerCellX, boundsRect.Y * pixelsPerCellY, targetWidthInPixels, targetHeightInPixels);
+    }
+
+    /// <summary>
+    ///     Scales an image to fit within the current Viewport while maintaining aspect ratio.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This method calculates the largest possible size for the given image that will fit
+    ///         within the current <see cref="Viewport"/> while maintaining its aspect ratio.
+    ///     </para>
+    ///     <para>
+    ///         The calculation is based on the terminal's cell resolution and the <see cref="Viewport"/>
+    ///         size, returning the exact pixel dimensions and position required for the scaled image.
+    ///     </para>
+    /// </remarks>
+    /// <param name="imageSize">The original size of the image to scale.</param>
+    /// <returns>The scaled size of the image that fits within the <see cref="Viewport"/>.</returns>
+    public Size FitImageInViewportInPixels (Size imageSize)
+    {
+        Rectangle viewportInPixels = ViewportToScreenInPixels ();
+
+        if (imageSize.Width == 0 || imageSize.Height == 0)
+        {
+            return Size.Empty;
+        }
+
+        // Calculate aspect-ratio-preserving size
+        double widthScale = (double)viewportInPixels.Width / imageSize.Width;
+        double heightScale = (double)viewportInPixels.Height / imageSize.Height;
+        double scale = Math.Min (widthScale, heightScale);
+
+        int newWidth = Math.Max (1, (int)(imageSize.Width * scale));
+        int newHeight = Math.Max (1, (int)(imageSize.Height * scale));
+
+        return new Size (newWidth, newHeight);
+    }
+
     /// <inheritdoc/>
     protected override bool OnDrawingContent (DrawContext? context)
     {
@@ -106,7 +172,7 @@ public class ImageView : View, IDesignable
             DrawCellBased ();
         }
 
-        context?.AddDrawnRectangle (GetRenderableArea ());
+        context?.AddDrawnRectangle (ViewportToScreen ());
 
         return true;
     }
@@ -188,16 +254,6 @@ public class ImageView : View, IDesignable
         }
     }
 
-    private Rectangle GetRenderableArea ()
-    {
-        Rectangle frame = FrameToScreen ();
-        return new (
-          frame.X + (Margin?.Thickness.Left ?? 0) + (Border?.Thickness.Left ?? 0),
-          frame.Y + (Margin?.Thickness.Top ?? 0) + (Border?.Thickness.Top ?? 0),
-          frame.Width - (Margin?.Thickness.Horizontal ?? 0) - (Border?.Thickness.Horizontal ?? 0),
-          frame.Height - (Margin?.Thickness.Vertical ?? 0) - (Border?.Thickness.Vertical ?? 0));
-    }
-
     private void UpdateSixelData ()
     {
         SixelSupportResult? support = App?.Driver?.SixelSupport;
@@ -208,22 +264,16 @@ public class ImageView : View, IDesignable
         }
 
         // Use caller-provided encoder or create a default one
-        if (SixelEncoder == null)
+        if (SixelEncoder is null)
         {
-            SixelEncoder = new SixelEncoder { AvoidBottomScroll = true };
+            SixelEncoder = new SixelEncoder ();
             SixelEncoder.Quantizer.MaxColors = Math.Min (SixelEncoder.Quantizer.MaxColors, support.MaxPaletteColors);
         }
 
-        int pixelsPerCellX = support.Resolution.Width;
-        int pixelsPerCellY = support.Resolution.Height;
-        Rectangle boundsRect = GetRenderableArea ();
-
-        // Calculate target size in pixels based on viewport and cell resolution
-        int targetWidthInPixels = boundsRect.Width * pixelsPerCellX;
-        int targetHeightInPixels = SixelEncoder.GetHeightInPixels (boundsRect.Height, pixelsPerCellY);
+        Rectangle targetRect = ViewportToScreenInPixels ();
 
         // Scale the image to the target pixel size while maintaining aspect ratio
-        Color [,]? scaled = GetScaledImage (targetWidthInPixels, targetHeightInPixels);
+        Color [,]? scaled = GetScaledImage (targetRect.Width, targetRect.Height);
 
         if (scaled is null)
         {
@@ -264,37 +314,20 @@ public class ImageView : View, IDesignable
         int newWidth = Math.Max (1, (int)(srcWidth * scale));
         int newHeight = Math.Max (1, (int)(srcHeight * scale));
 
-        // Check if cached scaled image is still valid
-        if (_scaledImage is { }
-            && _scaledImage.GetLength (0) == newWidth
-            && _scaledImage.GetLength (1) == newHeight)
+        // We can start with the input image, maybe it's the correct size already
+        if (_scaledImage is null)
         {
-            return _scaledImage;
+            _scaledImage = _image;
         }
 
         // Nearest-neighbor scale
         if (_scaledImage is null || _scaledImage.GetLength (0) != newWidth || _scaledImage.GetLength (1) != newHeight)
         {
             _scaledImage = new Color [newWidth, newHeight];
+            ScaleNearestNeighbor (_image, _scaledImage);
         }
 
-        ScaleNearestNeighbor (_image, _scaledImage);
-
         return _scaledImage;
-    }
-
-    /// <summary>
-    ///     Scales a <c>Color[,]</c> pixel array using nearest-neighbor interpolation.
-    /// </summary>
-    /// <param name="source">The source pixel array indexed as [x, y].</param>
-    /// <param name="newWidth">The desired output width.</param>
-    /// <param name="newHeight">The desired output height.</param>
-    /// <returns>A new <c>Color[,]</c> array of the specified dimensions.</returns>
-    public static Color [,] ScaleNearestNeighbor (Color [,] source, int newWidth, int newHeight)
-    {
-        var result = new Color [newWidth, newHeight];
-        ScaleNearestNeighbor (source, result);
-        return result;
     }
 
     /// <summary>

--- a/Terminal.Gui/Views/ImageView.cs
+++ b/Terminal.Gui/Views/ImageView.cs
@@ -113,7 +113,7 @@ public class ImageView : View, IDesignable
 
         // Calculate target size in pixels based on viewport and cell resolution
         int targetWidthInPixels = boundsRect.Width * pixelsPerCellX;
-        int targetHeightInPixels = SixelEncoder.GetHeightInPixels (boundsRect.Height, pixelsPerCellY);
+        int targetHeightInPixels = SixelEncoder?.GetHeightInPixels (boundsRect.Height, pixelsPerCellY) ?? boundsRect.Height * pixelsPerCellY;
 
         return new Rectangle (boundsRect.X * pixelsPerCellX, boundsRect.Y * pixelsPerCellY, targetWidthInPixels, targetHeightInPixels);
     }

--- a/Terminal.Gui/Views/Markdown/Markdown.cs
+++ b/Terminal.Gui/Views/Markdown/Markdown.cs
@@ -63,7 +63,8 @@ public partial class Markdown : View, IDesignable
     private readonly List<IntermediateBlock> _blocks = [];
     private readonly List<RenderedLine> _renderedLines = [];
     private readonly List<MarkdownLinkRegion> _linkRegions = [];
-    private readonly HashSet<string> _queuedSixelIds = [];
+    private readonly Dictionary<string, SixelToRender> _sixelRenderMap = [];
+    private readonly HashSet<string> _visibleSixelIds = [];
     private readonly Dictionary<string, int> _headingAnchors = new (StringComparer.OrdinalIgnoreCase);
     private readonly List<MarkdownCodeBlock> _codeBlockViews = [];
     private readonly List<MarkdownTable> _tableViews = [];
@@ -352,6 +353,9 @@ public partial class Markdown : View, IDesignable
         _blocks.Clear ();
         _renderedLines.Clear ();
         _linkRegions.Clear ();
+        foreach (var render in _sixelRenderMap.Values) { render.SixelData = null; }
+        _sixelRenderMap.Clear ();
+        _visibleSixelIds.Clear ();
         _activeLinkIndex = -1;
         _headingAnchors.Clear ();
         RemoveCodeBlockViews ();

--- a/Terminal.Gui/Views/Markdown/MarkdownView.Drawing.cs
+++ b/Terminal.Gui/Views/Markdown/MarkdownView.Drawing.cs
@@ -307,6 +307,6 @@ public partial class Markdown
             return;
         }
 
-        Driver.GetSixels ().Enqueue (new SixelToRender { Id = queueId, ScreenPosition = ContentToScreen (screenPosition), SixelData = sixelData });
+        Driver.GetSixels ().Enqueue (new SixelToRender { Id = queueId, ScreenPosition = ContentToScreen (screenPosition), SixelData = sixelData, AlwaysRender = true });
     }
 }

--- a/Terminal.Gui/Views/Markdown/MarkdownView.Drawing.cs
+++ b/Terminal.Gui/Views/Markdown/MarkdownView.Drawing.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 namespace Terminal.Gui.Views;
 
 public partial class Markdown
@@ -19,6 +20,8 @@ public partial class Markdown
         SetAttribute (fillAttr);
         FillRect (Viewport with { X = 0, Y = 0 }, (Rune)' ');
 
+        _visibleSixelIds.Clear ();
+
         int startRow = Viewport.Y;
         int endRow = Math.Min (Viewport.Y + Viewport.Height, _renderedLines.Count);
 
@@ -26,6 +29,15 @@ public partial class Markdown
         {
             int drawRow = contentRow - Viewport.Y;
             DrawRenderedLine (_renderedLines [contentRow], contentRow, drawRow);
+        }
+
+        // Cleanup sixels that are no longer visible
+        var toRemove = _sixelRenderMap.Keys.Where (id => !_visibleSixelIds.Contains (id)).ToList ();
+        foreach (var id in toRemove)
+        {
+            _sixelRenderMap [id].SixelData = null;
+            _sixelRenderMap [id].IsDirty = false;
+            _sixelRenderMap.Remove (id);
         }
 
         // Return false so SubViews (copy buttons) still draw on top
@@ -288,7 +300,7 @@ public partial class Markdown
     private Attribute GetAttributeForSegment (StyledSegment segment) =>
         MarkdownAttributeHelper.GetAttributeForSegment (this, segment, SyntaxHighlighter, UseThemeBackground ? SyntaxHighlighter?.DefaultBackground : null);
 
-    private void TryQueueSixel (string imageSource, Point screenPosition)
+    private void TryQueueSixel (string imageSource, Point viewPosition)
     {
         if (!EnableSixelImages || Driver is null)
         {
@@ -300,13 +312,29 @@ public partial class Markdown
             return;
         }
 
-        var queueId = $"{imageSource}:{screenPosition.X}:{screenPosition.Y}";
+        var queueId = $"{imageSource}:{viewPosition.X}:{viewPosition.Y}";
 
-        if (!_queuedSixelIds.Add (queueId))
+        if (!_visibleSixelIds.Add (queueId))
         {
             return;
         }
 
-        Driver.GetSixels ().Enqueue (new SixelToRender { Id = queueId, ScreenPosition = ContentToScreen (screenPosition), SixelData = sixelData, AlwaysRender = true });
+        if (_sixelRenderMap.TryGetValue (queueId, out SixelToRender? render))
+        {
+            render.IsDirty = true;
+
+            return;
+        }
+
+        var newRender = new SixelToRender
+        {
+            Id = queueId,
+            ScreenPosition = ContentToScreen (viewPosition),
+            SixelData = sixelData,
+            AlwaysRender = false,
+            IsDirty = true
+        };
+        _sixelRenderMap [queueId] = newRender;
+        Driver.GetSixels ().Enqueue (newRender);
     }
 }

--- a/Tests/UnitTestsParallelizable/Application/MainLoopCoordinatorTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/MainLoopCoordinatorTests.cs
@@ -292,6 +292,76 @@ public class MainLoopCoordinatorTests (ITestOutputHelper outputHelper) : IDispos
         Assert.Equal ("Crash on boot", ex.InnerExceptions [0].Message);
     }
 
+    [Fact]
+    public async Task StartInputTaskAsync_DetectsSixelSupport_WhenTerminalResponds ()
+    {
+        // Arrange: inject a response containing "4" (sixel capability) in DAR,
+        // followed by a sixel resolution response "[6;20;10t".
+        // The SixelSupportDetector sends CSI_SendDeviceAttributes first, then
+        // CSI_RequestSixelResolution on success. We need to feed responses for both.
+        ConcurrentQueue<char> inputQueue = new ();
+        TimedEvents timedEvents = new ();
+        ApplicationMainLoop<char> loop = new ();
+
+        // The TestAnsiInput only sends a single response string at startup.
+        // The SixelSupportDetector uses QueueAnsiRequest (async callbacks), not raw input.
+        // We cannot easily simulate the full DAR/resolution exchange through raw input here,
+        // but we CAN verify that after boot the SixelSupport property is populated
+        // by checking that it starts null on a non-legacy console driver.
+        TestAnsiInput input = new (null);
+        AnsiOutput output = new ();
+        TestAnsiComponentFactory factory = new (input, output);
+        MainLoopCoordinator<char> coordinator = new (timedEvents, inputQueue, loop, factory);
+        Mock<IApplication> appMock = new ();
+
+        appMock.SetupProperty (a => a.Driver);
+        appMock.SetupProperty (a => a.MainThreadId, 789);
+
+        // Act
+        await coordinator.StartInputTaskAsync (appMock.Object);
+
+        DriverImpl driver = Assert.IsType<DriverImpl> (appMock.Object.Driver);
+
+        // Assert: SixelSupport will be null because no DAR response was received,
+        // but the important thing is the driver was initialized and the detection
+        // path did not throw. The SixelSupportDetector queued a request.
+        // The property remains null until a terminal response arrives.
+        Assert.Null (driver.SixelSupport);
+
+        // Verify the driver is NOT legacy console (sixel detection should have been attempted)
+        Assert.False (driver.IsLegacyConsole);
+
+        coordinator.Stop ();
+    }
+
+    [Fact]
+    public async Task StartInputTaskAsync_SkipsSixelDetection_ForLegacyConsole ()
+    {
+        // Arrange
+        ConcurrentQueue<char> inputQueue = new ();
+        TimedEvents timedEvents = new ();
+        ApplicationMainLoop<char> loop = new ();
+        TestAnsiInput input = new (null);
+        AnsiOutput output = new () { IsLegacyConsole = true };
+        TestAnsiComponentFactory factory = new (input, output);
+        MainLoopCoordinator<char> coordinator = new (timedEvents, inputQueue, loop, factory);
+        Mock<IApplication> appMock = new ();
+
+        appMock.SetupProperty (a => a.Driver);
+        appMock.SetupProperty (a => a.MainThreadId, 101);
+
+        // Act
+        await coordinator.StartInputTaskAsync (appMock.Object);
+
+        DriverImpl driver = Assert.IsType<DriverImpl> (appMock.Object.Driver);
+
+        // Assert: SixelSupport should be null (detection was skipped for legacy console)
+        Assert.Null (driver.SixelSupport);
+        Assert.True (driver.IsLegacyConsole);
+
+        coordinator.Stop ();
+    }
+
     private sealed class TestAnsiComponentFactory (TestAnsiInput input, AnsiOutput output) : ComponentFactoryImpl<char>
     {
         public override string GetDriverName () => DriverRegistry.Names.ANSI;
@@ -336,3 +406,4 @@ public class MainLoopCoordinatorTests (ITestOutputHelper outputHelper) : IDispos
         public void Dispose () { }
     }
 }
+

--- a/Tests/UnitTestsParallelizable/Application/MainLoopCoordinatorTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/MainLoopCoordinatorTests.cs
@@ -293,7 +293,7 @@ public class MainLoopCoordinatorTests (ITestOutputHelper outputHelper) : IDispos
     }
 
     [Fact]
-    public async Task StartInputTaskAsync_DetectsSixelSupport_WhenTerminalResponds ()
+    public async Task StartInputTaskAsync_InitiatesSixelSupportDetection ()
     {
         // Arrange: inject a response containing "4" (sixel capability) in DAR,
         // followed by a sixel resolution response "[6;20;10t".
@@ -406,4 +406,3 @@ public class MainLoopCoordinatorTests (ITestOutputHelper outputHelper) : IDispos
         public void Dispose () { }
     }
 }
-

--- a/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
@@ -756,6 +756,53 @@ public class OutputBaseTests
     }
 
     [Fact]
+    public void DriverImpl_SetSixelSupport_RaisesSixelSupportChangedEvent ()
+    {
+        // Arrange
+        using DriverImpl driver = new (
+                                 new AnsiComponentFactory (),
+                                 new AnsiInputProcessor (null!),
+                                 new OutputBufferImpl (),
+                                 new AnsiOutput (),
+                                 new (new AnsiResponseParser (new SystemTimeProvider ())),
+                                 new SizeMonitorImpl (new AnsiOutput ()));
+
+        SixelSupportResult firstResult = new ()
+        {
+            IsSupported = true,
+            MaxPaletteColors = 256,
+            SupportsTransparency = false
+        };
+
+        SixelSupportResult secondResult = new ()
+        {
+            IsSupported = true,
+            MaxPaletteColors = 512,
+            SupportsTransparency = true
+        };
+
+        List<ValueChangedEventArgs<SixelSupportResult?>> raisedArgs = [];
+
+        driver.SixelSupportChanged += (_, e) => raisedArgs.Add (e);
+
+        // Act 1: first call, old value should be null
+        driver.SetSixelSupport (firstResult);
+
+        // Assert 1
+        Assert.Single (raisedArgs);
+        Assert.Null (raisedArgs [0].OldValue);
+        Assert.Same (firstResult, raisedArgs [0].NewValue);
+
+        // Act 2: second call, old value should be firstResult
+        driver.SetSixelSupport (secondResult);
+
+        // Assert 2
+        Assert.Equal (2, raisedArgs.Count);
+        Assert.Same (firstResult, raisedArgs [1].OldValue);
+        Assert.Same (secondResult, raisedArgs [1].NewValue);
+    }
+
+    [Fact]
     public void DriverImpl_SetSixelSupport_StoresResult ()
     {
         // Arrange

--- a/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace DriverTests.Output;
 
@@ -548,5 +548,241 @@ public class OutputBaseTests
         Assert.Equal ("https://two.com", buffer.GetCellUrl (0, 0));
         Assert.Equal ("https://two.com", buffer.GetCellUrl (1, 0));
         Assert.Equal ("https://two.com", buffer.GetCellUrl (2, 0));
+    }
+
+    [Fact]
+    public void Write_SkipsSixel_WhenIsDirtyIsFalse ()
+    {
+        // Arrange
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (1, 1);
+        buffer.AddStr (".");
+
+        SixelToRender s = new ()
+        {
+            SixelData = "SKIPPED-SIXEL",
+            ScreenPosition = new (0, 0),
+            IsDirty = false
+        };
+
+        IDriver driver = new DriverImpl (
+                                         new AnsiComponentFactory (),
+                                         new AnsiInputProcessor (null!),
+                                         new OutputBufferImpl (),
+                                         output,
+                                         new (new AnsiResponseParser (new SystemTimeProvider ())),
+                                         new SizeMonitorImpl (output));
+
+        driver.GetSixels ().Enqueue (s);
+
+        // Act
+        output.Write (buffer);
+
+        // Assert: sixel data should NOT have been emitted
+        Assert.DoesNotContain ("SKIPPED-SIXEL", output.GetLastOutput ());
+
+        driver.Dispose ();
+    }
+
+    [Fact]
+    public void Write_ClearsIsDirty_AfterWritingSixel ()
+    {
+        // Arrange
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (1, 1);
+        buffer.AddStr (".");
+
+        SixelToRender s = new ()
+        {
+            SixelData = "DIRTY-SIXEL",
+            ScreenPosition = new (0, 0),
+            IsDirty = true
+        };
+
+        IDriver driver = new DriverImpl (
+                                         new AnsiComponentFactory (),
+                                         new AnsiInputProcessor (null!),
+                                         new OutputBufferImpl (),
+                                         output,
+                                         new (new AnsiResponseParser (new SystemTimeProvider ())),
+                                         new SizeMonitorImpl (output));
+
+        driver.GetSixels ().Enqueue (s);
+
+        // Act
+        output.Write (buffer);
+
+        // Assert: sixel was emitted and IsDirty was cleared
+        Assert.Contains ("DIRTY-SIXEL", output.GetLastOutput ());
+        Assert.False (s.IsDirty);
+
+        driver.Dispose ();
+    }
+
+    [Fact]
+    public void Write_SecondFrame_SkipsSixel_WhenIsDirtyWasClearedByFirstFrame ()
+    {
+        // Arrange
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (1, 1);
+        buffer.AddStr (".");
+
+        SixelToRender s = new ()
+        {
+            SixelData = "ONCE-SIXEL",
+            ScreenPosition = new (0, 0),
+            IsDirty = true
+        };
+
+        IDriver driver = new DriverImpl (
+                                         new AnsiComponentFactory (),
+                                         new AnsiInputProcessor (null!),
+                                         new OutputBufferImpl (),
+                                         output,
+                                         new (new AnsiResponseParser (new SystemTimeProvider ())),
+                                         new SizeMonitorImpl (output));
+
+        driver.GetSixels ().Enqueue (s);
+
+        // Frame 1: should emit
+        output.Write (buffer);
+        Assert.Contains ("ONCE-SIXEL", output.GetLastOutput ());
+        Assert.False (s.IsDirty);
+
+        // Frame 2: re-dirty the buffer so Write traverses rows, but sixel should be skipped
+        buffer.Move (0, 0);
+        buffer.AddStr ("X");
+        output.Write (buffer);
+        Assert.DoesNotContain ("ONCE-SIXEL", output.GetLastOutput ());
+
+        driver.Dispose ();
+    }
+
+    [Fact]
+    public void Write_AlwaysRender_BypassesIsDirtyCheck ()
+    {
+        // Arrange
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (1, 1);
+        buffer.AddStr (".");
+
+        SixelToRender s = new ()
+        {
+            SixelData = "ALWAYS-SIXEL",
+            ScreenPosition = new (0, 0),
+            IsDirty = false,
+            AlwaysRender = true
+        };
+
+        IDriver driver = new DriverImpl (
+                                         new AnsiComponentFactory (),
+                                         new AnsiInputProcessor (null!),
+                                         new OutputBufferImpl (),
+                                         output,
+                                         new (new AnsiResponseParser (new SystemTimeProvider ())),
+                                         new SizeMonitorImpl (output));
+
+        driver.GetSixels ().Enqueue (s);
+
+        // Act
+        output.Write (buffer);
+
+        // Assert: sixel was emitted even though IsDirty was false
+        Assert.Contains ("ALWAYS-SIXEL", output.GetLastOutput ());
+
+        driver.Dispose ();
+    }
+
+    [Fact]
+    public void Write_AlwaysRender_EmitsEveryFrame ()
+    {
+        // Arrange
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (1, 1);
+        buffer.AddStr (".");
+
+        SixelToRender s = new ()
+        {
+            SixelData = "EVERY-FRAME",
+            ScreenPosition = new (0, 0),
+            IsDirty = false,
+            AlwaysRender = true
+        };
+
+        IDriver driver = new DriverImpl (
+                                         new AnsiComponentFactory (),
+                                         new AnsiInputProcessor (null!),
+                                         new OutputBufferImpl (),
+                                         output,
+                                         new (new AnsiResponseParser (new SystemTimeProvider ())),
+                                         new SizeMonitorImpl (output));
+
+        driver.GetSixels ().Enqueue (s);
+
+        // Frame 1
+        output.Write (buffer);
+        Assert.Contains ("EVERY-FRAME", output.GetLastOutput ());
+
+        // Frame 2: re-dirty buffer so Write traverses, sixel should still emit
+        buffer.Move (0, 0);
+        buffer.AddStr ("Y");
+        output.Write (buffer);
+        Assert.Contains ("EVERY-FRAME", output.GetLastOutput ());
+
+        driver.Dispose ();
+    }
+
+    [Fact]
+    public void DriverImpl_SixelSupport_DefaultsToNull ()
+    {
+        // Arrange & Act
+        DriverImpl driver = new (
+                                 new AnsiComponentFactory (),
+                                 new AnsiInputProcessor (null!),
+                                 new OutputBufferImpl (),
+                                 new AnsiOutput (),
+                                 new (new AnsiResponseParser (new SystemTimeProvider ())),
+                                 new SizeMonitorImpl (new AnsiOutput ()));
+
+        // Assert
+        Assert.Null (driver.SixelSupport);
+
+        driver.Dispose ();
+    }
+
+    [Fact]
+    public void DriverImpl_SetSixelSupport_StoresResult ()
+    {
+        // Arrange
+        DriverImpl driver = new (
+                                 new AnsiComponentFactory (),
+                                 new AnsiInputProcessor (null!),
+                                 new OutputBufferImpl (),
+                                 new AnsiOutput (),
+                                 new (new AnsiResponseParser (new SystemTimeProvider ())),
+                                 new SizeMonitorImpl (new AnsiOutput ()));
+
+        SixelSupportResult result = new ()
+        {
+            IsSupported = true,
+            MaxPaletteColors = 512,
+            SupportsTransparency = true
+        };
+
+        // Act
+        driver.SetSixelSupport (result);
+
+        // Assert
+        Assert.NotNull (driver.SixelSupport);
+        Assert.True (driver.SixelSupport!.IsSupported);
+        Assert.Equal (512, driver.SixelSupport.MaxPaletteColors);
+        Assert.True (driver.SixelSupport.SupportsTransparency);
+
+        driver.Dispose ();
     }
 }

--- a/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
@@ -1,0 +1,445 @@
+namespace ViewsTests;
+
+/// <summary>
+///     Unit tests for <see cref="ImageView"/>.
+/// </summary>
+public class ImageViewTests
+{
+    #region Construction and Defaults
+
+    [Fact]
+    public void Defaults_AreExpected ()
+    {
+        ImageView imageView = new ();
+
+        Assert.Null (imageView.Image);
+        Assert.True (imageView.UseSixel);
+        Assert.Null (imageView.SixelEncoder);
+        Assert.False (imageView.IsUsingSixel); // No driver, so sixel not available
+
+        imageView.Dispose ();
+    }
+
+    #endregion Construction and Defaults
+
+    #region Image Property
+
+    [Fact]
+    public void Image_Set_SetsNeedsDraw ()
+    {
+        ImageView imageView = new () { Width = 10, Height = 10 };
+        View host = new () { Width = 10, Height = 10 };
+        host.Add (imageView);
+        host.BeginInit ();
+        host.EndInit ();
+        host.Layout ();
+
+        imageView.ClearNeedsDraw ();
+        Assert.False (imageView.NeedsDraw);
+
+        Color [,] pixels = CreateSolidImage (5, 5, new Color (255, 0, 0));
+        imageView.Image = pixels;
+
+        Assert.True (imageView.NeedsDraw);
+
+        host.Dispose ();
+    }
+
+    [Fact]
+    public void Image_SetNull_ClearsState ()
+    {
+        ImageView imageView = new ();
+
+        Color [,] pixels = CreateSolidImage (5, 5, new Color (255, 0, 0));
+        imageView.Image = pixels;
+        Assert.NotNull (imageView.Image);
+
+        imageView.Image = null;
+        Assert.Null (imageView.Image);
+
+        imageView.Dispose ();
+    }
+
+    [Fact]
+    public void Image_Set_ClearsCachedScaledImage ()
+    {
+        ImageView imageView = new () { Width = 10, Height = 10, UseSixel = false };
+        View host = new () { Width = 10, Height = 10 };
+        host.Add (imageView);
+        host.BeginInit ();
+        host.EndInit ();
+        host.Layout ();
+
+        // Set an initial image
+        Color [,] pixels1 = CreateSolidImage (5, 5, new Color (255, 0, 0));
+        imageView.Image = pixels1;
+
+        // Set a different image — should clear cached scaled image
+        Color [,] pixels2 = CreateSolidImage (3, 3, new Color (0, 255, 0));
+        imageView.Image = pixels2;
+
+        Assert.Same (pixels2, imageView.Image);
+
+        host.Dispose ();
+    }
+
+    #endregion Image Property
+
+    #region UseSixel Property
+
+    [Fact]
+    public void UseSixel_DefaultsToTrue ()
+    {
+        ImageView imageView = new ();
+        Assert.True (imageView.UseSixel);
+        imageView.Dispose ();
+    }
+
+    [Fact]
+    public void IsUsingSixel_FalseWhenUseSixelFalse ()
+    {
+        ImageView imageView = new () { UseSixel = false };
+        Assert.False (imageView.IsUsingSixel);
+        imageView.Dispose ();
+    }
+
+    [Fact]
+    public void IsUsingSixel_FalseWhenNoDriver ()
+    {
+        ImageView imageView = new () { UseSixel = true };
+
+        // No App/Driver available, so sixel shouldn't be active
+        Assert.False (imageView.IsUsingSixel);
+        imageView.Dispose ();
+    }
+
+    #endregion UseSixel Property
+
+    #region SixelEncoder Property
+
+    [Fact]
+    public void SixelEncoder_DefaultsToNull ()
+    {
+        ImageView imageView = new ();
+        Assert.Null (imageView.SixelEncoder);
+        imageView.Dispose ();
+    }
+
+    [Fact]
+    public void SixelEncoder_CanBeSet ()
+    {
+        SixelEncoder encoder = new () { AvoidBottomScroll = true };
+        ImageView imageView = new () { SixelEncoder = encoder };
+
+        Assert.Same (encoder, imageView.SixelEncoder);
+
+        imageView.Dispose ();
+    }
+
+    #endregion SixelEncoder Property
+
+    #region ScaleNearestNeighbor
+
+    [Fact]
+    public void ScaleNearestNeighbor_IdentityScale_PreservesPixels ()
+    {
+        Color [,] source = CreateGradientImage (4, 4);
+        Color [,] result = ImageView.ScaleNearestNeighbor (source, 4, 4);
+
+        Assert.Equal (4, result.GetLength (0));
+        Assert.Equal (4, result.GetLength (1));
+
+        for (int x = 0; x < 4; x++)
+        {
+            for (int y = 0; y < 4; y++)
+            {
+                Assert.Equal (source [x, y], result [x, y]);
+            }
+        }
+    }
+
+    [Fact]
+    public void ScaleNearestNeighbor_Upscale_CorrectDimensions ()
+    {
+        Color [,] source = CreateSolidImage (2, 2, new Color (100, 100, 100));
+        Color [,] result = ImageView.ScaleNearestNeighbor (source, 6, 6);
+
+        Assert.Equal (6, result.GetLength (0));
+        Assert.Equal (6, result.GetLength (1));
+
+        // All pixels should be the same color since source is solid
+        for (int x = 0; x < 6; x++)
+        {
+            for (int y = 0; y < 6; y++)
+            {
+                Assert.Equal (new Color (100, 100, 100), result [x, y]);
+            }
+        }
+    }
+
+    [Fact]
+    public void ScaleNearestNeighbor_Downscale_CorrectDimensions ()
+    {
+        Color [,] source = CreateSolidImage (10, 10, new Color (50, 50, 50));
+        Color [,] result = ImageView.ScaleNearestNeighbor (source, 3, 3);
+
+        Assert.Equal (3, result.GetLength (0));
+        Assert.Equal (3, result.GetLength (1));
+
+        // All pixels should still be solid
+        for (int x = 0; x < 3; x++)
+        {
+            for (int y = 0; y < 3; y++)
+            {
+                Assert.Equal (new Color (50, 50, 50), result [x, y]);
+            }
+        }
+    }
+
+    [Fact]
+    public void ScaleNearestNeighbor_1x1_Target_ProducesOnePixel ()
+    {
+        Color [,] source = CreateGradientImage (10, 10);
+        Color [,] result = ImageView.ScaleNearestNeighbor (source, 1, 1);
+
+        Assert.Equal (1, result.GetLength (0));
+        Assert.Equal (1, result.GetLength (1));
+
+        // Should be the top-left pixel (nearest neighbor from 0,0)
+        Assert.Equal (source [0, 0], result [0, 0]);
+    }
+
+    [Fact]
+    public void ScaleNearestNeighbor_NonSquare_ScalesCorrectly ()
+    {
+        Color [,] source = CreateSolidImage (4, 2, new Color (200, 100, 50));
+        Color [,] result = ImageView.ScaleNearestNeighbor (source, 8, 4);
+
+        Assert.Equal (8, result.GetLength (0));
+        Assert.Equal (4, result.GetLength (1));
+
+        for (int x = 0; x < 8; x++)
+        {
+            for (int y = 0; y < 4; y++)
+            {
+                Assert.Equal (new Color (200, 100, 50), result [x, y]);
+            }
+        }
+    }
+
+    #endregion ScaleNearestNeighbor
+
+    #region Cell-Based Rendering
+
+    [Fact]
+    public void CellBasedRendering_DrawsBackgroundColors ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 10, Height = 10 };
+        app.Begin (runnable);
+
+        ImageView imageView = new ()
+        {
+            Width = 4,
+            Height = 2,
+            UseSixel = false
+        };
+
+        Color red = new (255, 0, 0);
+        imageView.Image = CreateSolidImage (4, 2, red);
+
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // Verify the cells have background color set to red (spaces with red background)
+        Cell [,]? contents = app.Driver!.Contents;
+        Assert.NotNull (contents);
+
+        // Check that the first cell in the image area has the correct background color
+        Attribute attr = contents! [0, 0].Attribute!.Value;
+        Assert.Equal (red, attr.Background);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void CellBasedRendering_WithNullImage_DrawsNothing ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 10, Height = 10 };
+        app.Begin (runnable);
+
+        ImageView imageView = new ()
+        {
+            Width = 4,
+            Height = 2,
+            UseSixel = false
+        };
+
+        // Image is null — should not throw
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void CellBasedRendering_ScalesImageToViewport ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 20, Height = 20 };
+        app.Begin (runnable);
+
+        // Create a 10x10 image but display in a 5x5 viewport
+        ImageView imageView = new ()
+        {
+            Width = 5,
+            Height = 5,
+            UseSixel = false
+        };
+
+        Color blue = new (0, 0, 255);
+        imageView.Image = CreateSolidImage (10, 10, blue);
+
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // Verify cells have the blue background (image was scaled down)
+        Cell [,]? contents = app.Driver!.Contents;
+        Assert.NotNull (contents);
+        Assert.Equal (blue, contents! [0, 0].Attribute!.Value.Background);
+
+        runnable.Dispose ();
+    }
+
+    #endregion Cell-Based Rendering
+
+    #region Dispose
+
+    [Fact]
+    public void Dispose_CleansUpSixelData ()
+    {
+        ImageView imageView = new ();
+        Color [,] pixels = CreateSolidImage (5, 5, new Color (128, 128, 128));
+        imageView.Image = pixels;
+
+        // Should not throw
+        imageView.Dispose ();
+
+        // Accessing after dispose is a code smell but should not crash
+        Assert.NotNull (imageView.Image); // Still set; just disposed
+    }
+
+    [Fact]
+    public void Dispose_WithNoImage_DoesNotThrow ()
+    {
+        ImageView imageView = new ();
+        imageView.Dispose (); // Should not throw
+    }
+
+    #endregion Dispose
+
+    #region IDesignable
+
+    [Fact]
+    public void EnableForDesign_SetsTestImage ()
+    {
+        ImageView imageView = new ();
+        bool result = ((IDesignable)imageView).EnableForDesign ();
+
+        Assert.True (result);
+        Assert.NotNull (imageView.Image);
+        Assert.Equal (20, imageView.Image!.GetLength (0)); // width
+        Assert.Equal (10, imageView.Image.GetLength (1));  // height
+
+        imageView.Dispose ();
+    }
+
+    [Fact]
+    public void EnableForDesign_CreatesGradientImage ()
+    {
+        ImageView imageView = new ();
+        ((IDesignable)imageView).EnableForDesign ();
+
+        Color [,] image = imageView.Image!;
+
+        // Top-left should be (0, 0, 128)
+        Assert.Equal (new Color (0, 0, 128), image [0, 0]);
+
+        // Bottom-right should be (255, 255, 128)
+        Assert.Equal (new Color (255, 255, 128), image [19, 9]);
+
+        imageView.Dispose ();
+    }
+
+    #endregion IDesignable
+
+    #region SixelToRender IsDirty Flag
+
+    [Fact]
+    public void SixelToRender_IsDirty_DefaultsToTrue ()
+    {
+        SixelToRender sixel = new ();
+        Assert.True (sixel.IsDirty);
+    }
+
+    [Fact]
+    public void SixelToRender_IsDirty_CanBeSetToFalse ()
+    {
+        SixelToRender sixel = new () { IsDirty = false };
+        Assert.False (sixel.IsDirty);
+    }
+
+    [Fact]
+    public void SixelToRender_AlwaysRender_DefaultsToFalse ()
+    {
+        SixelToRender sixel = new ();
+        Assert.False (sixel.AlwaysRender);
+    }
+
+    #endregion SixelToRender IsDirty Flag
+
+    #region Helper Methods
+
+    /// <summary>Creates a solid-color image of the specified dimensions.</summary>
+    private static Color [,] CreateSolidImage (int width, int height, Color color)
+    {
+        Color [,] image = new Color [width, height];
+
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                image [x, y] = color;
+            }
+        }
+
+        return image;
+    }
+
+    /// <summary>Creates a gradient image where pixel color varies by position.</summary>
+    private static Color [,] CreateGradientImage (int width, int height)
+    {
+        Color [,] image = new Color [width, height];
+
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                byte r = (byte)(x * 255 / Math.Max (1, width - 1));
+                byte g = (byte)(y * 255 / Math.Max (1, height - 1));
+                image [x, y] = new Color (r, g, 128);
+            }
+        }
+
+        return image;
+    }
+
+    #endregion Helper Methods
+}

--- a/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
@@ -239,7 +239,7 @@ public class ImageViewTests
     [Fact]
     public void CellBasedRendering_DrawsBackgroundColors ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 10, Height = 10 };
@@ -272,7 +272,7 @@ public class ImageViewTests
     [Fact]
     public void CellBasedRendering_WithNullImage_DrawsNothing ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 10, Height = 10 };
@@ -295,7 +295,7 @@ public class ImageViewTests
     [Fact]
     public void CellBasedRendering_ScalesImageToViewport ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 20, Height = 20 };
@@ -430,7 +430,7 @@ public class ImageViewTests
     [Fact]
     public void ViewportToScreenInPixels_ReturnsCorrectPixelRect ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 40, Height = 20 };
@@ -458,7 +458,7 @@ public class ImageViewTests
     [Fact]
     public void ViewportToScreenInPixels_AccountsForViewPosition ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 40, Height = 20 };
@@ -491,7 +491,7 @@ public class ImageViewTests
     [Fact]
     public void ViewportToScreenInPixels_DifferentResolution ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 40, Height = 20 };
@@ -523,7 +523,7 @@ public class ImageViewTests
     [Fact]
     public void FitImageInViewportInPixels_ZeroSizeImage_ReturnsEmpty ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 40, Height = 20 };
@@ -551,7 +551,7 @@ public class ImageViewTests
     [Fact]
     public void FitImageInViewportInPixels_ImageFitsExactly ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 40, Height = 20 };
@@ -577,7 +577,7 @@ public class ImageViewTests
     [Fact]
     public void FitImageInViewportInPixels_WideImage_ScalesToFitWidth ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 40, Height = 20 };
@@ -605,7 +605,7 @@ public class ImageViewTests
     [Fact]
     public void FitImageInViewportInPixels_TallImage_ScalesToFitHeight ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 40, Height = 20 };
@@ -633,7 +633,7 @@ public class ImageViewTests
     [Fact]
     public void FitImageInViewportInPixels_SmallImage_ScalesUp ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 40, Height = 20 };
@@ -661,7 +661,7 @@ public class ImageViewTests
     [Fact]
     public void FitImageInViewportInPixels_VerySmallImage_ClampsToMinimumOne ()
     {
-        IApplication app = Application.Create ();
+        using IApplication app = Application.Create ();
         app.Init (DriverRegistry.Names.ANSI);
 
         Runnable runnable = new () { Width = 40, Height = 20 };

--- a/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
@@ -686,6 +686,234 @@ public class ImageViewTests
 
     #endregion FitImageInViewportInPixels
 
+    #region FitImageInViewportCells
+
+    [Fact]
+    public void FitImageInViewportCells_ZeroSizeImage_ReturnsEmpty ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        Size result = imageView.FitImageInViewportCells (new Size (0, 0));
+        Assert.Equal (Size.Empty, result);
+
+        result = imageView.FitImageInViewportCells (new Size (100, 0));
+        Assert.Equal (Size.Empty, result);
+
+        result = imageView.FitImageInViewportCells (new Size (0, 100));
+        Assert.Equal (Size.Empty, result);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportCells_SquareImage_AccountsForCellAspectRatio ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        // Cell resolution 10x20: cell aspect ratio = 20/10 = 2.0
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // Viewport: 10 cells wide x 5 cells tall
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // 100x100 pixel image:
+        // After aspect adjustment: imageSize = (100, 100/2.0) = (100, 50)
+        // widthScale = 10/100 = 0.1, heightScale = 5/50 = 0.1
+        // scale = 0.1, result = (100*0.1, 50*0.1) = (10, 5)
+        Size result = imageView.FitImageInViewportCells (new Size (100, 100));
+
+        Assert.Equal (10, result.Width);
+        Assert.Equal (5, result.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportCells_WideImage_ConstrainedByWidth ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // Viewport: 10 cells wide x 10 cells tall
+        ImageView imageView = new () { Width = 10, Height = 10, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // 200x100 pixel image:
+        // After aspect adjustment: imageSize = (200, 100/2.0) = (200, 50)
+        // widthScale = 10/200 = 0.05, heightScale = 10/50 = 0.2
+        // scale = 0.05, result = (200*0.05, 50*0.05) = (10, 2)
+        Size result = imageView.FitImageInViewportCells (new Size (200, 100));
+
+        Assert.Equal (10, result.Width);
+        Assert.Equal (2, result.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportCells_TallImage_ConstrainedByHeight ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // Viewport: 10 cells wide x 5 cells tall
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // 100x400 pixel image:
+        // After aspect adjustment: imageSize = (100, 400/2.0) = (100, 200)
+        // widthScale = 10/100 = 0.1, heightScale = 5/200 = 0.025
+        // scale = 0.025, result = (100*0.025, 200*0.025) = (2, 5)
+        Size result = imageView.FitImageInViewportCells (new Size (100, 400));
+
+        Assert.Equal (2, result.Width);
+        Assert.Equal (5, result.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportCells_SmallImage_ScalesUp ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // Viewport: 20 cells wide x 10 cells tall
+        ImageView imageView = new () { Width = 20, Height = 10, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // 10x20 pixel image:
+        // After aspect adjustment: imageSize = (10, 20/2.0) = (10, 10)
+        // widthScale = 20/10 = 2.0, heightScale = 10/10 = 1.0
+        // scale = 1.0, result = (10*1.0, 10*1.0) = (10, 10)
+        Size result = imageView.FitImageInViewportCells (new Size (10, 20));
+
+        Assert.Equal (10, result.Width);
+        Assert.Equal (10, result.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportCells_NoDriver_UsesDefaultAspectRatio ()
+    {
+        // Without a driver, the fallback cell aspect ratio is 2.0
+        ImageView imageView = new () { Width = 10, Height = 5 };
+        View host = new () { Width = 20, Height = 20 };
+        host.Add (imageView);
+        host.BeginInit ();
+        host.EndInit ();
+        host.Layout ();
+
+        // 100x100 pixel image:
+        // Default aspect ratio = 2.0 → imageSize = (100, 100/2.0) = (100, 50)
+        // widthScale = 10/100 = 0.1, heightScale = 5/50 = 0.1
+        // scale = 0.1, result = (100*0.1, 50*0.1) = (10, 5)
+        Size result = imageView.FitImageInViewportCells (new Size (100, 100));
+
+        Assert.Equal (10, result.Width);
+        Assert.Equal (5, result.Height);
+
+        host.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportCells_DifferentResolution_AdjustsAspectRatio ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        // Cell resolution 8x16: cell aspect ratio = 16/8 = 2.0
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (8, 16) });
+
+        // Viewport: 10 cells wide x 5 cells tall
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // 80x80 pixel image:
+        // After aspect adjustment: imageSize = (80, 80/2.0) = (80, 40)
+        // widthScale = 10/80 = 0.125, heightScale = 5/40 = 0.125
+        // scale = 0.125, result = (80*0.125, 40*0.125) = (10, 5)
+        Size result = imageView.FitImageInViewportCells (new Size (80, 80));
+
+        Assert.Equal (10, result.Width);
+        Assert.Equal (5, result.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportCells_VerySmallImage_ClampsToMinimumOne ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // 1x1 viewport = very small cell area
+        ImageView imageView = new () { Width = 1, Height = 1, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // Even with a very wide image, result dimensions should be >= 1
+        Size result = imageView.FitImageInViewportCells (new Size (1000, 1));
+
+        Assert.True (result.Width >= 1);
+        Assert.True (result.Height >= 1);
+
+        runnable.Dispose ();
+    }
+
+    #endregion FitImageInViewportCells
+
     #region Helper Methods
 
     /// <summary>Creates a solid-color image of the specified dimensions.</summary>

--- a/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
@@ -144,16 +144,17 @@ public class ImageViewTests
     public void ScaleNearestNeighbor_IdentityScale_PreservesPixels ()
     {
         Color [,] source = CreateGradientImage (4, 4);
-        Color [,] result = ImageView.ScaleNearestNeighbor (source, 4, 4);
+        Color [,] destination = new Color [4, 4];
+        ImageView.ScaleNearestNeighbor (source, destination);
 
-        Assert.Equal (4, result.GetLength (0));
-        Assert.Equal (4, result.GetLength (1));
+        Assert.Equal (4, destination.GetLength (0));
+        Assert.Equal (4, destination.GetLength (1));
 
         for (int x = 0; x < 4; x++)
         {
             for (int y = 0; y < 4; y++)
             {
-                Assert.Equal (source [x, y], result [x, y]);
+                Assert.Equal (source [x, y], destination [x, y]);
             }
         }
     }
@@ -162,17 +163,18 @@ public class ImageViewTests
     public void ScaleNearestNeighbor_Upscale_CorrectDimensions ()
     {
         Color [,] source = CreateSolidImage (2, 2, new Color (100, 100, 100));
-        Color [,] result = ImageView.ScaleNearestNeighbor (source, 6, 6);
+        Color [,] destination = new Color [6, 6];
+        ImageView.ScaleNearestNeighbor (source, destination);
 
-        Assert.Equal (6, result.GetLength (0));
-        Assert.Equal (6, result.GetLength (1));
+        Assert.Equal (6, destination.GetLength (0));
+        Assert.Equal (6, destination.GetLength (1));
 
         // All pixels should be the same color since source is solid
         for (int x = 0; x < 6; x++)
         {
             for (int y = 0; y < 6; y++)
             {
-                Assert.Equal (new Color (100, 100, 100), result [x, y]);
+                Assert.Equal (new Color (100, 100, 100), destination [x, y]);
             }
         }
     }
@@ -181,17 +183,18 @@ public class ImageViewTests
     public void ScaleNearestNeighbor_Downscale_CorrectDimensions ()
     {
         Color [,] source = CreateSolidImage (10, 10, new Color (50, 50, 50));
-        Color [,] result = ImageView.ScaleNearestNeighbor (source, 3, 3);
+        Color [,] destination = new Color [3, 3];
+        ImageView.ScaleNearestNeighbor (source, destination);
 
-        Assert.Equal (3, result.GetLength (0));
-        Assert.Equal (3, result.GetLength (1));
+        Assert.Equal (3, destination.GetLength (0));
+        Assert.Equal (3, destination.GetLength (1));
 
         // All pixels should still be solid
         for (int x = 0; x < 3; x++)
         {
             for (int y = 0; y < 3; y++)
             {
-                Assert.Equal (new Color (50, 50, 50), result [x, y]);
+                Assert.Equal (new Color (50, 50, 50), destination [x, y]);
             }
         }
     }
@@ -200,29 +203,31 @@ public class ImageViewTests
     public void ScaleNearestNeighbor_1x1_Target_ProducesOnePixel ()
     {
         Color [,] source = CreateGradientImage (10, 10);
-        Color [,] result = ImageView.ScaleNearestNeighbor (source, 1, 1);
+        Color [,] destination = new Color [1, 1];
+        ImageView.ScaleNearestNeighbor (source, destination);
 
-        Assert.Equal (1, result.GetLength (0));
-        Assert.Equal (1, result.GetLength (1));
+        Assert.Equal (1, destination.GetLength (0));
+        Assert.Equal (1, destination.GetLength (1));
 
         // Should be the top-left pixel (nearest neighbor from 0,0)
-        Assert.Equal (source [0, 0], result [0, 0]);
+        Assert.Equal (source [0, 0], destination [0, 0]);
     }
 
     [Fact]
     public void ScaleNearestNeighbor_NonSquare_ScalesCorrectly ()
     {
         Color [,] source = CreateSolidImage (4, 2, new Color (200, 100, 50));
-        Color [,] result = ImageView.ScaleNearestNeighbor (source, 8, 4);
+        Color [,] destination = new Color [8, 4];
+        ImageView.ScaleNearestNeighbor (source, destination);
 
-        Assert.Equal (8, result.GetLength (0));
-        Assert.Equal (4, result.GetLength (1));
+        Assert.Equal (8, destination.GetLength (0));
+        Assert.Equal (4, destination.GetLength (1));
 
         for (int x = 0; x < 8; x++)
         {
             for (int y = 0; y < 4; y++)
             {
-                Assert.Equal (new Color (200, 100, 50), result [x, y]);
+                Assert.Equal (new Color (200, 100, 50), destination [x, y]);
             }
         }
     }
@@ -404,6 +409,282 @@ public class ImageViewTests
     }
 
     #endregion SixelToRender IsDirty Flag
+
+    #region ViewportToScreenInPixels
+    [Fact]
+    public void ViewportToScreenInPixels_Throws_WhenNoSixelSupport ()
+    {
+        ImageView imageView = new () { Width = 10, Height = 5 };
+        View host = new () { Width = 20, Height = 20 };
+        host.Add (imageView);
+        host.BeginInit ();
+        host.EndInit ();
+        host.Layout ();
+
+        // No App/Driver — should throw
+        Assert.Throws<InvalidOperationException> (() => imageView.ViewportToScreenInPixels ());
+
+        host.Dispose ();
+    }
+
+    [Fact]
+    public void ViewportToScreenInPixels_ReturnsCorrectPixelRect ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        // Configure sixel support with 10x20 pixel resolution per cell
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        ImageView imageView = new () { Width = 8, Height = 4, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        Rectangle pixelRect = imageView.ViewportToScreenInPixels ();
+
+        // Width: 8 cells * 10 px/cell = 80 px
+        Assert.Equal (80, pixelRect.Width);
+
+        // Height: 4 cells * 20 px/cell = 80 px (via GetHeightInPixels)
+        Assert.Equal (80, pixelRect.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void ViewportToScreenInPixels_AccountsForViewPosition ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        ImageView imageView = new () { X = 3, Y = 2, Width = 5, Height = 3, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        Rectangle pixelRect = imageView.ViewportToScreenInPixels ();
+
+        // X: 3 cells * 10 px/cell = 30 px
+        Assert.Equal (30, pixelRect.X);
+
+        // Y: 2 cells * 20 px/cell = 40 px
+        Assert.Equal (40, pixelRect.Y);
+
+        // Width: 5 cells * 10 px/cell = 50 px
+        Assert.Equal (50, pixelRect.Width);
+
+        // Height: 3 cells * 20 px/cell = 60 px
+        Assert.Equal (60, pixelRect.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void ViewportToScreenInPixels_DifferentResolution ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        // Use a non-default resolution (8x16)
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (8, 16) });
+
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        Rectangle pixelRect = imageView.ViewportToScreenInPixels ();
+
+        // Width: 10 cells * 8 px/cell = 80 px
+        Assert.Equal (80, pixelRect.Width);
+
+        // Height: 5 cells * 16 px/cell = 80 px
+        Assert.Equal (80, pixelRect.Height);
+
+        runnable.Dispose ();
+    }
+
+    #endregion ViewportToScreenInPixels
+
+    #region FitImageInViewportInPixels
+
+    [Fact]
+    public void FitImageInViewportInPixels_ZeroSizeImage_ReturnsEmpty ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        Size result = imageView.FitImageInViewportInPixels (new Size (0, 0));
+        Assert.Equal (Size.Empty, result);
+
+        result = imageView.FitImageInViewportInPixels (new Size (100, 0));
+        Assert.Equal (Size.Empty, result);
+
+        result = imageView.FitImageInViewportInPixels (new Size (0, 100));
+        Assert.Equal (Size.Empty, result);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportInPixels_ImageFitsExactly ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // Viewport: 10 cells * 10 px = 100 px wide, 5 cells * 20 px = 100 px tall
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // Image is exactly the viewport pixel size
+        Size result = imageView.FitImageInViewportInPixels (new Size (100, 100));
+
+        Assert.Equal (100, result.Width);
+        Assert.Equal (100, result.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportInPixels_WideImage_ScalesToFitWidth ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // Viewport: 10 cells * 10 px = 100 px wide, 5 cells * 20 px = 100 px tall
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // Image is 200x100 (2:1 aspect) — width-constrained
+        // Scale = min(100/200, 100/100) = min(0.5, 1.0) = 0.5
+        // Result: 200*0.5 = 100 wide, 100*0.5 = 50 tall
+        Size result = imageView.FitImageInViewportInPixels (new Size (200, 100));
+
+        Assert.Equal (100, result.Width);
+        Assert.Equal (50, result.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportInPixels_TallImage_ScalesToFitHeight ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // Viewport: 10 cells * 10 px = 100 px wide, 5 cells * 20 px = 100 px tall
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // Image is 100x200 (1:2 aspect) — height-constrained
+        // Scale = min(100/100, 100/200) = min(1.0, 0.5) = 0.5
+        // Result: 100*0.5 = 50 wide, 200*0.5 = 100 tall
+        Size result = imageView.FitImageInViewportInPixels (new Size (100, 200));
+
+        Assert.Equal (50, result.Width);
+        Assert.Equal (100, result.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportInPixels_SmallImage_ScalesUp ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // Viewport: 10 cells * 10 px = 100 px wide, 5 cells * 20 px = 100 px tall
+        ImageView imageView = new () { Width = 10, Height = 5, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // Image is 10x20 (1:2 aspect) — height-constrained
+        // Scale = min(100/10, 100/20) = min(10, 5) = 5
+        // Result: 10*5 = 50 wide, 20*5 = 100 tall
+        Size result = imageView.FitImageInViewportInPixels (new Size (10, 20));
+
+        Assert.Equal (50, result.Width);
+        Assert.Equal (100, result.Height);
+
+        runnable.Dispose ();
+    }
+
+    [Fact]
+    public void FitImageInViewportInPixels_VerySmallImage_ClampsToMinimumOne ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 40, Height = 20 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+
+        // 1x1 viewport = 10x20 pixel viewport
+        ImageView imageView = new () { Width = 1, Height = 1, SixelEncoder = new SixelEncoder () };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        // Even with a 1000x1 image scaled to fit 10x20, width and height should be >= 1
+        Size result = imageView.FitImageInViewportInPixels (new Size (1000, 1));
+
+        Assert.True (result.Width >= 1);
+        Assert.True (result.Height >= 1);
+
+        runnable.Dispose ();
+    }
+
+    #endregion FitImageInViewportInPixels
 
     #region Helper Methods
 


### PR DESCRIPTION
Creates a ImageView view and uses it in UICatalog.

This view takes no new dependencies in Terminal.Gui so it operates on raw Color[,] arrays. The performance for resizing these is poor. As a result, it may make sense to take an optional lambda to allow the constructor to provide a more efficient resizing implementation using their image library of choice.

## Fixes

- Fixes #5291

## Proposed Changes/Todos


## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
