### PR TITLE
Handle TypeLoadException in config property scans

### DIFF
--- a/Terminal.Gui/Configuration/ConfigProperty.cs
+++ b/Terminal.Gui/Configuration/ConfigProperty.cs
@@ -185,7 +185,16 @@ public class ConfigProperty
     /// <returns>True if the PropertyInfo has a ConfigurationPropertyAttribute; otherwise, false</returns>
     internal static bool HasConfigurationPropertyAttribute (PropertyInfo propertyInfo)
     {
-        return propertyInfo.GetCustomAttribute (typeof (ConfigurationPropertyAttribute)) != null;
+        try
+        {
+            return propertyInfo.GetCustomAttribute (typeof (ConfigurationPropertyAttribute)) != null;
+        }
+        catch (TypeLoadException)
+        {
+            // Foreign assemblies loaded into the process can carry broken custom-attribute metadata.
+            // Those properties are not Terminal.Gui configuration hosts and should not terminate the scan.
+            return false;
+        }
     }
 
     /// <summary>
@@ -510,17 +519,26 @@ public class ConfigProperty
         // Supplement the built-in list by discovering host types defined outside Terminal.Gui
         // (test suites, plugins, embedding apps). This remains important under NativeAOT for
         // consumer-rooted host types such as app-defined AppSettingsScope entries.
-        ScanLoadedAssembliesForConfigPropertyHosts (dict);
+        ScanLoadedAssembliesForConfigPropertyHosts (dict, AppDomain.CurrentDomain.GetAssemblies ());
 
         _classesWithConfigProps = dict.ToImmutableSortedDictionary ();
     }
 
     [RequiresDynamicCode ("Uses reflection to scan assemblies for configuration properties.")]
     [RequiresUnreferencedCode ("Scanning for types via reflection is not trim-safe.")]
-    private static void ScanLoadedAssembliesForConfigPropertyHosts (Dictionary<string, Type> dict)
+    internal static ImmutableSortedDictionary<string, Type> ScanAssembliesForConfigPropertyHosts (IEnumerable<Assembly> assemblies)
     {
-        Assembly [] assemblies = AppDomain.CurrentDomain.GetAssemblies ();
+        Dictionary<string, Type> dict = new (StringComparer.InvariantCultureIgnoreCase);
 
+        ScanLoadedAssembliesForConfigPropertyHosts (dict, assemblies);
+
+        return dict.ToImmutableSortedDictionary ();
+    }
+
+    [RequiresDynamicCode ("Uses reflection to scan assemblies for configuration properties.")]
+    [RequiresUnreferencedCode ("Scanning for types via reflection is not trim-safe.")]
+    private static void ScanLoadedAssembliesForConfigPropertyHosts (Dictionary<string, Type> dict, IEnumerable<Assembly> assemblies)
+    {
         foreach (Assembly assembly in assemblies)
         {
             try

--- a/Tests/TestAssets/ConfigPropertyTypeLoad/AttrProviderFull/AttrProviderFull.csproj
+++ b/Tests/TestAssets/ConfigPropertyTypeLoad/AttrProviderFull/AttrProviderFull.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>FakeCodeAnalysis</AssemblyName>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Tests/TestAssets/ConfigPropertyTypeLoad/AttrProviderFull/MemberNotNullWhenAttribute.cs
+++ b/Tests/TestAssets/ConfigPropertyTypeLoad/AttrProviderFull/MemberNotNullWhenAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage (AttributeTargets.Method | AttributeTargets.Property, Inherited = false)]
+    public sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        public MemberNotNullWhenAttribute (bool returnValue, params string [] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        public string [] Members { get; }
+
+        public bool ReturnValue { get; }
+    }
+}

--- a/Tests/TestAssets/ConfigPropertyTypeLoad/AttrProviderMissing/AttrProviderMissing.csproj
+++ b/Tests/TestAssets/ConfigPropertyTypeLoad/AttrProviderMissing/AttrProviderMissing.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>FakeCodeAnalysis</AssemblyName>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/Tests/TestAssets/ConfigPropertyTypeLoad/AttrProviderMissing/PlaceholderType.cs
+++ b/Tests/TestAssets/ConfigPropertyTypeLoad/AttrProviderMissing/PlaceholderType.cs
@@ -1,0 +1,6 @@
+namespace Placeholder
+{
+    public class PlaceholderType
+    {
+    }
+}

