### PR TITLE
Fixes #5434. Track adornment thickness deltas so LayoutAndDraw can stop force-drawing

### DIFF
--- a/Terminal.Gui/App/ApplicationImpl.Screen.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Screen.cs
@@ -278,18 +278,16 @@ internal partial class ApplicationImpl
             Rectangle clipRect = Screen with { X = 0, Y = 0 };
             Driver.Clip = new Region (clipRect);
 
-            // Only force a complete redraw if needed (needsLayout or forceRedraw).
-            // Otherwise, just redraw views that need it.
+            // Only force a complete redraw when explicitly requested.
+            // Otherwise, redraw only the views that need it.
             //
             // NOTE (#5358): passing force=true here calls SetNeedsDraw on the top runnable, which
             // cascades to all overlapping subviews via the existing SetNeedsDraw recursion. This
             // is the remaining draw-fan-out source documented by TabsFanOutIntegrationTests. The
             // proper fix requires tracking adornment thickness changes (in addition to Frame
             // changes) so the SuperView can be invalidated precisely instead of force-redrawing
-            // the whole tree. Dropping force-on-neededLayout without that tracking exposes
-            // stale-content bugs in the shrink/move and adornment-rebalance paths (covered by
-            // ShadowTests / BorderViewTests).
-            View.Draw (views.ToArray ().Cast<View> (), neededLayout || forceRedraw);
+            // the whole tree.
+            View.Draw (views.ToArray ().Cast<View> (), forceRedraw);
 
             Driver.Clip = new Region (clipRect);
 

--- a/Terminal.Gui/ViewBase/View.Adornments.cs
+++ b/Terminal.Gui/ViewBase/View.Adornments.cs
@@ -23,7 +23,7 @@ public partial class View // Adornments
         // When any adornment's thickness changes, recompute frames and request layout + redraw.
         Margin.ThicknessChanged += (_, _) =>
                                    {
-                                      previousMarginThickness = HandleAdornmentThicknessChanged (Margin, previousMarginThickness);
+                                       previousMarginThickness = HandleAdornmentThicknessChanged (Margin, previousMarginThickness);
                                    };
 
         Border.ThicknessChanged += (_, _) =>
@@ -370,17 +370,18 @@ public partial class View // Adornments
     {
         Thickness thickness = GetAdornmentsThicknessForAdornment (changedAdornment, changedThickness);
 
-        return new Rectangle (_viewportLocation,
-                              new Size (Math.Max (0, Frame.Width - thickness.Horizontal), Math.Max (0, Frame.Height - thickness.Vertical)));
+        return new Rectangle (_viewportLocation, GetViewportSizeForThickness (thickness));
     }
 
     private Rectangle GetViewportFrameForAdornmentThickness (IAdornment changedAdornment, Thickness changedThickness)
     {
         Thickness thickness = GetAdornmentsThicknessForAdornment (changedAdornment, changedThickness);
 
-        return new Rectangle (new Point (thickness.Left, thickness.Top),
-                              new Size (Math.Max (0, Frame.Width - thickness.Horizontal), Math.Max (0, Frame.Height - thickness.Vertical)));
+        return new Rectangle (new Point (thickness.Left, thickness.Top), GetViewportSizeForThickness (thickness));
     }
+
+    private Size GetViewportSizeForThickness (Thickness thickness) =>
+        new (Math.Max (0, Frame.Width - thickness.Horizontal), Math.Max (0, Frame.Height - thickness.Vertical));
 
     private Thickness GetAdornmentsThicknessForAdornment (IAdornment changedAdornment, Thickness changedThickness)
     {

--- a/Terminal.Gui/ViewBase/View.Adornments.cs
+++ b/Terminal.Gui/ViewBase/View.Adornments.cs
@@ -11,6 +11,11 @@ public partial class View // Adornments
         {
             return;
         }
+
+        Thickness previousMarginThickness = Margin.Thickness;
+        Thickness previousBorderThickness = Border.Thickness;
+        Thickness previousPaddingThickness = Padding.Thickness;
+
         Margin.Parent = this;
         Border.Parent = this;
         Padding.Parent = this;
@@ -18,27 +23,42 @@ public partial class View // Adornments
         // When any adornment's thickness changes, recompute frames and request layout + redraw.
         Margin.ThicknessChanged += (_, _) =>
                                    {
-                                       Margin.View?.SetNeedsLayout ();
-                                       SetAdornmentFrames ();
-                                       SetNeedsLayout ();
-                                       SetNeedsDraw ();
+                                      previousMarginThickness = HandleAdornmentThicknessChanged (Margin, previousMarginThickness);
                                    };
 
         Border.ThicknessChanged += (_, _) =>
                                    {
-                                       Border.View?.SetNeedsLayout ();
-                                       SetAdornmentFrames ();
-                                       SetNeedsLayout ();
-                                       SetNeedsDraw ();
+                                       previousBorderThickness = HandleAdornmentThicknessChanged (Border, previousBorderThickness);
                                    };
 
         Padding.ThicknessChanged += (_, _) =>
                                     {
-                                        Padding.View?.SetNeedsLayout ();
-                                        SetAdornmentFrames ();
-                                        SetNeedsLayout ();
-                                        SetNeedsDraw ();
+                                        previousPaddingThickness = HandleAdornmentThicknessChanged (Padding, previousPaddingThickness);
                                     };
+
+        Thickness HandleAdornmentThicknessChanged (IAdornment adornment, Thickness previousThickness)
+        {
+            Rectangle oldViewport = GetViewportForAdornmentThickness (adornment, previousThickness);
+            Rectangle oldViewportFrame = GetViewportFrameForAdornmentThickness (adornment, previousThickness);
+            Thickness currentThickness = adornment.Thickness;
+
+            (adornment.View as View)?.SetNeedsLayout ();
+            SetAdornmentFrames ();
+            SetNeedsLayout ();
+            SetNeedsDraw ();
+
+            if (oldViewportFrame != GetViewportFrameForAdornmentThickness (adornment, currentThickness))
+            {
+                InvalidateAdornmentThicknessChange ();
+            }
+
+            if (oldViewport != Viewport)
+            {
+                RaiseViewportChangedEvent (oldViewport);
+            }
+
+            return currentThickness;
+        }
     }
 
     private void BeginInitAdornments ()
