### PR TITLE
Fixes #5461. AnsiOutput should momentarily display a blank screen instead of rendering to a screen with the wrong dimensions

### DIFF
--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -39,7 +39,7 @@ public class AnsiOutput : OutputBase, IOutput
     // Tracks which underlying platform APIs are in use
     private readonly AnsiPlatform _platform;
 
-    private Size _consoleSize = new (80, 25);
+    private Size _consoleSize;
     private IOutputBuffer? _lastBuffer;
 
     private readonly WindowsVTOutputHelper? _windowsVTOutput;
@@ -71,7 +71,6 @@ public class AnsiOutput : OutputBase, IOutput
         _platform = AnsiPlatform.Degraded;
 
         _lastBuffer = new OutputBufferImpl ();
-        _lastBuffer.SetSize (80, 25);
         _currentCursor = new Cursor ();
 
         try
@@ -86,6 +85,9 @@ public class AnsiOutput : OutputBase, IOutput
             // Check if we have a real console first
             if (!IsAttachedToTerminal)
             {
+                _consoleSize = new Size (80, 25);
+                _lastBuffer.SetSize (_consoleSize.Width, _consoleSize.Height);
+
                 Trace.Lifecycle (nameof (AnsiOutput), "Init", "No real terminal attached. Running in degraded mode.");
 
                 return;


### PR DESCRIPTION
## Fixes

- Fixes #5461

## Proposed Changes/Todos

- [x] Only set default size if IsAttachedToTerminal is false.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
