### PR TITLE
Fixes #5349. Ignore non-readable poll events during ANSI shutdown

### DIFF
--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -236,7 +236,20 @@ internal static class UnixIOHelper
         {
             int n = poll (pollMap, (uint)pollMap.Length, timeoutMs);
 
-            return n > 0;
+            if (n <= 0)
+            {
+                return false;
+            }
+
+            foreach (Pollfd pollfd in pollMap)
+            {
+                if ((pollfd.revents & (short)Condition.PollIn) != 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
         catch
         {

--- a/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTests.cs
@@ -1,0 +1,85 @@
+using System.Runtime.InteropServices;
+using Terminal.Gui.Drivers;
+
+namespace DriverTests;
+
+/// <summary>
+///     Tests for <see cref="UnixIOHelper"/> polling semantics on Unix-like platforms.
+/// </summary>
+[Collection ("Driver Tests")]
+public class UnixIOHelperTests
+{
+    [DllImport ("libc", SetLastError = true)]
+    private static extern int pipe (int [] pipefd);
+
+    [DllImport ("libc", SetLastError = true)]
+    private static extern int close (int fd);
+
+    [Fact]
+    // Copilot
+    public void IsInputAvailable_ReturnsTrue_WhenPollReportsReadableData ()
+    {
+        if (!OperatingSystem.IsLinux () && !OperatingSystem.IsMacOS () && !OperatingSystem.IsFreeBSD ())
+        {
+            return;
+        }
+
+        int [] pipeFds = new int [2];
+        Assert.Equal (0, pipe (pipeFds));
+
+        try
+        {
+            byte [] payload = [0x41];
+            Assert.Equal (1, UnixIOHelper.write (pipeFds [1], payload, payload.Length));
+
+            UnixIOHelper.Pollfd [] pollMap =
+            [
+                new ()
+                {
+                    fd = pipeFds [0],
+                    events = (short)UnixIOHelper.Condition.PollIn
+                }
+            ];
+
+            Assert.True (UnixIOHelper.IsInputAvailable (pollMap, 0));
+        }
+        finally
+        {
+            close (pipeFds [0]);
+            close (pipeFds [1]);
+        }
+    }
+
+    [Fact]
+    // Copilot
+    public void IsInputAvailable_ReturnsFalse_WhenPollReportsNonReadableEvent ()
+    {
+        if (!OperatingSystem.IsLinux () && !OperatingSystem.IsMacOS () && !OperatingSystem.IsFreeBSD ())
+        {
+            return;
+        }
+
+        int [] pipeFds = new int [2];
+        Assert.Equal (0, pipe (pipeFds));
+
+        try
+        {
+            Assert.Equal (0, close (pipeFds [0]));
+
+            UnixIOHelper.Pollfd [] pollMap =
+            [
+                new ()
+                {
+                    fd = pipeFds [0],
+                    events = (short)UnixIOHelper.Condition.PollIn
+                }
+            ];
+
+            Assert.False (UnixIOHelper.IsInputAvailable (pollMap, 0));
+        }
+        finally
+        {
+            close (pipeFds [1]);
+        }
+    }
+}


### PR DESCRIPTION
## Fixes

- Fixes #5349

## Proposed Changes
- Change `UnixIOHelper.IsInputAvailable ()` to return `true` only when `poll()` reports `POLLIN`
- Add `UnixIOHelperTests` to cover both a readable poll event and a non-readable poll event on Unix-like platforms
- Keep the fix at the shared helper so all ANSI input paths stop treating `POLLHUP`/`POLLERR`/`POLLNVAL`-only wakeups as readable input

## Root Cause

`AnsiInput.FlushInput ()` uses `UnixIOHelper.IsInputAvailable ()` to decide whether to keep draining input during shutdown.

On Unix/macOS, `poll()` can wake up with non-readable events such as `POLLHUP` or `POLLNVAL` without `POLLIN`. The old helper treated any `poll() > 0` result as readable input,   so shutdown could attempt another read even though no readable data was available. If that happened while `MainLoopCoordinator.Stop ()` was waiting for the input task to exit, `app.Dispose ()` could hang.

## OSS Comparison

This fix matches the defensive pattern used by other mature terminal codebases:
- `prompt_toolkit` fixed the same class of closed/unpollable-stdin bugs by treating EOF/unpollable stdin as terminal closure and unregistering the reader
- `kitty` currently has an active bug in the same family where non-readable poll events are effectively treated as readable
- `lnav`, `vim`, `zsh` ZLE, and `arcan` all gate reads on `POLLIN` and handle hangup/error events separately

That makes this change consistent with established terminal I/O practice: only read when `POLLIN` is set.

## Verification
- `dotnet build --no-restore`
- `dotnet test --project Tests/UnitTestsParallelizable --no-build --filter-class "*UnixIOHelperTests"`
- `dotnet test --project Tests/UnitTestsParallelizable --no-build --filter-class "*AllDriverTests"`
- `dotnet test --project Tests/UnitTestsParallelizable --no-build --filter-class "*RunTests"`

No new warnings were introduced in the touched files. The build still reports an existing unrelated `IntegrationTests` analyzer warning (`AD0001`).

## To pull down this PR locally:

```bash
git remote add copilot https://github.com/harder/Terminal.Gui.git
git fetch copilot fix-5349-ansi-dispose-hang
git checkout copilot/fix-5349-ansi-dispose-hang
```
