### PR TITLE
Audit and fix inaccuracies in AI guidance files

### DIFF
--- a/.claude/rules/event-patterns.md
+++ b/.claude/rules/event-patterns.md
@@ -69,13 +69,13 @@ void OnTextChanged (object sender, EventArgs e) { }
 
 ## Local Function Naming
 
-**Use camelCase for local functions:**
+**Use PascalCase for local functions** (the `.editorconfig` `local_functions_rule` enforces `upper_camel_case_style` at `warning` severity):
 
 ```csharp
 // CORRECT
-void textViewDrawContent (object? sender, DrawEventArgs e) { }
+void TextViewDrawContent (object? sender, DrawEventArgs e) { }
 
 // WRONG
 void TextView_DrawContent (object? sender, DrawEventArgs e) { }
-void TextViewDrawContent (object? sender, DrawEventArgs e) { }
+void textViewDrawContent (object? sender, DrawEventArgs e) { }
 ```

--- a/.claude/rules/testing-patterns.md
+++ b/.claude/rules/testing-patterns.md
@@ -48,7 +48,6 @@
 - ~10 min timeout
 - Uses `Application.Init` and static state
 - Cannot run in parallel
-- Includes `--diagnostic` flag for logging
 
 **Command:**
 ```bash
@@ -86,7 +85,7 @@ dotnet test --project Tests/IntegrationTests --no-build --verbosity normal
 
 - `xunit.runner.json` - Per-project xUnit configuration (parallelization, etc.)
 - `Tests/TestEnvironmentSetup.cs` - Compiled into every test project; its `[ModuleInitializer]` sets `DisableRealDriverIO=1` before any test code runs
-- Coverage is collected via the `coverlet.collector` package referenced by each test project. `.runsettings` files are ignored by Microsoft Testing Platform (MTP).
+- Coverage tooling: each test project references the `coverlet.collector` package, but coverage is not actively collected in CI yet (see "Code Coverage" above — pending an MTP-compatible solution). `.runsettings` files are ignored by Microsoft Testing Platform (MTP).
 
 ## Example Test Pattern
 

--- a/.claude/rules/testing-patterns.md
+++ b/.claude/rules/testing-patterns.md
@@ -27,7 +27,7 @@
 3. **Follow existing test patterns**
    - Study tests in respective test projects before writing new ones
 
-4. **Avoid adding new tests to `UnitTests` Project**
+4. **Never add new tests to `UnitTests.Legacy`**
    - Make them parallelizable and add them to `UnitTestsParallelizable`
 
 5. **Avoid static dependencies**
@@ -38,7 +38,7 @@
 
 ## Test Projects
 
-### 1. Non-Parallel Tests (`Tests/UnitTests/`)
+### 1. Non-Parallel Tests (`Tests/UnitTests.NonParallelizable/`)
 
 **When to use:**
 - Testing functionality that depends on static state
@@ -52,7 +52,7 @@
 
 **Command:**
 ```bash
