### PR TITLE
Fixes #5356. Add tab fan-out layout/draw diagnostic tests

### DIFF
--- a/Tests/IntegrationTests/TabsFanOutIntegrationTests.cs
+++ b/Tests/IntegrationTests/TabsFanOutIntegrationTests.cs
@@ -1,0 +1,179 @@
+using System.Text;
+using AppTestHelpers;
+
+namespace IntegrationTests;
+
+// Claude - Opus 4.7
+
+/// <summary>
+///     Integration counterpart to <c>TabsFanOutDiagnosticTests</c>. Drives the active tab via real
+///     key injection through the driver's input processor → command dispatch → main-loop
+///     <c>LayoutAndDraw</c> path, instead of mutating <see cref="View.Viewport"/> directly. This
+///     verifies the fan-out from issue #4973 / #5356 is observable end-to-end, not just under
+///     synthetic <see cref="View.Layout()"/> / <see cref="View.Draw"/> calls.
+/// </summary>
+/// <remarks>
+///     Instrumentation-only. The per-tab counters are attached to event subscriptions on
+///     <see cref="View.DrawComplete"/>, <see cref="View.SubViewsLaidOut"/>, and
+///     <see cref="View.ClearedViewport"/>; no rendering or invalidation behavior is changed.
+/// </remarks>
+public class TabsFanOutIntegrationTests (ITestOutputHelper outputHelper) : TestsAllDrivers
+{
+    private readonly TextWriter _out = new TestOutputWriter (outputHelper);
+
+    /// <summary>
+    ///     A <see cref="Code"/> that registers <see cref="Command.ScrollDown"/> /
+    ///     <see cref="Command.ScrollUp"/> so <see cref="Key.PageDown"/> / <see cref="Key.PageUp"/>
+    ///     drive vertical scrolling through the normal command pipeline. Used only by this test —
+    ///     <see cref="Code"/> doesn't expose <c>AddCommand</c> publicly, so a subclass is the
+    ///     simplest way to wire a real input → scroll path without modifying production code.
+    /// </summary>
+    private sealed class ScrollableCode : Code
+    {
+        public ScrollableCode ()
+        {
+            AddCommand (Command.ScrollDown, () => ScrollVertical (1));
+            AddCommand (Command.ScrollUp, () => ScrollVertical (-1));
+
+            KeyBindings.Add (Key.PageDown, Command.ScrollDown);
+            KeyBindings.Add (Key.PageUp, Command.ScrollUp);
+        }
+    }
+
+    private sealed class Counters
+    {
+        public int SubViewsLaidOut;
+        public int DrawComplete;
+        public int ClearedViewport;
+    }
+
+    private static string MakeText (string prefix, int lines)
+    {
+        StringBuilder sb = new ();
+
+        for (var i = 1; i <= lines; i++)
+        {
+            sb.Append (prefix);
+            sb.Append (' ');
+            sb.Append (i);
+
+            if (i < lines)
+            {
+                sb.Append ('\n');
+            }
+        }
+
+        return sb.ToString ();
+    }
+
+    /// <summary>
+    ///     End-to-end fan-out check: a real <see cref="Key.PageDown"/> on the active tab causes
+    ///     layout/draw activity on inactive tabs.
+    /// </summary>
+    [Theory]
+    [MemberData (nameof (GetAllDriverNames))]
+    public void Integration_RealPageDown_OnActiveTab_FansOutToInactiveTabs (string driverName)
+    {
+        const int TabCount = 4;
+
+        Tabs tabs = new () { Width = Dim.Fill (), Height = Dim.Fill () };
+        ScrollableCode [] codes = new ScrollableCode [TabCount];
+
+        for (var i = 0; i < TabCount; i++)
+        {
+            codes [i] = new ScrollableCode
+            {
+                Title = $"Tab{i + 1}",
+                Text = MakeText ($"Tab{i + 1} line", 80),
+                Language = null,
+                SyntaxHighlighter = null,
+                Width = Dim.Fill (),
+                Height = Dim.Fill ()
+            };
+
+            tabs.Add (codes [i]);
+        }
+
+        Counters [] perTab = new Counters [TabCount];
+        Counters tabsContainer = new ();
+
+        for (var i = 0; i < TabCount; i++)
+        {
+            int captured = i;
+            perTab [i] = new Counters ();
+            codes [i].SubViewsLaidOut += (_, _) => perTab [captured].SubViewsLaidOut++;
+            codes [i].DrawComplete += (_, _) => perTab [captured].DrawComplete++;
+            codes [i].ClearedViewport += (_, _) => perTab [captured].ClearedViewport++;
+        }
+
+        tabs.SubViewsLaidOut += (_, _) => tabsContainer.SubViewsLaidOut++;
+        tabs.DrawComplete += (_, _) => tabsContainer.DrawComplete++;
+        tabs.ClearedViewport += (_, _) => tabsContainer.ClearedViewport++;
+
+        ScrollableCode active = codes [0];
+
+        using AppTestHelper helper = With.A<Window> (60, 20, driverName, _out)
+                                         .Add (tabs)
+                                         .Focus (active)
+                                         .Then (
+                                                _ =>
+                                                {
+                                                    for (var i = 0; i < TabCount; i++)
+                                                    {
+                                                        perTab [i].SubViewsLaidOut = 0;
+                                                        perTab [i].DrawComplete = 0;
+                                                        perTab [i].ClearedViewport = 0;
+                                                    }
+
+                                                    tabsContainer.SubViewsLaidOut = 0;
+                                                    tabsContainer.DrawComplete = 0;
+                                                    tabsContainer.ClearedViewport = 0;
+                                                })
+                                         .KeyDown (Key.PageDown)
+                                         .KeyDown (Key.PageDown)
+                                         .KeyDown (Key.PageDown);
+
+        outputHelper.WriteLine ($"Driver: {driverName}");
+        outputHelper.WriteLine ($"Active tab viewport Y after 3 PageDowns: {active.Viewport.Y}");
+        outputHelper.WriteLine ("Per-tab counters (after 3 PageDowns on active tab):");
+        outputHelper.WriteLine ("  tab        laidOut  drawComplete  clearedViewport");
+        outputHelper.WriteLine ($"  Tabs       {tabsContainer.SubViewsLaidOut,7}  {tabsContainer.DrawComplete,12}  {tabsContainer.ClearedViewport,15}");
+
+        for (var i = 0; i < TabCount; i++)
+        {
+            outputHelper.WriteLine ($"  Code{i + 1,-6} {perTab [i].SubViewsLaidOut,7}  {perTab [i].DrawComplete,12}  {perTab [i].ClearedViewport,15}");
+        }
+
+        Assert.True (
+                     active.Viewport.Y > 0,
+                     $"PageDown should have scrolled the active tab via real input → command path. Got Viewport.Y={active.Viewport.Y}.");
+
+        Assert.True (
+                     perTab [0].DrawComplete > 0,
+                     $"Active tab must draw in response to real PageDown, got DrawComplete={perTab [0].DrawComplete}.");
+
+        int inactiveDraws = 0;
+        int inactiveLayouts = 0;
+
+        for (var i = 1; i < TabCount; i++)
+        {
+            inactiveDraws += perTab [i].DrawComplete;
+            inactiveLayouts += perTab [i].SubViewsLaidOut;
+        }
+
+        outputHelper.WriteLine ($"Sum inactive DrawComplete = {inactiveDraws}");
+        outputHelper.WriteLine ($"Sum inactive SubViewsLaidOut = {inactiveLayouts}");
+
+        // CURRENT BEHAVIOR (issue #4973): inactive tabs receive draw and layout work when active scrolls,
+        // even through the real input → command → main-loop path. After #4973 lands, flip these to == 0.
+        Assert.True (
+                     inactiveDraws > 0,
+                     $"Documents issue #4973 (integration-level): inactive_total DrawComplete={inactiveDraws}. " +
+                     "Flip to Assert.Equal(0, inactiveDraws) after fix lands.");
+
+        Assert.True (
+                     inactiveLayouts > 0,
+                     $"Documents issue #4973 (integration-level): inactive_total SubViewsLaidOut={inactiveLayouts}. " +
+                     "Flip to Assert.Equal(0, inactiveLayouts) after fix lands.");
+    }
+}

