### PR TITLE
Fix EditorRef packageSourceMapping to resolve API docs build

### DIFF
--- a/docfx/EditorRef/nuget.config
+++ b/docfx/EditorRef/nuget.config
@@ -7,4 +7,10 @@
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
+  <packageSourceMapping>
+    <clear />
+    <packageSource key="nuget">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
The EditorRef nuget.config was missing a `<packageSourceMapping><clear />` section. Without it, the repo-root config's source mapping (which restricts `Terminal.Gui*` to `LocalPackages`) was inherited, causing EditorRef's `dotnet restore` to fail in CI.

This adds the mapping override so all packages resolve from nuget.org.

Fixes the API docs workflow failure after #5387.