### PR TITLE
Fixes #5451. Linux UnixClipboard Selection Regression

### DIFF
--- a/Terminal.Gui/Drivers/DriverImpl.cs
+++ b/Terminal.Gui/Drivers/DriverImpl.cs
@@ -79,7 +79,7 @@ internal class DriverImpl : IDriver
         _terminalSize = new Size (outputBuffer.Cols, outputBuffer.Rows);
         AnsiStartupGate = ansiStartupGate;
 
-        CreateClipboard ();
+        Clipboard = CreateClipboard ();
 
         Driver.Force16ColorsChanged += OnDriverOnForce16ColorsChanged;
     }
@@ -158,27 +158,61 @@ internal class DriverImpl : IDriver
     public IAnsiStartupGate? AnsiStartupGate { get; }
 
     /// <inheritdoc/>
-    public IClipboard? Clipboard { get; set; } = new FakeClipboard ();
+    public IClipboard? Clipboard { get; set; }
 
     /// <inheritdoc/>
     public ProgressIndicator? ProgressIndicator { get; internal set; }
 
-    private void CreateClipboard ()
+    internal static IClipboard CreateClipboard (
+        Func<bool> isWindows,
+        Func<bool> isMac,
+        Func<bool> isWsl,
+        Func<bool> isLinux,
+        Func<IClipboard> createWindowsClipboard,
+        Func<IClipboard> createMacClipboard,
+        Func<IClipboard> createWslClipboard,
+        Func<IClipboard> createUnixClipboard,
+        IClipboard fallbackClipboard
+    )
+    {
+        if (isWindows ())
+        {
+            return createWindowsClipboard ();
+        }
+
+        if (isMac ())
+        {
+            return createMacClipboard ();
+        }
+
+        if (isWsl ())
+        {
+            return createWslClipboard ();
+        }
+
+        if (!isLinux ())
+        {
+            return fallbackClipboard;
+        }
+
+        IClipboard unixClipboard = createUnixClipboard ();
+
+        return !unixClipboard.IsSupported ? fallbackClipboard : unixClipboard;
+    }
+
+    private static IClipboard CreateClipboard ()
     {
         PlatformID p = Environment.OSVersion.Platform;
 
-        if (p is PlatformID.Win32NT or PlatformID.Win32S or PlatformID.Win32Windows)
-        {
-            Clipboard = new WindowsClipboard ();
-        }
-        else if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX))
-        {
-            Clipboard = new MacOSXClipboard ();
-        }
-        else if (PlatformDetection.IsWSL ())
-        {
-            Clipboard = new WSLClipboard ();
-        }
+        return CreateClipboard (() => p is PlatformID.Win32NT or PlatformID.Win32S or PlatformID.Win32Windows,
+                                () => RuntimeInformation.IsOSPlatform (OSPlatform.OSX),
+                                PlatformDetection.IsWSL,
+                                PlatformDetection.IsLinux,
+                                () => new WindowsClipboard (),
+                                () => new MacOSXClipboard (),
+                                () => new WSLClipboard (),
+                                () => new UnixClipboard (),
+                                new FakeClipboard ());
     }
 
     internal void InitializeProgressIndicator ()

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixClipboard.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixClipboard.cs
@@ -7,18 +7,27 @@ namespace Terminal.Gui.Drivers;
 /// <remarks>If xclip is not installed, this implementation will not work.</remarks>
 internal class UnixClipboard : ClipboardBase
 {
+    private readonly IClipboardProcessRunner _processRunner;
     private string _xclipPath = string.Empty;
-    public UnixClipboard () => IsSupported = CheckSupport ();
+
+    public UnixClipboard () : this (new ClipboardProcessRunnerImpl ()) { }
+
+    internal UnixClipboard (IClipboardProcessRunner processRunner)
+    {
+        _processRunner = processRunner ?? throw new ArgumentNullException (nameof (processRunner));
+        IsSupported = CheckSupport ();
+    }
+
     public override bool IsSupported { get; }
 
     protected override string GetClipboardDataImpl ()
     {
         string tempFileName = Path.GetTempFileName ();
-        var xclipargs = "-selection clipboard -o";
+        string xclipArgs = "-selection clipboard -o";
 
         try
         {
-            (int exitCode, string _) = ClipboardProcessRunner.Bash ($"{_xclipPath} {xclipargs} > {tempFileName}", waitForOutput: false);
+            (int exitCode, string _) = _processRunner.Bash ($"{_xclipPath} {xclipArgs} > {tempFileName}", waitForOutput: false);
 
             if (exitCode == 0)
             {
@@ -27,7 +36,7 @@ internal class UnixClipboard : ClipboardBase
         }
         catch (Exception e)
         {
-            throw new NotSupportedException ($"\"{_xclipPath} {xclipargs}\" failed.", e);
+            throw new NotSupportedException ($"\"{_xclipPath} {xclipArgs}\" failed.", e);
         }
         finally
         {
@@ -39,15 +48,15 @@ internal class UnixClipboard : ClipboardBase
 
     protected override void SetClipboardDataImpl (string text)
     {
-        var xclipargs = "-selection clipboard -i";
+        string xclipArgs = "-selection clipboard -i";
 
         try
         {
-            ClipboardProcessRunner.Bash ($"{_xclipPath} {xclipargs}", text);
+            _processRunner.Bash ($"{_xclipPath} {xclipArgs}", text);
         }
         catch (Exception e)
         {
-            throw new NotSupportedException ($"\"{_xclipPath} {xclipargs} < {text}\" failed", e);
+            throw new NotSupportedException ($"\"{_xclipPath} {xclipArgs} < {text}\" failed", e);
         }
     }
 
@@ -56,7 +65,7 @@ internal class UnixClipboard : ClipboardBase
 #pragma warning disable RCS1075 // Avoid empty catch clause that catches System.Exception.
         try
         {
-            (int exitCode, string result) = ClipboardProcessRunner.Bash ("which xclip", waitForOutput: true);
+            (int exitCode, string result) = _processRunner.Bash ("which xclip", waitForOutput: true);
 
             if (exitCode == 0 && result.FileExists ())
             {

--- a/Tests/UnitTestsParallelizable/Drivers/DriverImplClipboardTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/DriverImplClipboardTests.cs
@@ -1,0 +1,116 @@
+namespace UnitTestsParallelizable.Drivers;
+
+public class DriverImplClipboardTests
+{
+    [Fact]
+    public void UnixClipboard_Set_Then_Get_RoundTrips_Through_Xclip_Runner ()
+    {
+        UnixClipboardProcessRunner processRunner = new ();
+        UnixClipboard clipboard = new (processRunner);
+
+        Assert.True (clipboard.IsSupported);
+
+        clipboard.SetClipboardData ("hello");
+
+        Assert.Equal ("hello", clipboard.GetClipboardData ());
+        Assert.Contains ("-selection clipboard -i", processRunner.LastSetCommandLine);
+        Assert.Contains ("-selection clipboard -o", processRunner.LastGetCommandLine);
+    }
+
+    [Fact]
+    public void CreateClipboard_Linux_AttachedToTerminal_And_UnixSupported_Uses_UnixClipboard ()
+    {
+        FakeClipboard fallbackClipboard = new ();
+        FakeClipboard unixClipboard = new ();
+
+        IClipboard clipboard = DriverImpl.CreateClipboard (isWindows: () => false,
+                                                           isMac: () => false,
+                                                           isWsl: () => false,
+                                                           isLinux: () => true,
+                                                           createWindowsClipboard: () => throw new InvalidOperationException (),
+                                                           createMacClipboard: () => throw new InvalidOperationException (),
+                                                           createWslClipboard: () => throw new InvalidOperationException (),
+                                                           createUnixClipboard: () => unixClipboard,
+                                                           fallbackClipboard: fallbackClipboard);
+
+        Assert.Same (unixClipboard, clipboard);
+    }
+
+    [Fact]
+    public void CreateClipboard_NotLinux_Uses_FallbackClipboard ()
+    {
+        FakeClipboard fallbackClipboard = new ();
+
+        IClipboard clipboard = DriverImpl.CreateClipboard (isWindows: () => false,
+                                                           isMac: () => false,
+                                                           isWsl: () => false,
+                                                           isLinux: () => false,
+                                                           createWindowsClipboard: () => throw new InvalidOperationException (),
+                                                           createMacClipboard: () => throw new InvalidOperationException (),
+                                                           createWslClipboard: () => throw new InvalidOperationException (),
+                                                           createUnixClipboard: () => throw new InvalidOperationException (),
+                                                           fallbackClipboard: fallbackClipboard);
+
+        Assert.Same (fallbackClipboard, clipboard);
+    }
+
+    [Fact]
+    public void CreateClipboard_Linux_AttachedToTerminal_But_UnixUnsupported_Uses_FallbackClipboard ()
+    {
+        FakeClipboard fallbackClipboard = new ();
+        FakeClipboard unsupportedUnixClipboard = new (isSupportedAlwaysFalse: true);
+
+        IClipboard clipboard = DriverImpl.CreateClipboard (isWindows: () => false,
+                                                           isMac: () => false,
+                                                           isWsl: () => false,
+                                                           isLinux: () => true,
+                                                           createWindowsClipboard: () => throw new InvalidOperationException (),
+                                                           createMacClipboard: () => throw new InvalidOperationException (),
+                                                           createWslClipboard: () => throw new InvalidOperationException (),
+                                                           createUnixClipboard: () => unsupportedUnixClipboard,
+                                                           fallbackClipboard: fallbackClipboard);
+
+        Assert.Same (fallbackClipboard, clipboard);
+    }
+
+    private sealed class UnixClipboardProcessRunner : IClipboardProcessRunner
+    {
+        private string _clipboardText = string.Empty;
+
+        public string LastGetCommandLine { get; private set; } = string.Empty;
+        public string LastSetCommandLine { get; private set; } = string.Empty;
+
+        public (int exitCode, string result) Bash (string commandLine, string inputText = "", bool waitForOutput = false)
+        {
+            if (commandLine == "which xclip")
+            {
+                return (0, "/usr/bin/xclip");
+            }
+
+            if (commandLine.Contains ("-selection clipboard -i", StringComparison.Ordinal))
+            {
+                LastSetCommandLine = commandLine;
+                _clipboardText = inputText;
+
+                return (0, string.Empty);
+            }
+
+            if (!commandLine.Contains ("-selection clipboard -o", StringComparison.Ordinal))
+            {
+                return (1, string.Empty);
+            }
+            LastGetCommandLine = commandLine;
+            int redirectIndex = commandLine.IndexOf (" > ", StringComparison.Ordinal);
+            string tempFileName = commandLine [(redirectIndex + 3)..];
+
+            File.WriteAllText (tempFileName, _clipboardText);
+
+            return (0, string.Empty);
+        }
+
+        public (int exitCode, string result) Process (string cmd, string arguments, string? input = null, bool waitForOutput = true)
+        {
+            throw new NotSupportedException ();
+        }
+    }
+}


### PR DESCRIPTION
## Fixes

- Fixes #5451

## Proposed Changes/Todos

- [x] Selects UnixClipboard on Linux when supported.
- [x] Provides an internal test seam for platform and clipboard factory behavior.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
