### PR TITLE
Fixes #5367. Include Terminal.Gui.Editor in DocFX API reference

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -34,7 +34,7 @@ jobs:
       run: dotnet build Terminal.Gui/Terminal.Gui.csproj --configuration Release --no-restore
 
     - name: Build EditorRef (for Terminal.Gui.Editor docs)
-      run: dotnet build docfx/EditorRef/EditorRef.csproj --configuration Release --no-restore
+      run: dotnet build docfx/EditorRef/EditorRef.csproj --configuration Release
 
     - name: DocFX Build
       working-directory: docfx

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Build Terminal.Gui Release
       run: dotnet build Terminal.Gui/Terminal.Gui.csproj --configuration Release --no-restore
 
+    - name: Build EditorRef (for Terminal.Gui.Editor docs)
+      run: dotnet build docfx/EditorRef/EditorRef.csproj --configuration Release --no-restore
+
     - name: DocFX Build
       working-directory: docfx
       run: |

--- a/docfx/EditorRef/EditorRef.csproj
+++ b/docfx/EditorRef/EditorRef.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <!-- Ensure package DLLs are copied to output for docfx metadata extraction -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- This project exists solely to provide the Terminal.Gui.Editor DLL for docfx -->
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Terminal.Gui.Editor" />
+  </ItemGroup>
+
+</Project>

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -15,6 +15,18 @@
     {
       "src": [
         {
+          "src": "EditorRef/bin/Release/net10.0",
+          "files": [
+            "Terminal.Gui.Editor.dll"
+          ]
+        }
+      ],
+      "dest": "api",
+      "memberLayout": "separatePages"
+    },
+    {
+      "src": [
+        {
           "src": "../UICatalog",
           "files": [
             "**/*.csproj"


### PR DESCRIPTION
## Summary

Adds `Terminal.Gui.Editor` package types to the DocFX-generated API reference so they are discoverable alongside the core Terminal.Gui API.

## Changes

- **`docfx/EditorRef/EditorRef.csproj`** — Minimal project that references `Terminal.Gui.Editor` via `PackageReference`. Exists solely to place the Editor DLL at a predictable build output path for docfx metadata extraction.
- **`docfx/docfx.json`** — New metadata entry pointing to `EditorRef/bin/Release/net10.0/Terminal.Gui.Editor.dll`. Uses the same `"dest": "api"` as the core library so Editor types merge into the unified API reference.

## CI Note

The `.github/workflows/api-docs.yml` also needs a build step added before docfx runs:

```yaml
- name: Build EditorRef (for Terminal.Gui.Editor docs)
  run: dotnet build docfx/EditorRef/EditorRef.csproj --configuration Release --no-restore
```

This couldn't be pushed due to OAuth token scope limitations — a maintainer needs to add this step manually (between "Build Terminal.Gui Release" and "DocFX Build").

## Verification

- `dotnet build docfx/EditorRef/EditorRef.csproj -c Release` ✅
- `docfx metadata` processes `Terminal.Gui.Editor.dll` and generates yml for ~25 Editor types ✅
- `docfx build` succeeds ✅

## Related

- Filed gui-cs/Editor#222 requesting XML docs be included in the NuGet package (currently only type structure is generated, no summaries)

Fixes: #5367