-dotnet test --project Tests/UnitTests --no-build --verbosity normal
+dotnet test --project Tests/UnitTests.NonParallelizable --no-build --verbosity normal
 ```
 
 ### 2. Parallel Tests (`Tests/UnitTestsParallelizable/`) - **PREFERRED**
@@ -84,8 +84,9 @@ dotnet test --project Tests/IntegrationTests --no-build --verbosity normal
 
 ## Test Configuration Files
 
-- `xunit.runner.json` - xUnit configuration
-- `coverlet.runsettings` - Coverage settings (currently unused, pending MTP integration)
+- `xunit.runner.json` - Per-project xUnit configuration (parallelization, etc.)
+- `Tests/TestEnvironmentSetup.cs` - Compiled into every test project; its `[ModuleInitializer]` sets `DisableRealDriverIO=1` before any test code runs
+- Coverage is collected via the `coverlet.collector` package referenced by each test project. `.runsettings` files are ignored by Microsoft Testing Platform (MTP).
 
 ## Example Test Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ See `.claude/rules/` for detailed guidance:
 - `event-patterns.md` - Lambdas, closures, handlers
 - `early-return.md` - **Guard clauses, minimal nesting** (commonly violated!)
 - `collection-expressions.md` - Use `[...]` syntax
+- `unicode-graphemes.md` - **Think in graphemes** - `GetColumns()`, `GraphemeHelper.GetGraphemes()`
 - `cwp-pattern.md` - Cancellable Workflow Pattern
 - `code-layout.md` - Backing fields, member ordering
 - `api-documentation.md` - XML documentation requirements
@@ -63,7 +64,6 @@ See `.claude/rules/` for detailed guidance:
 ## Task-Specific Guides
 
 See `.claude/tasks/` for task checklists:
-- `scenario-modernization.md` - Upgrading UICatalog scenarios
 - `clean-code-review.md` - Creating clean git commit histories
 - `build-app.md` - Building applications with Terminal.Gui
 
@@ -100,8 +100,11 @@ dotnet test --project Tests/UnitTests.NonParallelizable --no-build
 # Legacy tests — do NOT add new tests here; candidates for rewrite/deletion
 dotnet test --project Tests/UnitTests.Legacy --no-build
 
-# Run a single test by fully-qualified name
-dotnet test --project Tests/UnitTestsParallelizable --no-build --filter "FullyQualifiedName~MyTestClass.MyTestMethod"
+# Run a single test by method name (Microsoft Testing Platform)
+dotnet test --project Tests/UnitTestsParallelizable --no-build --filter-method "*MyTestMethod"
+
+# Run all tests in a class
+dotnet test --project Tests/UnitTestsParallelizable --no-build --filter-class "*MyTestClass"
 ```
 
 See `Tests/README.md` for the full list of test projects (including `IntegrationTests`, `StressTests`, `Benchmarks`) and the static-state classification that determines where a new test belongs.


### PR DESCRIPTION
## Summary

Audited the AI-agent guidance files (`CLAUDE.md` and `.claude/rules/*`) for claims that have drifted from the actual codebase/config, and corrected them. Each fix is backed by the real source/config rather than assumption.

- **CLAUDE.md**
  - Single-test command now uses the real Microsoft Testing Platform flags (`--filter-method` / `--filter-class`) instead of the VSTest-only `--filter "FullyQualifiedName~..."`. Confirmed the test projects are `xunit.v3` with `OutputType=Exe` (MTP runner).
  - Removed the dangling `.claude/tasks/scenario-modernization.md` link — that file does not exist (`.claude/tasks/` contains only `build-app.md` and `clean-code-review.md`).
  - Added the existing `unicode-graphemes.md` rule to the "Detailed Rules" list, where it was missing.
- **`.claude/rules/event-patterns.md`** — Local-function naming corrected from camelCase to **PascalCase**, matching `.editorconfig`'s `local_functions_rule` (`upper_camel_case_style`, warning severity) and real code (`OnButtonClicked`, `OnMouseLeave`, …).
- **`.claude/rules/testing-patterns.md`** — Non-parallel section now points at the real `Tests/UnitTests.NonParallelizable` project (`Tests/UnitTests` does not exist); names `UnitTests.Legacy` as the do-not-add project; replaces the phantom `coverlet.runsettings` reference (no `.runsettings` file exists and MTP ignores them) with the actual mechanism — the `coverlet.collector` package plus `Tests/TestEnvironmentSetup.cs`.

Verified-and-already-correct (left unchanged): C# 14 / net10.0, all `docfx/docs/*` links, the `var`-for-built-in-types rule (matches ReSharper `use_var_when_evident`), and the `Benchmarks` / `StressTests` / `IntegrationTests` directory references.

## Test plan

- [ ] Docs-only change — no build/test impact.
- [ ] Spot-check the corrected commands: `dotnet test --project Tests/UnitTests.NonParallelizable --no-build` and `--filter-method "*MyTestMethod"` resolve against existing projects.
- [ ] Confirm all file paths referenced in `CLAUDE.md` / `.claude/rules/*` now resolve.

https://claude.ai/code/session_01Msd5RHe9K8JR55YXTZEtdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Msd5RHe9K8JR55YXTZEtdn)_