### PR TITLE
Fixes #5316. Fix FileDialog End key in path field

### DIFF
--- a/Terminal.Gui/Views/FileDialogs/FileDialog.Navigation.cs
+++ b/Terminal.Gui/Views/FileDialogs/FileDialog.Navigation.cs
@@ -194,8 +194,21 @@ public partial class FileDialog
 
     private static void SuppressIfBadChar (Key k)
     {
-        // don't let user type bad letters
-        var ch = (char)k;
+        // Only suppress actual typed printable characters.
+        // Navigation keys (Home/End/etc.) must pass through to key bindings.
+        if (k.IsAlt || k.IsCtrl)
+        {
+            return;
+        }
+
+        string grapheme = k.AsGrapheme;
+
+        if (grapheme.Length != 1)
+        {
+            return;
+        }
+
+        char ch = grapheme [0];
 
         if (_badChars.Contains (ch))
         {

--- a/Tests/UnitTestsParallelizable/Views/AppendAutocompleteTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/AppendAutocompleteTests.cs
@@ -84,6 +84,49 @@ public class AppendAutocompleteTests : TestDriverBase
     }
 
     [Fact]
+    public void ProcessKey_End_ReturnsFalse_WhenSuggestionExists ()
+    {
+        // Copilot - End should not be consumed by AppendAutocomplete.
+        // This lets TextField's normal End command move the cursor.
+        // Arrange: focused text field with "f" at end and suggestion "fish"
+        TextField tf = new () { Text = "f" };
+        tf.SetFocus ();
+        tf.MoveEnd ();
+
+        AppendAutocomplete ac = new (tf);
+        ((SingleWordSuggestionGenerator)ac.SuggestionGenerator).AllSuggestions = ["fish"];
+
+        AutocompleteContext context = new ([new Cell (Grapheme: "f")], cursorPosition: 1);
+        ac.GenerateSuggestions (context);
+
+        Assert.NotEmpty (ac.Suggestions);
+
+        // Act
+        bool result = ac.ProcessKey (Key.End);
+
+        // Assert: End was not consumed by autocomplete
+        Assert.False (result);
+        Assert.Equal ("f", tf.Text);
+        Assert.NotEmpty (ac.Suggestions);
+    }
+
+    [Fact]
+    public void ProcessKey_End_ReturnsFalse_WhenNoSuggestions ()
+    {
+        // Copilot - End key should NOT consume the event when no suggestion is showing,
+        // allowing the normal MoveEnd command to run.
+        // Arrange: text field without suggestions
+        TextField tf = new () { Text = "f" };
+        AppendAutocomplete ac = new (tf);
+
+        // Act
+        bool result = ac.ProcessKey (Key.End);
+
+        // Assert: End was not consumed
+        Assert.False (result);
+    }
+
+    [Fact]
     public void AcceptSelectionIfAny_AcceptsSuggestionWhenFocused ()
     {
         // Arrange: focused text field with "f" at end and suggestion "fish"

--- a/Tests/UnitTestsParallelizable/Views/FileDialogResultTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/FileDialogResultTests.cs
@@ -170,6 +170,57 @@ public class FileDialogResultTests
         Assert.False (tableView.Style.ShowVerticalCellLineForLastColumn);
     }
 
+    [Fact]
+    public void FileDialog_PathField_End_MovesInsertionPointToEnd ()
+    {
+        // Copilot
+        MockFileSystem fs = new ();
+        fs.AddDirectory ("/testdir");
+        using FileDialog fd = new TestableFileDialog (fs);
+
+        FieldInfo? tbPathField = typeof (FileDialog).GetField ("_tbPath", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull (tbPathField);
+
+        TextField tbPath = Assert.IsType<TextField> (tbPathField!.GetValue (fd));
+        tbPath.Text = "/testdir/example.txt";
+
+        tbPath.NewKeyDownEvent (Key.Home);
+        Assert.Equal (0, tbPath.InsertionPoint);
+
+        tbPath.NewKeyDownEvent (Key.End);
+        Assert.Equal (tbPath.Text.Length, tbPath.InsertionPoint);
+    }
+
+    [Theory]
+    [InlineData ('"')]
+    [InlineData ('<')]
+    [InlineData ('>')]
+    [InlineData ('|')]
+    [InlineData ('*')]
+    [InlineData ('?')]
+    public void FileDialog_PathField_BadChars_AreSuppressed (char badChar)
+    {
+        // Copilot
+        MockFileSystem fs = new ();
+        fs.AddDirectory ("/testdir");
+        using FileDialog fd = new TestableFileDialog (fs);
+
+        FieldInfo? tbPathField = typeof (FileDialog).GetField ("_tbPath", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull (tbPathField);
+
+        TextField tbPath = Assert.IsType<TextField> (tbPathField!.GetValue (fd));
+        tbPath.Text = "/testdir/";
+        tbPath.MoveEnd ();
+
+        int insertionPointBefore = tbPath.InsertionPoint;
+        string textBefore = tbPath.Text;
+
+        tbPath.NewKeyDownEvent (new Key (badChar));
+
+        Assert.Equal (textBefore, tbPath.Text);
+        Assert.Equal (insertionPointBefore, tbPath.InsertionPoint);
+    }
+
     /// <summary>Testable subclass that exposes the internal file-system constructor.</summary>
     private sealed class TestableFileDialog : FileDialog
     {


### PR DESCRIPTION
<details><summary>Copilot Session</summary><p>[98754f4a-2722-4beb-919b-4ec49c52170e]</p></details>

## Summary
- Fix `FileDialog` path-field key filtering so navigation keys like `End` are not treated as bad characters.
- Keep bad-character suppression for typed path characters (`"`, `<`, `>`, `|`, `*`, `?`).
- Add regression tests for both behaviors.

## Changes
- `FileDialog.Navigation.SuppressIfBadChar` now evaluates only single printable grapheme input.
- Added `FileDialog_PathField_End_MovesInsertionPointToEnd`.
- Added `FileDialog_PathField_BadChars_AreSuppressed`.
- Added `AppendAutocomplete` tests to ensure `End` is not consumed by autocomplete.