@@ -344,5 +364,47 @@ public partial class View // Adornments
 
         // Border and Padding dynamically update based on Margin's View's Frame changing
         Margin.View?.Frame = Frame with { Location = Point.Empty };
+    }
+
+    private Rectangle GetViewportForAdornmentThickness (IAdornment changedAdornment, Thickness changedThickness)
+    {
+        Thickness thickness = GetAdornmentsThicknessForAdornment (changedAdornment, changedThickness);
+
+        return new Rectangle (_viewportLocation,
+                              new Size (Math.Max (0, Frame.Width - thickness.Horizontal), Math.Max (0, Frame.Height - thickness.Vertical)));
+    }
+
+    private Rectangle GetViewportFrameForAdornmentThickness (IAdornment changedAdornment, Thickness changedThickness)
+    {
+        Thickness thickness = GetAdornmentsThicknessForAdornment (changedAdornment, changedThickness);
+
+        return new Rectangle (new Point (thickness.Left, thickness.Top),
+                              new Size (Math.Max (0, Frame.Width - thickness.Horizontal), Math.Max (0, Frame.Height - thickness.Vertical)));
+    }
+
+    private Thickness GetAdornmentsThicknessForAdornment (IAdornment changedAdornment, Thickness changedThickness)
+    {
+        Thickness thickness = Thickness.Empty;
+
+        thickness += ReferenceEquals (changedAdornment, Margin) ? changedThickness : Margin.Thickness;
+        thickness += ReferenceEquals (changedAdornment, Border) ? changedThickness : Border.Thickness;
+        thickness += ReferenceEquals (changedAdornment, Padding) ? changedThickness : Padding.Thickness;
+
+        return thickness;
+    }
+
+    private void InvalidateAdornmentThicknessChange ()
+    {
+        if (SuperView is null)
+        {
+            NeedsClearScreenNextIteration ();
+
+            return;
+        }
+
+        Rectangle invalidationViewport = Frame;
+        Point superScroll = SuperView.Viewport.Location;
+        invalidationViewport.Offset (-superScroll.X, -superScroll.Y);
+        SuperView.SetNeedsDraw (invalidationViewport);
     }
 }

--- a/Tests/IntegrationTests/TabsFanOutIntegrationTests.cs
+++ b/Tests/IntegrationTests/TabsFanOutIntegrationTests.cs
@@ -68,8 +68,8 @@ public class TabsFanOutIntegrationTests (ITestOutputHelper outputHelper) : Tests
     }
 
     /// <summary>
-    ///     End-to-end check: a real <see cref="Key.PageDown"/> on the active tab still produces
-    ///     draw fan-out on inactive tabs, but layout work stays on the active tab.
+    ///     End-to-end check: a real <see cref="Key.PageDown"/> on the active tab keeps both
+    ///     layout and text drawing on the active tab.
     /// </summary>
     [Theory]
     [MemberData (nameof (GetAllDriverNames))]
@@ -169,21 +169,7 @@ public class TabsFanOutIntegrationTests (ITestOutputHelper outputHelper) : Tests
         outputHelper.WriteLine ($"Sum inactive DrawingText = {inactiveTextDraws}");
         outputHelper.WriteLine ($"Sum inactive SubViewsLaidOut = {inactiveLayouts}");
 
