### PR TITLE
Fixes #5449. WSL Clipboard Unicode Copy/Paste Issue

### DIFF
--- a/Terminal.Gui/App/Clipboard/ClipboardProcessRunnerImpl.cs
+++ b/Terminal.Gui/App/Clipboard/ClipboardProcessRunnerImpl.cs
@@ -1,0 +1,14 @@
+namespace Terminal.Gui.App;
+
+internal sealed class ClipboardProcessRunnerImpl : IClipboardProcessRunner
+{
+    public (int exitCode, string result) Bash (string commandLine, string inputText = "", bool waitForOutput = false)
+    {
+        return ClipboardProcessRunner.Bash (commandLine, inputText, waitForOutput);
+    }
+
+    public (int exitCode, string result) Process (string cmd, string arguments, string? input = null, bool waitForOutput = true)
+    {
+        return ClipboardProcessRunner.Process (cmd, arguments, input, waitForOutput);
+    }
+}

--- a/Terminal.Gui/App/Clipboard/IClipboardProcessRunner.cs
+++ b/Terminal.Gui/App/Clipboard/IClipboardProcessRunner.cs
@@ -1,0 +1,7 @@
+namespace Terminal.Gui.App;
+
+internal interface IClipboardProcessRunner
+{
+    (int exitCode, string result) Bash (string commandLine, string inputText = "", bool waitForOutput = false);
+    (int exitCode, string result) Process (string cmd, string arguments, string? input = null, bool waitForOutput = true);
+}

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixClipboard.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixClipboard.cs
@@ -18,7 +18,7 @@ internal class UnixClipboard : ClipboardBase
 
         try
         {
-            (int exitCode, string result) = ClipboardProcessRunner.Bash ($"{_xclipPath} {xclipargs} > {tempFileName}", waitForOutput: false);
+            (int exitCode, string _) = ClipboardProcessRunner.Bash ($"{_xclipPath} {xclipargs} > {tempFileName}", waitForOutput: false);
 
             if (exitCode == 0)
             {
@@ -43,7 +43,7 @@ internal class UnixClipboard : ClipboardBase
 
         try
         {
-            (int exitCode, _) = ClipboardProcessRunner.Bash ($"{_xclipPath} {xclipargs}", text);
+            ClipboardProcessRunner.Bash ($"{_xclipPath} {xclipargs}", text);
         }
         catch (Exception e)
         {
@@ -172,6 +172,17 @@ internal class MacOSXClipboard : ClipboardBase
 internal class WSLClipboard : ClipboardBase
 {
     private static string _powershellPath = string.Empty;
+    private readonly string _powershellPathOverride;
+    private readonly IClipboardProcessRunner _processRunner;
+
+    public WSLClipboard () : this (new ClipboardProcessRunnerImpl ()) { }
+
+    internal WSLClipboard (IClipboardProcessRunner processRunner, string powershellPath = "")
+    {
+        _processRunner = processRunner ?? throw new ArgumentNullException (nameof (processRunner));
+        _powershellPathOverride = powershellPath;
+    }
+
     public override bool IsSupported => CheckSupport ();
 
     protected override string GetClipboardDataImpl ()
@@ -182,19 +193,19 @@ internal class WSLClipboard : ClipboardBase
         }
 
         (int exitCode, string output) =
-            ClipboardProcessRunner.Process (_powershellPath, "-noprofile -command \"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Clipboard\"");
+            _processRunner.Process (GetPowershellPath (), "-noprofile -command \"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Clipboard\"");
 
-        if (exitCode == 0)
+        if (exitCode != 0)
         {
-            if (output.EndsWith ("\r\n"))
-            {
-                output = output.Substring (0, output.Length - 2);
-            }
-
-            return output;
+            return string.Empty;
         }
 
-        return string.Empty;
+        if (output.EndsWith ("\r\n", StringComparison.Ordinal))
+        {
+            output = output [..^2];
+        }
+
+        return output;
     }
 
     protected override void SetClipboardDataImpl (string text)
@@ -204,27 +215,46 @@ internal class WSLClipboard : ClipboardBase
             return;
         }
 
-        (int exitCode, string output) = ClipboardProcessRunner.Process (_powershellPath, "-noprofile -command \"$input | Set-Clipboard\"", input: text);
+        _processRunner.Process (GetPowershellPath (),
+                                "-noprofile -command \"$encoded = [Console]::In.ReadToEnd(); $text = [System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String($encoded)); Set-Clipboard -Value $text\"",
+                                input: Convert.ToBase64String (Encoding.Unicode.GetBytes (text)));
     }
 
     private bool CheckSupport ()
     {
-        if (string.IsNullOrEmpty (_powershellPath))
+        if (!string.IsNullOrEmpty (_powershellPathOverride))
         {
-            // Specify pwsh.exe (not pwsh) to ensure we get the Windows version (invoked via WSL)
-            (int exitCode, string result) = ClipboardProcessRunner.Bash ("which pwsh.exe", waitForOutput: true);
+            return true;
+        }
 
-            if (exitCode > 0)
-            {
-                (exitCode, result) = ClipboardProcessRunner.Bash ("which powershell.exe", waitForOutput: true);
-            }
+        if (!string.IsNullOrEmpty (_powershellPath))
+        {
+            return !string.IsNullOrEmpty (_powershellPath);
+        }
 
-            if (exitCode == 0)
-            {
-                _powershellPath = result;
-            }
+        // Specify pwsh.exe (not pwsh) to ensure we get the Windows version (invoked via WSL)
+        (int exitCode, string result) = _processRunner.Bash ("which pwsh.exe", waitForOutput: true);
+
+        if (exitCode > 0)
+        {
+            (exitCode, result) = _processRunner.Bash ("which powershell.exe", waitForOutput: true);
+        }
+
+        if (exitCode == 0)
+        {
+            _powershellPath = result;
         }
 
         return !string.IsNullOrEmpty (_powershellPath);
+    }
+
+    private string GetPowershellPath ()
+    {
+        if (!string.IsNullOrEmpty (_powershellPathOverride))
+        {
+            return _powershellPathOverride;
+        }
+
+        return _powershellPath;
     }
 }

