### PR TITLE
feat: add Command.InsertCaretAbove / .InsertCaretBelow (#5318)

### DIFF
--- a/Terminal.Gui/Input/Command.cs
+++ b/Terminal.Gui/Input/Command.cs
@@ -358,4 +358,24 @@ public enum Command
     Edit,
 
     #endregion
+
+    #region Multi-Caret Commands
+
+    /// <summary>
+    ///     Adds an additional caret one line above the topmost caret (multi-caret editing),
+    ///     preserving the sticky visual column. Mirrors VS Code's
+    ///     <c>editor.action.insertCursorAbove</c>. Views that support multi-caret bind this
+    ///     through <see cref="View.KeyBindings"/> or their configurable default key bindings.
+    /// </summary>
+    InsertCaretAbove,
+
+    /// <summary>
+    ///     Adds an additional caret one line below the bottommost caret (multi-caret editing),
+    ///     preserving the sticky visual column. Mirrors VS Code's
+    ///     <c>editor.action.insertCursorBelow</c>. Views that support multi-caret bind this
+    ///     through <see cref="View.KeyBindings"/> or their configurable default key bindings.
+    /// </summary>
+    InsertCaretBelow,
+
+    #endregion
 }

--- a/Tests/UnitTestsParallelizable/Input/CommandInsertCaretEnumTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/CommandInsertCaretEnumTests.cs
@@ -1,0 +1,61 @@
+// Claude - Opus 4.7
+
+using Terminal.Gui.Input;
+
+namespace UnitTestsParallelizable.Input;
+
+/// <summary>
+///     Tests for the multi-caret <see cref="Command"/> members added for #5318
+///     (consumed by gui-cs/Editor vertical multi-caret). The enum shape is part of
+///     the contract: the members must exist, be distinct, carry their readable
+///     names, and be appended at the end so persisted configs never silently
+///     rebind when the enum grows.
+/// </summary>
+public class CommandInsertCaretEnumTests
+{
+    [Theory]
+    [InlineData (Command.InsertCaretAbove)]
+    [InlineData (Command.InsertCaretBelow)]
+    public void InsertCaretCommand_IsDefined (Command command)
+    {
+        Assert.True (Enum.IsDefined (command));
+    }
+
+    [Fact]
+    public void InsertCaretCommands_AreDistinct ()
+    {
+        Assert.NotEqual (Command.InsertCaretAbove, Command.InsertCaretBelow);
+    }
+
+    [Theory]
+    [InlineData (Command.InsertCaretAbove, "InsertCaretAbove")]
+    [InlineData (Command.InsertCaretBelow, "InsertCaretBelow")]
+    public void InsertCaretCommand_HasReadableName (Command command, string expectedName)
+    {
+        // The readable name is what serializes into config.json (see
+        // CommandInsertCaretKeyBindingTests). A rename would silently break
+        // every user's persisted binding, so pin it.
+        Assert.Equal (expectedName, Enum.GetName (command));
+    }
+
+    [Fact]
+    public void InsertCaretCommands_AreAppendedAtEnd_NoRenumbering ()
+    {
+        // #5319 appends the two members at the END of the enum specifically so
+        // no pre-existing member's implicit value shifts (serialization-stable;
+        // a persisted (Command) value keeps resolving to the same command).
+        // Assert it positionally: every other member has a lower underlying
+        // value than InsertCaretAbove, and InsertCaretBelow is the maximum.
+        Command [] all = Enum.GetValues<Command> ();
+
+        var aboveValue = (int)Command.InsertCaretAbove;
+        var belowValue = (int)Command.InsertCaretBelow;
+
+        Assert.Equal (all.Max (c => (int)c), belowValue);
+        Assert.True (belowValue > aboveValue);
+
+        Assert.All (
+                    all.Where (c => c != Command.InsertCaretAbove && c != Command.InsertCaretBelow),
+                    other => Assert.True ((int)other < aboveValue, $"{other} ({(int)other}) is not below InsertCaretAbove ({aboveValue}) — the enum was renumbered, breaking persisted configs"));
+    }
+}

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/CommandInsertCaretKeyBindingTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/CommandInsertCaretKeyBindingTests.cs
@@ -1,0 +1,99 @@
+// Claude - Opus 4.7
+
+using System.Text.Json;
+
+namespace InputTests;
+
+/// <summary>
+///     The acceptance criterion for #5318: the new multi-caret commands must
+///     round-trip through the configuration serializer <b>by readable name</b>
+///     (not as a bare number), so a consumer's <c>[ConfigurationProperty]</c>
+///     default key bindings are discoverable and a user can override them in
+///     <c>config.json</c> by name — exactly the gui-cs/Editor scenario that
+///     forced the <c>(Command)1001/1002</c> magic-int workaround. Mirrors
+///     <see cref="KeyBindingSchemaTests"/> and uses the same canonical options.
+/// </summary>
+public class CommandInsertCaretKeyBindingTests
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new () { TypeInfoResolver = SourceGenerationContext.Default };
+
+    [Fact]
+    public void InsertCaretBindings_RoundTrip_ByName ()
+    {
+        // Arrange — the real chords gui-cs/Editor binds (DEC-006: VS Code parity).
+        Dictionary<Command, PlatformKeyBinding> original = new ()
+        {
+            [Command.InsertCaretAbove] = new PlatformKeyBinding { All = ["Ctrl+Alt+CursorUp"] },
+            [Command.InsertCaretBelow] = new PlatformKeyBinding { All = ["Ctrl+Alt+CursorDown"] }
+        };
+
+        // Act
+        string json = JsonSerializer.Serialize (original, _jsonOptions);
+        Dictionary<Command, PlatformKeyBinding>? deserialized = JsonSerializer.Deserialize<Dictionary<Command, PlatformKeyBinding>> (json, _jsonOptions);
+
+        // Assert — serialized as readable names, not numbers.
+        Assert.Contains ("\"InsertCaretAbove\"", json);
+        Assert.Contains ("\"InsertCaretBelow\"", json);
+        Assert.DoesNotContain ("\"" + (int)Command.InsertCaretAbove + "\"", json);
+        Assert.DoesNotContain ("\"" + (int)Command.InsertCaretBelow + "\"", json);
+
+        Assert.NotNull (deserialized);
+        Assert.Equal (2, deserialized.Count);
+        Assert.Equal ((Key [])["Ctrl+Alt+CursorUp"], deserialized [Command.InsertCaretAbove].All!.AsEnumerable ());
+        Assert.Equal ((Key [])["Ctrl+Alt+CursorDown"], deserialized [Command.InsertCaretBelow].All!.AsEnumerable ());
+    }
+
+    [Fact]
+    public void InsertCaretBindings_Deserialize_FromUserConfigFormat ()
+    {
+        // Arrange — what a user (or gui-cs/Editor's shipped default) writes by hand.
+        var json =
+            """
+            {
+              "InsertCaretAbove": { "All": ["Ctrl+Alt+CursorUp"] },
+              "InsertCaretBelow": { "All": ["Ctrl+Alt+CursorDown"], "Macos": ["Alt+CursorDown"] }
+            }
+            """;
+
+        // Act
+        Dictionary<Command, PlatformKeyBinding>? result = JsonSerializer.Deserialize<Dictionary<Command, PlatformKeyBinding>> (json, _jsonOptions);
+
+        // Assert
+        Assert.NotNull (result);
+        Assert.Equal (2, result.Count);
+        Assert.True (result.ContainsKey (Command.InsertCaretAbove));
+        Assert.True (result.ContainsKey (Command.InsertCaretBelow));
+        Assert.Equal ((Key [])["Ctrl+Alt+CursorUp"], result [Command.InsertCaretAbove].All!.AsEnumerable ());
+        Assert.Equal ((Key [])["Alt+CursorDown"], result [Command.InsertCaretBelow].Macos!.AsEnumerable ());
+        Assert.Null (result [Command.InsertCaretAbove].Macos);
+    }
+
+    [Fact]
+    public void ViewKeyBindings_WithInsertCaret_RoundTrips ()
+    {
+        // The concrete gui-cs/Editor shape: a per-view [ConfigurationProperty]
+        // Dictionary<string, Dictionary<Command, PlatformKeyBinding>> ("Editor"
+        // → its default bindings). This is the path the magic-int cast broke.
+        Dictionary<string, Dictionary<Command, PlatformKeyBinding>> original = new ()
+        {
+            ["Editor"] = new Dictionary<Command, PlatformKeyBinding>
+            {
+                [Command.InsertCaretAbove] = new () { All = ["Ctrl+Alt+CursorUp"] },
+                [Command.InsertCaretBelow] = new () { All = ["Ctrl+Alt+CursorDown"] }
+            }
+        };
+
+        // Act
+        string json = JsonSerializer.Serialize (original, _jsonOptions);
+
+        Dictionary<string, Dictionary<Command, PlatformKeyBinding>>? deserialized =
+            JsonSerializer.Deserialize<Dictionary<string, Dictionary<Command, PlatformKeyBinding>>> (json, _jsonOptions);
+
+        // Assert
+        Assert.Contains ("\"InsertCaretAbove\"", json);
+        Assert.NotNull (deserialized);
+        Assert.Single (deserialized);
+        Assert.Equal ((Key [])["Ctrl+Alt+CursorUp"], deserialized ["Editor"] [Command.InsertCaretAbove].All!.AsEnumerable ());
+        Assert.Equal ((Key [])["Ctrl+Alt+CursorDown"], deserialized ["Editor"] [Command.InsertCaretBelow].All!.AsEnumerable ());
+    }
+}