--- a/Tests/TestAssets/ConfigPropertyTypeLoad/ConsumerLib/ConsumerLib.csproj
+++ b/Tests/TestAssets/ConfigPropertyTypeLoad/ConsumerLib/ConsumerLib.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AttrProviderFull\AttrProviderFull.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/TestAssets/ConfigPropertyTypeLoad/ConsumerLib/FixtureType.cs
+++ b/Tests/TestAssets/ConfigPropertyTypeLoad/ConsumerLib/FixtureType.cs
@@ -1,0 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ConsumerLib
+{
+    public class FixtureType
+    {
+        [MemberNotNullWhen (true, nameof (Value))]
+        public bool HasValue => !string.IsNullOrEmpty (Value);
+
+        public string Value { get; set; } = string.Empty;
+    }
+}

--- a/Tests/UnitTests.NonParallelizable/Configuration/ConfigPropertyAssemblyScanTests.cs
+++ b/Tests/UnitTests.NonParallelizable/Configuration/ConfigPropertyAssemblyScanTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace UnitTests.NonParallelizable.ConfigurationTests;
+
+public class ConfigPropertyAssemblyScanTests
+{
+    [ConfigurationProperty (Scope = typeof (ConfigPropertyAssemblyScanTestsScope))]
+    public static bool? ScanSentinel { get; set; }
+
+    private class ConfigPropertyAssemblyScanTestsScope : Scope<ConfigPropertyAssemblyScanTestsScope>
+    {
+    }
+
+    [Fact]
+    public void ScanAssembliesForConfigPropertyHosts_Skips_TypeLoadException_From_Foreign_CustomAttribute_Metadata ()
+    {
+        string fixtureRoot = Path.Combine (AppContext.BaseDirectory, "ConfigPropertyTypeLoadFixtures");
+        string providerPath = Path.Combine (fixtureRoot, "FakeCodeAnalysis.dll");
+        string consumerPath = Path.Combine (fixtureRoot, "ConsumerLib.dll");
+
+        Assert.True (File.Exists (providerPath));
+        Assert.True (File.Exists (consumerPath));
+
+        AssemblyLoadContext loadContext = new (nameof (ConfigPropertyAssemblyScanTests), isCollectible: true);
+        loadContext.LoadFromAssemblyPath (providerPath);
+        Assembly consumerAssembly = loadContext.LoadFromAssemblyPath (consumerPath);
+        Type consumerType = consumerAssembly.GetType ("ConsumerLib.FixtureType", throwOnError: true)!;
+        PropertyInfo consumerProperty = consumerType.GetProperty ("HasValue")!;
+
+        Assert.Throws<TypeLoadException> (
+                                          () => consumerProperty.GetCustomAttribute (typeof (ConfigurationPropertyAttribute))
+                                         );
+
+        ImmutableSortedDictionary<string, Type> hosts =
+            ConfigProperty.ScanAssembliesForConfigPropertyHosts ([consumerAssembly, typeof (ConfigPropertyAssemblyScanTests).Assembly]);
+
+        Assert.Contains (nameof (ConfigPropertyAssemblyScanTests), hosts.Keys);
+        Assert.Same (typeof (ConfigPropertyAssemblyScanTests), hosts [nameof (ConfigPropertyAssemblyScanTests)]);
+
+        loadContext.Unload ();
+    }
+}

--- a/Tests/UnitTests.NonParallelizable/UnitTests.NonParallelizable.csproj
+++ b/Tests/UnitTests.NonParallelizable/UnitTests.NonParallelizable.csproj
@@ -38,8 +38,8 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\Terminal.Gui\Terminal.Gui.csproj" />
 		<ProjectReference Include="..\AppTestHelpers\AppTestHelpers.csproj" />
-		<ProjectReference Include="..\TestAssets\ConfigPropertyTypeLoad\ConsumerLib\ConsumerLib.csproj" ReferenceOutputAssembly="false" />
-		<ProjectReference Include="..\TestAssets\ConfigPropertyTypeLoad\AttrProviderMissing\AttrProviderMissing.csproj" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\TestAssets\ConfigPropertyTypeLoad\ConsumerLib\ConsumerLib.csproj" ReferenceOutputAssembly="false" OutputItemType="ConfigPropertyTypeLoadFixture" />
+		<ProjectReference Include="..\TestAssets\ConfigPropertyTypeLoad\AttrProviderMissing\AttrProviderMissing.csproj" ReferenceOutputAssembly="false" OutputItemType="ConfigPropertyTypeLoadFixture" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="xunit.runner.json">
@@ -51,8 +51,7 @@
 			<ConfigPropertyTypeLoadFixtureRoot>$(TargetDir)ConfigPropertyTypeLoadFixtures\</ConfigPropertyTypeLoadFixtureRoot>
 		</PropertyGroup>
 		<MakeDir Directories="$(ConfigPropertyTypeLoadFixtureRoot)" />
