### PR TITLE
Fixes #5436. HotKeys should not work on !Visible views

### DIFF
--- a/Terminal.Gui/ViewBase/View.Keyboard.cs
+++ b/Terminal.Gui/ViewBase/View.Keyboard.cs
@@ -820,6 +820,11 @@ public partial class View // Keyboard APIs
             return false;
         }
 
+        if (!Visible)
+        {
+            return false;
+        }
+
         bool? handled = null;
 
         // Process this View

--- a/Tests/UnitTestsParallelizable/ViewBase/Keyboard/KeyBindingsTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/Keyboard/KeyBindingsTests.cs
@@ -218,6 +218,56 @@ public class KeyBindingsTests
         Assert.True (hotKeyFired);
     }
 
+    // Copilot - Opus 4.6
+    /// <summary>
+    ///     A view with Visible = false should not have its HotKey invoked via InvokeCommandsBoundToHotKey.
+    /// </summary>
+    [Fact]
+    public void HotKey_Visible_False_Does_Not_Invoke ()
+    {
+        IApplication app = Application.Create ();
+        app.Begin (new Runnable<bool> ());
+
+        ScopedKeyBindingView view = new ();
+        app!.TopRunnableView!.Add (view);
+
+        // Sanity check: hotkey works when visible
+        app.Keyboard.RaiseKeyDownEvent (Key.H);
+        Assert.True (view.HotKeyCommandInvoked);
+
+        // Now hide the view and try again
+        view.HotKeyCommandInvoked = false;
+        view.Visible = false;
+        app.Keyboard.RaiseKeyDownEvent (Key.H);
+        Assert.False (view.HotKeyCommandInvoked);
+    }
+
+    // Copilot - Opus 4.6
+    /// <summary>
+    ///     A SubView of an invisible SuperView should not have its HotKey invoked.
+    /// </summary>
+    [Fact]
+    public void HotKey_Invisible_SuperView_SubView_Does_Not_Invoke ()
+    {
+        IApplication app = Application.Create ();
+        app.Begin (new Runnable<bool> ());
+
+        View container = new () { Id = "container" };
+        ScopedKeyBindingView subView = new ();
+        container.Add (subView);
+        app!.TopRunnableView!.Add (container);
+
+        // Sanity check: hotkey works when container is visible
+        app.Keyboard.RaiseKeyDownEvent (Key.H);
+        Assert.True (subView.HotKeyCommandInvoked);
+
+        // Hide the container and try again
+        subView.HotKeyCommandInvoked = false;
+        container.Visible = false;
+        app.Keyboard.RaiseKeyDownEvent (Key.H);
+        Assert.False (subView.HotKeyCommandInvoked);
+    }
+
     // tests that test KeyBindingScope.Focus and KeyBindingScope.HotKey (tests for KeyBindingScope.Application are in Application/KeyboardTests.cs)
 
     public class ScopedKeyBindingView : View


### PR DESCRIPTION
Fixes: #5436

`InvokeCommandsBoundToHotKey` checked `!Enabled` but not `!Visible`, so invisible views (and their entire subview trees) could still process hotkeys via custom `Command.HotKey` handlers that bypass the `CanBeVisible` check in `DefaultHotKeyHandler`.

This adds a `!Visible` guard matching the existing `!Enabled` pattern, preventing hotkey dispatch and subview recursion for invisible views.

MenuItem shortcuts (e.g., Ctrl+N) are unaffected -- they flow through `PopoverMenu.OnKeyDownNotHandled`, not through `HotKeyBindings`.

**Note:** A partial fix for this was already shipped in PR #5432 (the Wizard PR), which added the `!CanBeVisible(this)` check to `DefaultHotKeyHandler`. That protects the default handler, but custom `Command.HotKey` handlers (e.g., `MenuBarItem`) that don't call `DefaultHotKeyHandler` were still vulnerable. This PR completes the fix by guarding at the dispatch level.

**Tests added:**
- `HotKey_Visible_False_Does_Not_Invoke` -- direct invisible view
- `HotKey_Invisible_SuperView_SubView_Does_Not_Invoke` -- subview of invisible container

All 17,286 parallelizable tests pass.