--- a/Tests/UnitTestsParallelizable/Drivers/WSLClipboardTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/WSLClipboardTests.cs
@@ -1,0 +1,107 @@
+using System.Text;
+
+namespace UnitTestsParallelizable.Drivers;
+
+public class WSLClipboardTests
+{
+    [Fact]
+    public void TextField_Copy_Then_Paste_RoundTrips_Cjk_Text_Through_WslClipboard ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        WslClipboardProcessRunner processRunner = new ();
+        app.Driver!.Clipboard = new WSLClipboard (processRunner, "pwsh.exe");
+
+        using Runnable runnable = new ();
+        TextField textField = new () { Width = 10 };
+        runnable.Add (textField);
+        app.Begin (runnable);
+
+        processRunner.SetExternalClipboardText ("腌");
+
+        Assert.True (textField.Paste ());
+        Assert.Equal ("腌", textField.Text);
+
+        Assert.True (textField.SelectAll ());
+        Assert.True (textField.Copy ());
+
+        Assert.True (textField.MoveEnd ());
+        Assert.True (textField.Paste ());
+
+        Assert.Equal (0, processRunner.BashCallCount);
+        Assert.DoesNotContain ("$input", processRunner.LastSetArguments);
+        Assert.True (processRunner.LastSetInputWasAscii);
+        Assert.Equal ("腌腌", textField.Text);
+    }
+
+    [Fact]
+    public void SetClipboardData_Sends_Ascii_Base64_Through_Windows_PowerShell_Stdin ()
+    {
+        WslClipboardProcessRunner processRunner = new ();
+        WSLClipboard clipboard = new (processRunner, "pwsh.exe");
+
+        clipboard.SetClipboardData ("腌");
+
+        Assert.Equal (0, processRunner.BashCallCount);
+        Assert.DoesNotContain ("$input", processRunner.LastSetArguments);
+        Assert.True (processRunner.LastSetInputWasAscii);
+        Assert.Equal ("腌", clipboard.GetClipboardData ());
+    }
+
+    private sealed class WslClipboardProcessRunner : IClipboardProcessRunner
+    {
+        private string _clipboardText = string.Empty;
+
+        public string LastSetArguments { get; private set; } = string.Empty;
+        public bool LastSetInputWasAscii { get; private set; }
+        public int BashCallCount { get; private set; }
+
+        public void SetExternalClipboardText (string text)
+        {
+            _clipboardText = text;
+        }
+
+        public (int exitCode, string result) Bash (string commandLine, string inputText = "", bool waitForOutput = false)
+        {
+            BashCallCount++;
+
+            return (0, "pwsh.exe");
+        }
+
+        public (int exitCode, string result) Process (string cmd, string arguments, string? input = null, bool waitForOutput = true)
+        {
+            if (!arguments.Contains ("Set-Clipboard"))
+            {
+                return (0, _clipboardText);
+            }
+            LastSetArguments = arguments;
+            LastSetInputWasAscii = IsAscii (input ?? string.Empty);
+
+            if (arguments.Contains ("FromBase64String"))
+            {
+                byte [] bytes = Convert.FromBase64String (input ?? string.Empty);
+                _clipboardText = Encoding.Unicode.GetString (bytes);
+            }
+            else
+            {
+                _clipboardText = "Þàî";
+            }
+
+            return (0, string.Empty);
+        }
+
+        private static bool IsAscii (string text)
+        {
+            foreach (char ch in text)
+            {
+                if (ch > 127)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Fixes

- Fixes #5449

## Proposed Changes/Todos

- [x] Encodes clipboard text as UTF-16LE bytes and then base64

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