### PR DESCRIPTION
## Summary

Adds two named `Command` members — `InsertCaretAbove` and `InsertCaretBelow` — mirroring VS Code's `editor.action.insertCursorAbove` / `Below`. Closes #5318.

## Why

The configurable keybinding surface (`Application.DefaultKeyBindings`, `View.DefaultKeyBindings`, per-view `DefaultKeyBindings`, `View.ViewKeyBindings`, `ApplyKeyBindings`/`ApplyLayer`) is **keyed by `Command`**. A `View` that needs a command TG doesn't define has no sanctioned way to register it through that mechanism. Multi-caret editors — e.g. `gui-cs/Editor`'s vertical multi-caret (`gui-cs/Editor#133`) — need *add-caret-above/below*; nothing in the enum fits, forcing `(Command) 1001`-style magic-int casts that don't round-trip through `config.json` by a readable name and risk collision if the enum is renumbered.

## What

- `Command.InsertCaretAbove`, `Command.InsertCaretBelow`, with XML docs, in a new `#region Multi-Caret Commands`.
- **Appended at the end of the enum** so no existing member's implicit value changes — serialization-stable, no renumbering of persisted bindings.
- No behavior change in TG itself: these are command ids for consumers to `AddCommand` + bind. TG core views don't bind them.

## Scope / not in this PR

This intentionally does **not** introduce a general extensibility mechanism. A first-class API for extending the command set (string-keyed ids vs. a reserved-range registry; interaction with command bubbling/bridging, the binding layers, and `ConfigurationManager` name serialization) is a larger design tracked separately in #5319.

## Test plan

- [x] `Terminal.Gui` core builds clean (0 errors; only the unrelated SourceLink "no `upstream` remote" note).
- [ ] Reviewer confirms enum-tail placement is acceptable (no renumbering of existing members).
- Consumer validation: `gui-cs/Editor` switches its `(Command) 1001/1002` casts to these members once a TG release including them is consumed (gui-cs/Editor `specs/decisions.md` DEC-006).

Refs: #5318. Related: #4888 (configurable `MouseBindings`), gui-cs/Editor#133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
