### PR TITLE
Fixes #5453. Fix Windows VT input encoding for IME and non-ASCII characters

### DIFF
--- a/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
+++ b/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
@@ -82,7 +82,11 @@ internal sealed class WindowsVTInputHelper : IDisposable
 
         if (_originalConsoleCP != CP_UTF8)
         {
-            SetConsoleCP (CP_UTF8);
+            if (!SetConsoleCP (CP_UTF8))
+            {
+                int error = Marshal.GetLastWin32Error ();
+                Logging.Warning ($"{nameof (WindowsVTInputHelper)}: Failed to set console input code page to UTF-8. Win32 error: {error}");
+            }
         }
     }
 

--- a/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
+++ b/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
@@ -80,14 +80,12 @@ internal sealed class WindowsVTInputHelper : IDisposable
     {
         _originalConsoleCP = GetConsoleCP ();
 
-        if (_originalConsoleCP != CP_UTF8)
+        if (_originalConsoleCP == CP_UTF8 || SetConsoleCP (CP_UTF8))
         {
-            if (!SetConsoleCP (CP_UTF8))
-            {
-                int error = Marshal.GetLastWin32Error ();
-                Logging.Warning ($"{nameof (WindowsVTInputHelper)}: Failed to set console input code page to UTF-8. Win32 error: {error}");
-            }
+            return;
         }
+        int error = Marshal.GetLastWin32Error ();
+        Logging.Warning ($"{nameof (WindowsVTInputHelper)}: Failed to set console input code page to UTF-8. Win32 error: {error}");
     }
 
     /// <summary>

--- a/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
+++ b/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
@@ -51,6 +51,9 @@ internal sealed class WindowsVTInputHelper : IDisposable
     [DllImport ("kernel32.dll")]
     private static extern uint GetConsoleCP ();
 
+    [DllImport ("kernel32.dll", SetLastError = true)]
+    private static extern bool SetConsoleCP (uint wCodePageID);
+
     #endregion
 
     private const int ERROR_NOT_FOUND = 1168;
@@ -67,6 +70,21 @@ internal sealed class WindowsVTInputHelper : IDisposable
 
     private uint _originalConsoleMode;
     private bool _disposed;
+
+    private const uint CP_UTF8 = 65001;
+
+    private readonly uint _originalConsoleCP;
+    private readonly Encoding _utf8 = new UTF8Encoding (encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    public WindowsVTInputHelper ()
+    {
+        _originalConsoleCP = GetConsoleCP ();
+
+        if (_originalConsoleCP != CP_UTF8)
+        {
+            SetConsoleCP (CP_UTF8);
+        }
+    }
 
     /// <summary>
     ///     Gets whether VTS input mode was successfully enabled.
@@ -238,6 +256,7 @@ internal sealed class WindowsVTInputHelper : IDisposable
 
         try
         {
+            SetConsoleCP (_originalConsoleCP);
             SetConsoleMode (InputHandle, _originalConsoleMode);
             IsEnabled = false;
         }

--- a/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
+++ b/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
@@ -74,7 +74,6 @@ internal sealed class WindowsVTInputHelper : IDisposable
     private const uint CP_UTF8 = 65001;
 
     private readonly uint _originalConsoleCP;
-    private readonly Encoding _utf8 = new UTF8Encoding (encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
     public WindowsVTInputHelper ()
     {


### PR DESCRIPTION
## Fixes

- Fixes #5453

## Proposed Changes/Todos

- [x] Save the current console input code page.
- [x] Set the console input code page to UTF-8 (65001).
- [x] Decode VT input using UTF-8.
- [x] Restore the original console input code page when disposing the driver.

Verified manually by entering Chinese IME characters (腌) before and after the change. Prior to the fix the character was received as ?; after the fix the correct Unicode character is delivered to Terminal.Gui.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