-		<Copy SourceFiles="..\TestAssets\ConfigPropertyTypeLoad\ConsumerLib\bin\$(Configuration)\netstandard2.0\ConsumerLib.dll" DestinationFolder="$(ConfigPropertyTypeLoadFixtureRoot)" />
-		<Copy SourceFiles="..\TestAssets\ConfigPropertyTypeLoad\AttrProviderMissing\bin\$(Configuration)\netstandard2.0\FakeCodeAnalysis.dll" DestinationFolder="$(ConfigPropertyTypeLoadFixtureRoot)" />
+		<Copy SourceFiles="@(ConfigPropertyTypeLoadFixture)" DestinationFolder="$(ConfigPropertyTypeLoadFixtureRoot)" SkipUnchangedFiles="true" />
 	</Target>
 	<ItemGroup>
 		<Using Include="System.Drawing" />

--- a/Tests/UnitTests.NonParallelizable/UnitTests.NonParallelizable.csproj
+++ b/Tests/UnitTests.NonParallelizable/UnitTests.NonParallelizable.csproj
@@ -38,12 +38,22 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\Terminal.Gui\Terminal.Gui.csproj" />
 		<ProjectReference Include="..\AppTestHelpers\AppTestHelpers.csproj" />
+		<ProjectReference Include="..\TestAssets\ConfigPropertyTypeLoad\ConsumerLib\ConsumerLib.csproj" ReferenceOutputAssembly="false" />
+		<ProjectReference Include="..\TestAssets\ConfigPropertyTypeLoad\AttrProviderMissing\AttrProviderMissing.csproj" ReferenceOutputAssembly="false" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="xunit.runner.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
+	<Target Name="CopyConfigPropertyTypeLoadFixtures" AfterTargets="Build">
+		<PropertyGroup>
+			<ConfigPropertyTypeLoadFixtureRoot>$(TargetDir)ConfigPropertyTypeLoadFixtures\</ConfigPropertyTypeLoadFixtureRoot>
+		</PropertyGroup>
+		<MakeDir Directories="$(ConfigPropertyTypeLoadFixtureRoot)" />
+		<Copy SourceFiles="..\TestAssets\ConfigPropertyTypeLoad\ConsumerLib\bin\$(Configuration)\netstandard2.0\ConsumerLib.dll" DestinationFolder="$(ConfigPropertyTypeLoadFixtureRoot)" />
+		<Copy SourceFiles="..\TestAssets\ConfigPropertyTypeLoad\AttrProviderMissing\bin\$(Configuration)\netstandard2.0\FakeCodeAnalysis.dll" DestinationFolder="$(ConfigPropertyTypeLoadFixtureRoot)" />
+	</Target>
 	<ItemGroup>
 		<Using Include="System.Drawing" />
 		<Using Include="Terminal.Gui" />


### PR DESCRIPTION
## Summary
- handle `TypeLoadException` while checking foreign properties for `ConfigurationPropertyAttribute`
- expose the assembly-scan helper so the failure can be proven directly in tests
- add deterministic fixture-backed proof for the custom-attribute metadata failure shape

## Why
This supersedes the closed #5124 thread with the corrected proof.

The failure is not a plain `Assembly.GetTypes()` repro on modern CoreCLR. The real downstream failure happens later in the same config-host scan, when `ConfigProperty.Initialize()` reflects over properties from foreign loaded assemblies and `PropertyInfo.GetCustomAttribute(...)` throws a plain `TypeLoadException` while resolving broken custom-attribute metadata.

The new test proves that exact shape with two fixture assemblies:
- `ConsumerLib.dll` is compiled against a provider assembly that contains `System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute`
- at runtime the test loads a same-identity replacement provider assembly that no longer contains that type
- reflecting `GetCustomAttribute(typeof(ConfigurationPropertyAttribute))` on the consumer property throws `TypeLoadException`
- `ConfigProperty.ScanAssembliesForConfigPropertyHosts(...)` now skips that foreign property and continues scanning later assemblies

That matches the downstream `MemberNotNullWhenAttribute` failure we were seeing from loaded test-platform assemblies, but reduces it to a deterministic upstream test.

## Validation
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --project Tests/UnitTests.NonParallelizable/UnitTests.NonParallelizable.csproj --no-build -- --filter-class UnitTests.NonParallelizable.ConfigurationTests.ConfigPropertyAssemblyScanTests`
- `dotnet test --project Tests/UnitTests.NonParallelizable/UnitTests.NonParallelizable.csproj --no-build -- --filter-namespace UnitTests.NonParallelizable.ConfigurationTests`
- `dotnet test --project Tests/UnitTestsParallelizable/UnitTests.Parallelizable.csproj --no-build -- --filter-namespace ConfigurationTests`
- `dotnet test --project Tests/UnitTests.NonParallelizable/UnitTests.NonParallelizable.csproj --no-build`
- `dotnet test --project Tests/UnitTestsParallelizable/UnitTests.Parallelizable.csproj --no-build`