--- a/Tests/UnitTestsParallelizable/Views/TabView/TabsFanOutDiagnosticTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TabView/TabsFanOutDiagnosticTests.cs
@@ -22,6 +22,13 @@ namespace ViewsTests;
 ///         shadow margins, and adornment subviews.
 ///     </para>
 ///     <para>
+///         <see cref="Code"/> is used as the scrollable tab content because the older
+///         <c>TextView</c> is being deprecated. The fan-out behavior lives in the <see cref="View"/>
+///         layout/draw pipeline and is independent of which content widget is used, so any view
+///         that scrolls inside an Overlapped-arrangement <see cref="Tabs"/> exercises the same
+///         code paths.
+///     </para>
+///     <para>
 ///         Each test reports its measured counts through <see cref="ITestOutputHelper"/> so the data
 ///         is visible in CI logs even when the test passes. When the fan-out problem is fixed, these
 ///         tests are expected to be updated to assert the new (lower) counts; the diagnostic helper
@@ -122,7 +129,18 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
         return sb.ToString ();
     }
 
-    private static (View Root, Tabs Tabs, TextView [] TextViews, ViewActivityCounters Counters) BuildTabbedScenario (IDriver driver)
+    private static Code MakeCode (string title, string text) =>
+        new ()
+        {
+            Title = title,
+            Text = text,
+            Language = null,
+            SyntaxHighlighter = null,
+            Width = Dim.Fill (),
+            Height = Dim.Fill ()
+        };
+
+    private static (View Root, Tabs Tabs, Code [] Codes, ViewActivityCounters Counters) BuildTabbedScenario (IDriver driver)
     {
         View root = new ()
         {
@@ -135,20 +153,12 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
         Tabs tabs = new () { Driver = driver, Width = Dim.Fill (), Height = Dim.Fill () };
         root.Add (tabs);
 
-        TextView [] textViews = new TextView [TabCount];
+        Code [] codes = new Code [TabCount];
 
         for (var i = 0; i < TabCount; i++)
         {
-            TextView tv = new ()
-            {
-                Title = $"Tab{i + 1}",
-                Text = MakeText ($"Tab{i + 1} line", 50),
-                Width = Dim.Fill (),
-                Height = Dim.Fill ()
-            };
-
-            textViews [i] = tv;
-            tabs.Add (tv);
+            codes [i] = MakeCode ($"Tab{i + 1}", MakeText ($"Tab{i + 1} line", 50));
+            tabs.Add (codes [i]);
         }
 
         ViewActivityCounters counters = new ();
@@ -156,13 +166,13 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
 
         for (var i = 0; i < TabCount; i++)
         {
-            counters.Track (textViews [i], $"TextView{i + 1}");
+            counters.Track (codes [i], $"Code{i + 1}");
         }
 
-        return (root, tabs, textViews, counters);
+        return (root, tabs, codes, counters);
     }
 
-    private static (View Root, TextView TextView, ViewActivityCounters Counters) BuildSingleTextViewScenario (IDriver driver)
+    private static (View Root, Code Code, ViewActivityCounters Counters) BuildSingleScenario (IDriver driver)
     {
         View root = new ()
         {
@@ -172,20 +182,13 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
             Height = Dim.Fill ()
         };
 
-        TextView tv = new ()
-        {
-            Title = "Only",
-            Text = MakeText ("Only line", 50),
-            Width = Dim.Fill (),
-            Height = Dim.Fill ()
-        };
-
-        root.Add (tv);
+        Code code = MakeCode ("Only", MakeText ("Only line", 50));
+        root.Add (code);
 
         ViewActivityCounters counters = new ();
-        counters.Track (tv, "TextView");
+        counters.Track (code, "Code");
 
-        return (root, tv, counters);
+        return (root, code, counters);
     }
 
     /// <summary>
@@ -196,13 +199,13 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
     public void Diagnostic_ActiveTabScroll_LayoutEvents_OnEachTab ()
     {
         IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
-        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+        (View root, Tabs tabs, Code [] codes, ViewActivityCounters counters) = BuildTabbedScenario (driver);
 
         root.Layout ();
         root.Draw ();
 
-        TextView active = (TextView)tabs.Value!;
-        Assert.Same (textViews [0], active);
+        Code active = (Code)tabs.Value!;
+        Assert.Same (codes [0], active);
 
         counters.Reset ();
 
@@ -221,7 +224,7 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
 
         for (var i = 1; i < TabCount; i++)
         {
-            inactiveLayouts += counters.Get (textViews [i]).SubViewsLaidOut;
+            inactiveLayouts += counters.Get (codes [i]).SubViewsLaidOut;
         }
 
         output.WriteLine ($"Active SubViewsLaidOut: {activeCounts.SubViewsLaidOut}");
@@ -247,12 +250,12 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
     public void Diagnostic_ActiveTabScroll_DrawEvents_OnEachTab ()
     {
         IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
-        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+        (View root, Tabs tabs, Code [] codes, ViewActivityCounters counters) = BuildTabbedScenario (driver);
 
         root.Layout ();
         root.Draw ();
 
-        TextView active = (TextView)tabs.Value!;
+        Code active = (Code)tabs.Value!;
 
         counters.Reset ();
 
@@ -274,7 +277,7 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
 
         for (var i = 1; i < TabCount; i++)
         {
-            ViewActivityCounters.Counts c = counters.Get (textViews [i]);
+            ViewActivityCounters.Counts c = counters.Get (codes [i]);
             inactiveDraws += c.DrawComplete;
             inactiveClears += c.ClearedViewport;
             inactiveContentDraws += c.DrawingContent;
@@ -285,22 +288,24 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
         output.WriteLine ($"Sum of inactive ClearedViewport: {inactiveClears}");
         output.WriteLine ($"Sum of inactive DrawingContent:  {inactiveContentDraws}");
 
-        // CURRENT BEHAVIOR (issue #4973): inactive tabs receive draw, clear, and content-draw work
-        // when the active tab scrolls. After #4973 is fixed, flip these to `Assert.Equal (0, ...)`.
+        // CURRENT BEHAVIOR (issue #4973): inactive tabs receive full draw passes when active scrolls.
+        // DrawComplete is the widget-agnostic signal — it always fires once per call to Draw(),
+        // regardless of whether the view overrides OnClearingViewport / OnDrawingContent (as Code does).
+        // After #4973 is fixed, flip this to `Assert.Equal (0, inactiveDraws)`.
         Assert.True (
                      inactiveDraws > 0,
                      $"Documents issue #4973 draw fan-out: inactive_total DrawComplete={inactiveDraws}, " +
                      $"active={activeCounts.DrawComplete}. Flip to Assert.Equal(0, inactiveDraws) after #4973 fix.");
 
+        // ClearedViewport / DrawingContent on Code instances will be 0 because Code overrides those
+        // handlers and returns true (suppressing the events). The Tabs container still fires them,
+        // so they remain useful as a secondary diagnostic — recorded in the report above but not
+        // asserted at the per-tab level.
+        ViewActivityCounters.Counts tabsCounts = counters.Get (tabs);
         Assert.True (
-                     inactiveClears > 0,
-                     $"Documents issue #4973 clear fan-out: ClearViewport propagates via SetNeedsDraw. " +
-                     $"inactive_total ClearedViewport={inactiveClears}. Flip after #4973 fix.");
-
-        Assert.True (
-                     inactiveContentDraws > 0,
-                     $"Documents issue #4973 content-draw fan-out: inactive_total DrawingContent={inactiveContentDraws}. " +
-                     "Flip after #4973 fix.");
+                     tabsCounts.ClearedViewport > 0,
+                     $"Tabs container must register clear activity (got {tabsCounts.ClearedViewport}); " +
+                     "this confirms the lower-level draw pipeline is being exercised.");
 
         root.Dispose ();
         driver.Dispose ();
@@ -308,13 +313,13 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
 
     /// <summary>
     ///     Issue #5356 acceptance criterion: a comparable fan-out metric between an equivalent
-    ///     single-TextView scenario and a tabbed-TextView scenario.
+    ///     single-Code scenario and a tabbed-Code scenario.
     /// </summary>
     [Fact]
-    public void Diagnostic_TabbedFanOut_ComparedTo_SingleTextViewBaseline ()
+    public void Diagnostic_TabbedFanOut_ComparedTo_SingleViewBaseline ()
     {
         IDriver driverSingle = CreateTestDriver (DriverWidth, DriverHeight);
-        (View singleRoot, TextView singleTv, ViewActivityCounters singleCounters) = BuildSingleTextViewScenario (driverSingle);
+        (View singleRoot, Code single, ViewActivityCounters singleCounters) = BuildSingleScenario (driverSingle);
 
         singleRoot.Layout ();
         singleRoot.Draw ();
@@ -322,21 +327,21 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
 
         for (var y = 1; y <= 5; y++)
         {
-            singleTv.Viewport = singleTv.Viewport with { Y = y };
+            single.Viewport = single.Viewport with { Y = y };
             singleRoot.Layout ();
             singleRoot.Draw ();
         }
 
-        ViewActivityCounters.Counts singleCounts = singleCounters.Get (singleTv);
-        output.WriteLine (singleCounters.Report ("Single-TextView baseline (5 scrolls):"));
+        ViewActivityCounters.Counts singleCounts = singleCounters.Get (single);
+        output.WriteLine (singleCounters.Report ("Single-Code baseline (5 scrolls):"));
 
         IDriver driverTabbed = CreateTestDriver (DriverWidth, DriverHeight);
-        (View tabRoot, Tabs tabs, TextView [] textViews, ViewActivityCounters tabCounters) = BuildTabbedScenario (driverTabbed);
+        (View tabRoot, Tabs tabs, Code [] codes, ViewActivityCounters tabCounters) = BuildTabbedScenario (driverTabbed);
 
         tabRoot.Layout ();
         tabRoot.Draw ();
 
-        TextView active = (TextView)tabs.Value!;
+        Code active = (Code)tabs.Value!;
         tabCounters.Reset ();
 
         for (var y = 1; y <= 5; y++)
@@ -354,8 +359,8 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
 
         for (var i = 1; i < TabCount; i++)
         {
-            totalTabDraws += tabCounters.Get (textViews [i]).DrawComplete;
-            totalTabLayouts += tabCounters.Get (textViews [i]).SubViewsLaidOut;
+            totalTabDraws += tabCounters.Get (codes [i]).DrawComplete;
+            totalTabLayouts += tabCounters.Get (codes [i]).SubViewsLaidOut;
         }
 
         double drawFanOut = singleCounts.DrawComplete == 0 ? double.NaN : (double)totalTabDraws / singleCounts.DrawComplete;
@@ -364,19 +369,19 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
         output.WriteLine ($"Tabbed total draws / single draws  = {totalTabDraws} / {singleCounts.DrawComplete} = {drawFanOut:F2}");
         output.WriteLine ($"Tabbed total layouts / single layouts = {totalTabLayouts} / {singleCounts.SubViewsLaidOut} = {layoutFanOut:F2}");
 
-        Assert.True (singleCounts.DrawComplete > 0, "Single-TextView baseline must record draw activity.");
+        Assert.True (singleCounts.DrawComplete > 0, "Single-Code baseline must record draw activity.");
         Assert.True (tabActiveCounts.DrawComplete > 0, "Active tab in tabbed scenario must record draw activity.");
 
         // CURRENT BEHAVIOR (issue #4973): tabbed scenario produces N-times more total work than baseline.
         // After #4973 is fixed, drawFanOut and layoutFanOut should approach 1.0 (within rounding).
         Assert.True (
                      drawFanOut > 1.0,
-                     $"Documents issue #4973: tabbed draw fan-out ({drawFanOut:F2}x) exceeds single-TextView baseline. " +
+                     $"Documents issue #4973: tabbed draw fan-out ({drawFanOut:F2}x) exceeds single-Code baseline. " +
                      "After fix, drawFanOut should approach 1.0.");
 
         Assert.True (
                      layoutFanOut > 1.0,
-                     $"Documents issue #4973: tabbed layout fan-out ({layoutFanOut:F2}x) exceeds single-TextView baseline. " +
+                     $"Documents issue #4973: tabbed layout fan-out ({layoutFanOut:F2}x) exceeds single-Code baseline. " +
                      "After fix, layoutFanOut should approach 1.0.");
 
         singleRoot.Dispose ();
@@ -395,15 +400,15 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
     public void Diagnostic_TransparentInactiveTab_StillObservable ()
     {
         IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
-        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+        (View root, Tabs tabs, Code [] codes, ViewActivityCounters counters) = BuildTabbedScenario (driver);
 
-        textViews [1].ViewportSettings |= ViewportSettingsFlags.Transparent;
-        textViews [2].ViewportSettings |= ViewportSettingsFlags.Transparent;
+        codes [1].ViewportSettings |= ViewportSettingsFlags.Transparent;
+        codes [2].ViewportSettings |= ViewportSettingsFlags.Transparent;
 
         root.Layout ();
         root.Draw ();
 
-        TextView active = (TextView)tabs.Value!;
+        Code active = (Code)tabs.Value!;
         counters.Reset ();
 
         for (var y = 1; y <= 3; y++)
@@ -420,7 +425,7 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
 
         for (var i = 1; i < TabCount; i++)
         {
-            ViewActivityCounters.Counts c = counters.Get (textViews [i]);
+            ViewActivityCounters.Counts c = counters.Get (codes [i]);
 
             Assert.True (
                          c.DrawComplete >= 0,
@@ -439,15 +444,15 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
     public void Diagnostic_ShadowMargin_DoesNotMaskActiveTabActivity ()
     {
         IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
-        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+        (View root, Tabs tabs, Code [] codes, ViewActivityCounters counters) = BuildTabbedScenario (driver);
 
-        textViews [0].ShadowStyle = ShadowStyles.Opaque;
+        codes [0].ShadowStyle = ShadowStyles.Opaque;
 
         root.Layout ();
         root.Draw ();
 
-        TextView active = (TextView)tabs.Value!;
-        Assert.Same (textViews [0], active);
+        Code active = (Code)tabs.Value!;
+        Assert.Same (codes [0], active);
 
         counters.Reset ();
 
@@ -477,12 +482,12 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
     public void Diagnostic_IOutputLayer_ObservesActiveTabContent ()
     {
         IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
-        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+        (View root, Tabs tabs, Code [] codes, ViewActivityCounters counters) = BuildTabbedScenario (driver);
 
         root.Layout ();
         root.Draw ();
 
-        TextView active = (TextView)tabs.Value!;
+        Code active = (Code)tabs.Value!;
 
         IOutput output1 = driver.GetOutput ();
         IOutputBuffer buffer = driver.GetOutputBuffer ();
@@ -523,12 +528,12 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
     public void Diagnostic_LayoutAndDraw_ReportedSeparately ()
     {
         IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
-        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+        (View root, Tabs tabs, Code [] codes, ViewActivityCounters counters) = BuildTabbedScenario (driver);
 
         root.Layout ();
         root.Draw ();
 
-        TextView active = (TextView)tabs.Value!;
+        Code active = (Code)tabs.Value!;
         counters.Reset ();
 
         active.Viewport = active.Viewport with { Y = 2 };
@@ -543,8 +548,8 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
 
         for (var i = 1; i < TabCount; i++)
         {
-            inactiveLayouts += counters.Get (textViews [i]).SubViewsLaidOut;
-            inactiveDraws += counters.Get (textViews [i]).DrawComplete;
+            inactiveLayouts += counters.Get (codes [i]).SubViewsLaidOut;
+            inactiveDraws += counters.Get (codes [i]).DrawComplete;
         }
 
         output.WriteLine ($"Layout: active={activeLayouts}, inactive_total={inactiveLayouts}");

--- a/Tests/UnitTestsParallelizable/Views/TabView/TabsFanOutDiagnosticTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TabView/TabsFanOutDiagnosticTests.cs
@@ -427,9 +427,10 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
         {
             ViewActivityCounters.Counts c = counters.Get (codes [i]);
 
+            // Copilot: Lock in current fan-out behavior. After #4973, this should likely become == 0.
             Assert.True (
-                         c.DrawComplete >= 0,
-                         $"Tab {i + 1} DrawComplete counter must be observable (got {c.DrawComplete}) even with Transparent.");
+                         c.DrawComplete > 0,
+                         $"Tab {i + 1} should currently still record DrawComplete even with Transparent (got {c.DrawComplete}). Update this expectation after #4973.");
         }
 
         root.Dispose ();

--- a/Tests/UnitTestsParallelizable/Views/TabView/TabsFanOutDiagnosticTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TabView/TabsFanOutDiagnosticTests.cs
@@ -1,0 +1,566 @@
+using System.Text;
+using UnitTests;
+
+namespace ViewsTests;
+
+// Claude - Opus 4.7
+
+/// <summary>
+///     Diagnostic tests for issue #5356 — tabbed redraw/layout fan-out.
+/// </summary>
+/// <remarks>
+///     <para>
+///         These tests are intentionally instrumentation-only: they observe layout and draw activity
+///         on each tab via <see cref="View.SubViewsLaidOut"/>, <see cref="View.DrawComplete"/>, and
+///         <see cref="View.ClearedViewport"/> events, but do not change rendering or invalidation
+///         semantics. They lock in the current behavior so that future refactors of the layout/draw
+///         pipeline (see issue #4973) can be measured and verified.
+///     </para>
+///     <para>
+///         The diagnostics rely on counters/event traces — not on <c>Driver.Contents</c> alone —
+///         so they remain meaningful in the presence of clipping, transparent viewports,
+///         shadow margins, and adornment subviews.
+///     </para>
+///     <para>
+///         Each test reports its measured counts through <see cref="ITestOutputHelper"/> so the data
+///         is visible in CI logs even when the test passes. When the fan-out problem is fixed, these
+///         tests are expected to be updated to assert the new (lower) counts; the diagnostic helper
+///         and the test scaffolding remain useful as a regression check.
+///     </para>
+/// </remarks>
+public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBase
+{
+    /// <summary>
+    ///     Records per-view layout and draw activity for a set of tracked views. Used as the primary
+    ///     diagnostic for tab fan-out — the counts here are deterministic and survive future changes
+    ///     to clipping, shadow, transparency, and adornment-subview behavior.
+    /// </summary>
+    private sealed class ViewActivityCounters
+    {
+        private readonly Dictionary<View, Counts> _counts = new ();
+        private readonly List<(View View, string Label)> _order = [];
+
+        public void Track (View view, string label)
+        {
+            Counts counts = new ();
+            _counts [view] = counts;
+            _order.Add ((view, label));
+
+            view.SubViewsLaidOut += (_, _) => counts.SubViewsLaidOut++;
+            view.DrawComplete += (_, _) => counts.DrawComplete++;
+            view.ClearedViewport += (_, _) => counts.ClearedViewport++;
+            view.DrawingContent += (_, _) => counts.DrawingContent++;
+            view.FrameChanged += (_, _) => counts.FrameChanged++;
+        }
+
+        public Counts Get (View view) => _counts [view];
+
+        public void Reset ()
+        {
+            foreach (Counts counts in _counts.Values)
+            {
+                counts.Reset ();
+            }
+        }
+
+        public string Report (string title)
+        {
+            StringBuilder sb = new ();
+            sb.AppendLine (title);
+            sb.AppendLine ("  view                       laidOut  drawComplete  clearedViewport  drawingContent  frameChanged");
+
+            foreach ((View view, string label) in _order)
+            {
+                Counts c = _counts [view];
+
+                sb.AppendLine (
+                               $"  {label,-26} {c.SubViewsLaidOut,7}  {c.DrawComplete,12}  {c.ClearedViewport,15}  {c.DrawingContent,14}  {c.FrameChanged,12}");
+            }
+
+            return sb.ToString ();
+        }
+
+        public sealed class Counts
+        {
+            public int SubViewsLaidOut;
+            public int DrawComplete;
+            public int ClearedViewport;
+            public int DrawingContent;
+            public int FrameChanged;
+
+            public void Reset ()
+            {
+                SubViewsLaidOut = 0;
+                DrawComplete = 0;
+                ClearedViewport = 0;
+                DrawingContent = 0;
+                FrameChanged = 0;
+            }
+        }
+    }
+
+    private const int TabCount = 4;
+    private const int DriverWidth = 60;
+    private const int DriverHeight = 20;
+
+    private static string MakeText (string prefix, int lines)
+    {
+        StringBuilder sb = new ();
+
+        for (var i = 1; i <= lines; i++)
+        {
+            sb.Append (prefix);
+            sb.Append (' ');
+            sb.Append (i);
+
+            if (i < lines)
+            {
+                sb.Append ('\n');
+            }
+        }
+
+        return sb.ToString ();
+    }
+
+    private static (View Root, Tabs Tabs, TextView [] TextViews, ViewActivityCounters Counters) BuildTabbedScenario (IDriver driver)
+    {
+        View root = new ()
+        {
+            Driver = driver,
+            CanFocus = true,
+            Width = Dim.Fill (),
+            Height = Dim.Fill ()
+        };
+
+        Tabs tabs = new () { Driver = driver, Width = Dim.Fill (), Height = Dim.Fill () };
+        root.Add (tabs);
+
+        TextView [] textViews = new TextView [TabCount];
+
+        for (var i = 0; i < TabCount; i++)
+        {
+            TextView tv = new ()
+            {
+                Title = $"Tab{i + 1}",
+                Text = MakeText ($"Tab{i + 1} line", 50),
+                Width = Dim.Fill (),
+                Height = Dim.Fill ()
+            };
+
+            textViews [i] = tv;
+            tabs.Add (tv);
+        }
+
+        ViewActivityCounters counters = new ();
+        counters.Track (tabs, "Tabs");
+
+        for (var i = 0; i < TabCount; i++)
+        {
+            counters.Track (textViews [i], $"TextView{i + 1}");
+        }
+
+        return (root, tabs, textViews, counters);
+    }
+
+    private static (View Root, TextView TextView, ViewActivityCounters Counters) BuildSingleTextViewScenario (IDriver driver)
+    {
+        View root = new ()
+        {
+            Driver = driver,
+            CanFocus = true,
+            Width = Dim.Fill (),
+            Height = Dim.Fill ()
+        };
+
+        TextView tv = new ()
+        {
+            Title = "Only",
+            Text = MakeText ("Only line", 50),
+            Width = Dim.Fill (),
+            Height = Dim.Fill ()
+        };
+
+        root.Add (tv);
+
+        ViewActivityCounters counters = new ();
+        counters.Track (tv, "TextView");
+
+        return (root, tv, counters);
+    }
+
+    /// <summary>
+    ///     Issue #5356 / #4973 acceptance criterion: diagnostics can show whether inactive tabs
+    ///     received layout work when the active tab scrolls.
+    /// </summary>
+    [Fact]
+    public void Diagnostic_ActiveTabScroll_LayoutEvents_OnEachTab ()
+    {
+        IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
+        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+
+        root.Layout ();
+        root.Draw ();
+
+        TextView active = (TextView)tabs.Value!;
+        Assert.Same (textViews [0], active);
+
+        counters.Reset ();
+
+        for (var y = 1; y <= 5; y++)
+        {
+            active.Viewport = active.Viewport with { Y = y };
+            root.Layout ();
+        }
+
+        output.WriteLine (counters.Report ("After 5 active-tab scrolls (layout-only):"));
+
+        ViewActivityCounters.Counts activeCounts = counters.Get (active);
+        Assert.True (activeCounts.SubViewsLaidOut > 0, $"Active tab should receive layout activity, got {activeCounts.SubViewsLaidOut}");
+
+        int inactiveLayouts = 0;
+
+        for (var i = 1; i < TabCount; i++)
+        {
+            inactiveLayouts += counters.Get (textViews [i]).SubViewsLaidOut;
+        }
+
+        output.WriteLine ($"Active SubViewsLaidOut: {activeCounts.SubViewsLaidOut}");
+        output.WriteLine ($"Sum of inactive SubViewsLaidOut: {inactiveLayouts}");
+
+        // CURRENT BEHAVIOR (issue #4973): inactive tabs receive the same layout count as active.
+        // After #4973 is fixed, flip this to `Assert.Equal (0, inactiveLayouts)`.
+        Assert.True (
+                     inactiveLayouts > 0,
+                     $"Documents issue #4973: inactive tabs receive layout work when active tab scrolls. " +
+                     $"Observed inactive_total={inactiveLayouts}, active={activeCounts.SubViewsLaidOut}. " +
+                     "Flip to Assert.Equal(0, inactiveLayouts) after #4973 fix lands.");
+
+        root.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     Issue #5356 / #4973 acceptance criterion: diagnostics can show whether inactive tabs
+    ///     received draw work when the active tab scrolls.
+    /// </summary>
+    [Fact]
+    public void Diagnostic_ActiveTabScroll_DrawEvents_OnEachTab ()
+    {
+        IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
+        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+
+        root.Layout ();
+        root.Draw ();
+
+        TextView active = (TextView)tabs.Value!;
+
+        counters.Reset ();
+
+        for (var y = 1; y <= 5; y++)
+        {
+            active.Viewport = active.Viewport with { Y = y };
+            root.Layout ();
+            root.Draw ();
+        }
+
+        output.WriteLine (counters.Report ("After 5 active-tab scrolls (layout + draw):"));
+
+        ViewActivityCounters.Counts activeCounts = counters.Get (active);
+        Assert.True (activeCounts.DrawComplete > 0, $"Active tab must receive draw activity, got {activeCounts.DrawComplete}");
+
+        int inactiveDraws = 0;
+        int inactiveClears = 0;
+        int inactiveContentDraws = 0;
+
+        for (var i = 1; i < TabCount; i++)
+        {
+            ViewActivityCounters.Counts c = counters.Get (textViews [i]);
+            inactiveDraws += c.DrawComplete;
+            inactiveClears += c.ClearedViewport;
+            inactiveContentDraws += c.DrawingContent;
+        }
+
+        output.WriteLine ($"Active DrawComplete: {activeCounts.DrawComplete}");
+        output.WriteLine ($"Sum of inactive DrawComplete:    {inactiveDraws}");
+        output.WriteLine ($"Sum of inactive ClearedViewport: {inactiveClears}");
+        output.WriteLine ($"Sum of inactive DrawingContent:  {inactiveContentDraws}");
+
+        // CURRENT BEHAVIOR (issue #4973): inactive tabs receive draw, clear, and content-draw work
+        // when the active tab scrolls. After #4973 is fixed, flip these to `Assert.Equal (0, ...)`.
+        Assert.True (
+                     inactiveDraws > 0,
+                     $"Documents issue #4973 draw fan-out: inactive_total DrawComplete={inactiveDraws}, " +
+                     $"active={activeCounts.DrawComplete}. Flip to Assert.Equal(0, inactiveDraws) after #4973 fix.");
+
+        Assert.True (
+                     inactiveClears > 0,
+                     $"Documents issue #4973 clear fan-out: ClearViewport propagates via SetNeedsDraw. " +
+                     $"inactive_total ClearedViewport={inactiveClears}. Flip after #4973 fix.");
+
+        Assert.True (
+                     inactiveContentDraws > 0,
+                     $"Documents issue #4973 content-draw fan-out: inactive_total DrawingContent={inactiveContentDraws}. " +
+                     "Flip after #4973 fix.");
+
+        root.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     Issue #5356 acceptance criterion: a comparable fan-out metric between an equivalent
+    ///     single-TextView scenario and a tabbed-TextView scenario.
+    /// </summary>
+    [Fact]
+    public void Diagnostic_TabbedFanOut_ComparedTo_SingleTextViewBaseline ()
+    {
+        IDriver driverSingle = CreateTestDriver (DriverWidth, DriverHeight);
+        (View singleRoot, TextView singleTv, ViewActivityCounters singleCounters) = BuildSingleTextViewScenario (driverSingle);
+
+        singleRoot.Layout ();
+        singleRoot.Draw ();
+        singleCounters.Reset ();
+
+        for (var y = 1; y <= 5; y++)
+        {
+            singleTv.Viewport = singleTv.Viewport with { Y = y };
+            singleRoot.Layout ();
+            singleRoot.Draw ();
+        }
+
+        ViewActivityCounters.Counts singleCounts = singleCounters.Get (singleTv);
+        output.WriteLine (singleCounters.Report ("Single-TextView baseline (5 scrolls):"));
+
+        IDriver driverTabbed = CreateTestDriver (DriverWidth, DriverHeight);
+        (View tabRoot, Tabs tabs, TextView [] textViews, ViewActivityCounters tabCounters) = BuildTabbedScenario (driverTabbed);
+
+        tabRoot.Layout ();
+        tabRoot.Draw ();
+
+        TextView active = (TextView)tabs.Value!;
+        tabCounters.Reset ();
+
+        for (var y = 1; y <= 5; y++)
+        {
+            active.Viewport = active.Viewport with { Y = y };
+            tabRoot.Layout ();
+            tabRoot.Draw ();
+        }
+
+        ViewActivityCounters.Counts tabActiveCounts = tabCounters.Get (active);
+        output.WriteLine (tabCounters.Report ("Tabbed scenario (5 scrolls of active tab):"));
+
+        int totalTabDraws = tabActiveCounts.DrawComplete;
+        int totalTabLayouts = tabActiveCounts.SubViewsLaidOut;
+
+        for (var i = 1; i < TabCount; i++)
+        {
+            totalTabDraws += tabCounters.Get (textViews [i]).DrawComplete;
+            totalTabLayouts += tabCounters.Get (textViews [i]).SubViewsLaidOut;
+        }
+
+        double drawFanOut = singleCounts.DrawComplete == 0 ? double.NaN : (double)totalTabDraws / singleCounts.DrawComplete;
+        double layoutFanOut = singleCounts.SubViewsLaidOut == 0 ? double.NaN : (double)totalTabLayouts / singleCounts.SubViewsLaidOut;
+
+        output.WriteLine ($"Tabbed total draws / single draws  = {totalTabDraws} / {singleCounts.DrawComplete} = {drawFanOut:F2}");
+        output.WriteLine ($"Tabbed total layouts / single layouts = {totalTabLayouts} / {singleCounts.SubViewsLaidOut} = {layoutFanOut:F2}");
+
+        Assert.True (singleCounts.DrawComplete > 0, "Single-TextView baseline must record draw activity.");
+        Assert.True (tabActiveCounts.DrawComplete > 0, "Active tab in tabbed scenario must record draw activity.");
+
+        // CURRENT BEHAVIOR (issue #4973): tabbed scenario produces N-times more total work than baseline.
+        // After #4973 is fixed, drawFanOut and layoutFanOut should approach 1.0 (within rounding).
+        Assert.True (
+                     drawFanOut > 1.0,
+                     $"Documents issue #4973: tabbed draw fan-out ({drawFanOut:F2}x) exceeds single-TextView baseline. " +
+                     "After fix, drawFanOut should approach 1.0.");
+
+        Assert.True (
+                     layoutFanOut > 1.0,
+                     $"Documents issue #4973: tabbed layout fan-out ({layoutFanOut:F2}x) exceeds single-TextView baseline. " +
+                     "After fix, layoutFanOut should approach 1.0.");
+
+        singleRoot.Dispose ();
+        tabRoot.Dispose ();
+        driverSingle.Dispose ();
+        driverTabbed.Dispose ();
+    }
+
+    /// <summary>
+    ///     Edge case: transparent inactive tabs must not silently bypass the diagnostic.
+    ///     <see cref="ViewportSettingsFlags.Transparent"/> changes the clear/draw sequence in the inner
+    ///     view's draw path but it does not eliminate <see cref="View.DrawComplete"/> firing on the
+    ///     view itself. The diagnostic must still observe activity on transparent tabs.
+    /// </summary>
+    [Fact]
+    public void Diagnostic_TransparentInactiveTab_StillObservable ()
+    {
+        IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
+        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+
+        textViews [1].ViewportSettings |= ViewportSettingsFlags.Transparent;
+        textViews [2].ViewportSettings |= ViewportSettingsFlags.Transparent;
+
+        root.Layout ();
+        root.Draw ();
+
+        TextView active = (TextView)tabs.Value!;
+        counters.Reset ();
+
+        for (var y = 1; y <= 3; y++)
+        {
+            active.Viewport = active.Viewport with { Y = y };
+            root.Layout ();
+            root.Draw ();
+        }
+
+        output.WriteLine (counters.Report ("Transparent inactive tabs (3 active-tab scrolls):"));
+
+        ViewActivityCounters.Counts activeCounts = counters.Get (active);
+        Assert.True (activeCounts.DrawComplete > 0, "Active tab still draws when peers are transparent.");
+
+        for (var i = 1; i < TabCount; i++)
+        {
+            ViewActivityCounters.Counts c = counters.Get (textViews [i]);
+
+            Assert.True (
+                         c.DrawComplete >= 0,
+                         $"Tab {i + 1} DrawComplete counter must be observable (got {c.DrawComplete}) even with Transparent.");
+        }
+
+        root.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     Edge case: shadow margins draw in a separate pass (<see cref="MarginView.DrawMargins"/>).
+    ///     The diagnostic must observe the active tab's draw activity even when its margin has a shadow.
+    /// </summary>
+    [Fact]
+    public void Diagnostic_ShadowMargin_DoesNotMaskActiveTabActivity ()
+    {
+        IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
+        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+
+        textViews [0].ShadowStyle = ShadowStyles.Opaque;
+
+        root.Layout ();
+        root.Draw ();
+
+        TextView active = (TextView)tabs.Value!;
+        Assert.Same (textViews [0], active);
+
+        counters.Reset ();
+
+        for (var y = 1; y <= 3; y++)
+        {
+            active.Viewport = active.Viewport with { Y = y };
+            root.Layout ();
+            root.Draw ();
+        }
+
+        output.WriteLine (counters.Report ("Active tab with shadow margin (3 scrolls):"));
+
+        ViewActivityCounters.Counts activeCounts = counters.Get (active);
+        Assert.True (activeCounts.DrawComplete > 0, $"Active tab with shadow must still record DrawComplete (got {activeCounts.DrawComplete}).");
+
+        root.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     Acceptance criterion: assertions must not depend solely on <c>Driver.Contents</c>.
+    ///     This test confirms the diagnostic can also reach the actual <see cref="IOutput"/> layer —
+    ///     <see cref="IOutput.GetLastOutput"/> returns the ANSI bytes that would be written to the
+    ///     terminal, which is the source of truth beyond the in-memory <c>Driver.Contents</c> grid.
+    /// </summary>
+    [Fact]
+    public void Diagnostic_IOutputLayer_ObservesActiveTabContent ()
+    {
+        IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
+        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+
+        root.Layout ();
+        root.Draw ();
+
+        TextView active = (TextView)tabs.Value!;
+
+        IOutput output1 = driver.GetOutput ();
+        IOutputBuffer buffer = driver.GetOutputBuffer ();
+        output1.Write (buffer);
+        string ansiAfterInitial = output1.GetLastOutput ();
+
+        output.WriteLine ($"Initial GetLastOutput length: {ansiAfterInitial.Length}");
+        Assert.False (string.IsNullOrEmpty (ansiAfterInitial), "IOutput must produce non-empty output for initial draw.");
+
+        counters.Reset ();
+
+        active.Viewport = active.Viewport with { Y = 10 };
+        root.Layout ();
+        root.Draw ();
+
+        output1.Write (buffer);
+        string ansiAfterScroll = output1.GetLastOutput ();
+
+        output.WriteLine ($"After-scroll GetLastOutput length: {ansiAfterScroll.Length}");
+        Assert.False (string.IsNullOrEmpty (ansiAfterScroll), "IOutput must produce non-empty output after a scroll.");
+
+        ViewActivityCounters.Counts activeCounts = counters.Get (active);
+        Assert.True (activeCounts.DrawComplete > 0, "Active tab must draw for IOutput to receive content.");
+
+        Assert.Contains ($"Tab{1} line", ansiAfterInitial);
+
+        output.WriteLine (counters.Report ("IOutput-level check (1 scroll):"));
+
+        root.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     Diagnostic reports layout and draw fan-out as separate metrics, so a regression can be
+    ///     localized to one pipeline (layout vs draw) without conflating the two.
+    /// </summary>
+    [Fact]
+    public void Diagnostic_LayoutAndDraw_ReportedSeparately ()
+    {
+        IDriver driver = CreateTestDriver (DriverWidth, DriverHeight);
+        (View root, Tabs tabs, TextView [] textViews, ViewActivityCounters counters) = BuildTabbedScenario (driver);
+
+        root.Layout ();
+        root.Draw ();
+
+        TextView active = (TextView)tabs.Value!;
+        counters.Reset ();
+
+        active.Viewport = active.Viewport with { Y = 2 };
+        root.Layout ();
+        root.Draw ();
+
+        int activeLayouts = counters.Get (active).SubViewsLaidOut;
+        int activeDraws = counters.Get (active).DrawComplete;
+
+        var inactiveLayouts = 0;
+        var inactiveDraws = 0;
+
+        for (var i = 1; i < TabCount; i++)
+        {
+            inactiveLayouts += counters.Get (textViews [i]).SubViewsLaidOut;
+            inactiveDraws += counters.Get (textViews [i]).DrawComplete;
+        }
+
+        output.WriteLine ($"Layout: active={activeLayouts}, inactive_total={inactiveLayouts}");
+        output.WriteLine ($"Draw:   active={activeDraws}, inactive_total={inactiveDraws}");
+        output.WriteLine (counters.Report ("Single-scroll layout-vs-draw breakdown:"));
+
+        Assert.True (activeLayouts > 0, $"Active tab must register layout activity, got {activeLayouts}.");
+        Assert.True (activeDraws > 0, $"Active tab must register draw activity, got {activeDraws}.");
+
+        // The two counters can move independently — RC2 in #4973 affects layout fan-out only,
+        // RC1 affects draw fan-out only. Reporting them separately lets a regression land in just
+        // one pipeline without being masked by the other.
+        output.WriteLine ($"layout_fanout_ratio = {(activeLayouts == 0 ? "n/a" : ((double)inactiveLayouts / activeLayouts).ToString ("F2"))}");
+        output.WriteLine ($"draw_fanout_ratio   = {(activeDraws == 0 ? "n/a" : ((double)inactiveDraws / activeDraws).ToString ("F2"))}");
+
+        root.Dispose ();
+        driver.Dispose ();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `TabsFanOutDiagnosticTests` (7 parallelizable tests) that count layout and draw activity per tab via `SubViewsLaidOut`, `DrawComplete`, `ClearedViewport`, `DrawingContent`, and `FrameChanged` events.
- Captures the current #4973 fan-out as observable, regression-detectable counters so future fixes can be verified and silent regressions caught.
- Instrumentation-only: no rendering or invalidation behavior changes.

Implements the acceptance criteria from #5356:

- Active vs. inactive tab layout work
- Active vs. inactive tab draw work (`DrawComplete`, `ClearedViewport`, `DrawingContent`)
- Comparable single-TextView baseline vs. tabbed scenario, reporting fan-out ratios
- `ViewportSettings.Transparent` edge case (inactive tabs marked transparent)
- Shadow-margin edge case (active tab with `ShadowStyle = Opaque`)
- `IOutput`-level check via `driver.GetOutput().GetLastOutput()` — not relying solely on `Driver.Contents`
- Layout and draw counters reported separately so regressions can be localized to one pipeline

Each test emits a per-view counter table via `ITestOutputHelper` so the data is visible in CI logs even when the test passes. Assertions encode the current (buggy) behavior with comments indicating which assertions need to flip once #4973 is fixed.

Split from #4973.

## Test plan

- [x] `dotnet build Tests/UnitTestsParallelizable/UnitTests.Parallelizable.csproj` succeeds
- [x] `dotnet test --no-build -- --filter-method "*TabsFanOutDiagnostic*"` — 7 passed
- [x] `dotnet test --no-build -- --filter-method "*TabsTests*" "*TabsScrollingTests*" "*TabsFanOutDiagnostic*"` — 102 passed (no regressions in surrounding Tab tests)

## Related

- Closes #5356
- Parent: #4973
- Related: #4522