-        // Issue #5358 fix narrows draw fan-out at the View.Draw pipeline level (verified by
-        // TabsFanOutDiagnosticTests at synthetic level). At integration level a separate
-        // cascade source remains: ApplicationImpl.LayoutAndDraw passes force=true to
-        // View.Draw whenever any view needed layout, which calls SetNeedsDraw on the top
-        // runnable, which cascades to overlapping subviews via the existing SetNeedsDraw
-        // recursion. Removing that force=true uncovers stale-content bugs in the shrink/move
-        // path (covered by existing ShadowTests and BorderViewTests) and is out of scope
-        // for #5358. Until that broader fix lands, inactive tab pages still receive
-        // NeedsDraw via the LayoutAndDraw force path. Layout fan-out is already fully
-        // eliminated by PR #5373.
-        Assert.True (
-                     inactiveTextDraws > 0,
-                     $"Documents the remaining draw fan-out via ApplicationImpl.LayoutAndDraw's force=true path: " +
-                     $"inactive_total DrawingText={inactiveTextDraws}. Flip to Assert.Equal(0, inactiveTextDraws) " +
-                     "after the broader LayoutAndDraw cascade is addressed (out of scope for #5358).");
+        Assert.Equal (0, inactiveTextDraws);
 
         Assert.Equal (0, inactiveLayouts);
     }


### PR DESCRIPTION
## Summary

Follow-up to #5431 (#5358). `ApplicationImpl.LayoutAndDraw` previously force-redrew the
entire runnable tree whenever *any* view needed layout (`force = neededLayout || forceRedraw`),
cascading `SetNeedsDraw` to all overlapping subviews. That blanket force existed only because
**adornment thickness changes alter rendered coverage without changing the View's `Frame`**, so
nothing invalidated the affected region precisely.

This PR tracks adornment thickness deltas and invalidates the precise SuperView region on
change, allowing the force to be dropped (`force = forceRedraw`).

## Changes

- **`ApplicationImpl.Screen.cs`** — `LayoutAndDraw` no longer forces a full redraw just because
  layout ran. It now forces only when explicitly requested (`forceRedraw`).
- **`View.Adornments.cs`** — the `Margin`/`Border`/`Padding` `ThicknessChanged` handlers now route
  through `HandleAdornmentThicknessChanged`, which:
  - tracks each adornment's previous thickness,
  - performs the existing layout/draw invalidation,
  - precisely invalidates the SuperView region the view occupies when the adornment's inner frame
    changed (`InvalidateAdornmentThicknessChange`), mirroring the existing `SetFrame` invalidation,
    and falling back to a full-screen clear for top-level (no SuperView) views, and
  - raises `ViewportChanged` when the viewport actually changed.
- **`TabsFanOutIntegrationTests`** — flipped from documenting residual fan-out
  (`Assert.True(inactiveTextDraws > 0, ...)`) to asserting zero fan-out
  (`Assert.Equal(0, inactiveTextDraws)`).

This completes a consistent pattern: every mutation that changes rendered coverage without a
redraw request now self-invalidates the SuperView — `Frame` move/shrink (`SetFrame`), `Visible`
toggle (`Visible` setter), and now adornment thickness (this PR).

## ⚠️ Behavioral change to note

`ViewportChanged` now fires when an adornment's `Thickness` changes the viewport size. Previously,
setting `Border`/`Margin`/`Padding.Thickness` directly changed `Viewport.Size` **silently**; it now
raises `ViewportChanged`, consistent with `SetFrame` (which already raises it on any viewport
change). The cursor-adjustment branch in `RaiseViewportChangedEvent` is a no-op for this case
because the viewport *location* is unchanged (delta == 0), so there are no cursor jumps. Downstream
`ViewportChanged` subscribers will now be notified on thickness-driven size changes. This is
considered a latent-bug fix, but is called out explicitly for reviewer sign-off.

## Acceptance criteria

- [x] Layout detects adornment-thickness changes affecting rendered coverage without frame changes
- [x] Adornment changes invalidate the precise SuperView region
- [x] `LayoutAndDraw` no longer force-redraws solely because layout ran
- [x] No stale-content regressions in adornment-rebalance paths
- [x] Integration test asserts zero fan-out (was: documents fan-out)
- [x] No regressions for overlapping views, shadows, transparent content, or clipping

## Testing

- Build clean, 0 warnings.
- `TabsFanOutIntegrationTests` (3) and `TabsFanOutDiagnosticTests` pass with zero-fan-out assertions.
- Regression-risk suites green: `ShadowTests` (35), `BorderViewTests` (78), `AdornmentTests` (116),
  `BorderTests` (9), `PaddingTests` (8), `MarginTests` (17), `ViewportTests` (143).
- Full `UnitTestsParallelizable` (17,300) and `UnitTests.NonParallelizable` (72, +2 skipped) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
