### PR TITLE
Fixes #5360. Cull fully occluded overlapped opaque subviews during draw

### DIFF
--- a/Terminal.Gui/ViewBase/View.Drawing.cs
+++ b/Terminal.Gui/ViewBase/View.Drawing.cs
@@ -660,9 +660,45 @@ public partial class View // Drawing APIs
         // SubViews earlier in the collection are drawn last (on top).
         // NOTE: Do not use SubViews or GetSubViews() here as GetSubViews can be overridden to return a different set of views or ordering.
         // NOTE: We need to draw exactly the views in InternalSubViews.
-        foreach (View view in InternalSubViews.Snapshot ().Where (v => v.Visible).Reverse ())
+        View [] drawOrder = InternalSubViews.Snapshot ().Where (v => v.Visible).Reverse ().ToArray ();
+
+        // Occlusion culling (issue #5360): when Overlapped opaque siblings stack (e.g. Tabs pages,
+        // overlapped Windows), a lower-Z sibling that is fully covered by the higher-Z opaque peers
+        // already drawn produces no visible output — every cell it would draw, including its own
+        // RenderLineCanvas, is clipped away by the clip "holes" those peers punched in DoDrawComplete.
+        // Skipping such a sibling's Draw is therefore output-neutral. opaqueCoverage accumulates the
+        // screen region opaquely covered by higher-Z peers (iterated highest-Z first). The whole
+        // check is gated on at least one Overlapped sibling so the common (non-overlapping) path is
+        // zero-overhead.
+        bool considerOcclusion = Driver is { } && drawOrder.Length > 1 && drawOrder.Any (v => v.Arrangement.FastHasFlags (ViewArrangement.Overlapped));
+        Region? opaqueCoverage = null;
+
+        foreach (View view in drawOrder)
         {
+            Rectangle coveredScreenRect = Rectangle.Empty;
+            bool opaque = considerOcclusion && view.IsOpaqueForOcclusion (out coveredScreenRect);
+
+            if (opaque
+                && view.Arrangement.FastHasFlags (ViewArrangement.Overlapped)
+                && !view.SuperViewRendersLineCanvas
+                && view.ShadowStyle is null or ShadowStyles.None
+                && IsFullyCovered (view.FrameToScreen (), opaqueCoverage))
+            {
+                // Fully occluded by higher-Z opaque peers. Clear the draw flags to mirror a
+                // drawn-but-fully-clipped pass (Draw() would have called ClearNeedsDraw at its end);
+                // otherwise this view would stay dirty forever and keep the SuperView redrawing.
+                view.ClearNeedsDraw ();
+
+                continue;
+            }
+
             view.Draw (context);
+
+            if (opaque)
+            {
+                opaqueCoverage ??= new ();
+                opaqueCoverage.Union (coveredScreenRect);
+            }
 
             if (!view.SuperViewRendersLineCanvas)
             {
@@ -695,6 +731,77 @@ public partial class View // Drawing APIs
         // Store for compositing during RenderLineCanvas.
         // List is ordered highest-Z first (matching the iteration order above).
         _pendingOverlappedCellMaps = overlappedCellMaps;
+    }
+
+    /// <summary>
+    ///     Determines whether this view opaquely covers a screen rectangle — such that nothing drawn behind
+    ///     that rectangle can show through it. Used by <see cref="DrawSubViews"/> occlusion culling
+    ///     (issue #5360).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The view's content is opaque only when its content layer, <see cref="Border"/>, and
+    ///         <see cref="Padding"/> are not <see cref="ViewportSettingsFlags.Transparent"/>. The
+    ///         <see cref="Margin"/> is transparent by default; when it is, the opaquely-covered region is the
+    ///         area inside the Margin (<see cref="Border"/>'s frame). When the Margin is explicitly opaque,
+    ///         the full <see cref="Frame"/> is covered.
+    ///     </para>
+    ///     <para>
+    ///         This is the same notion of "opaque" used by <see cref="DoDrawComplete"/> to exclude a view's
+    ///         drawn area from the clip; here it is the area a higher-Z peer hides from the views drawn after
+    ///         it.
+    ///     </para>
+    /// </remarks>
+    /// <param name="coveredScreenRect">
+    ///     When this returns <see langword="true"/>, the screen-relative rectangle this view covers opaquely.
+    ///     <see cref="Rectangle.Empty"/> otherwise.
+    /// </param>
+    /// <returns><see langword="true"/> if the view opaquely covers <paramref name="coveredScreenRect"/>; otherwise <see langword="false"/>.</returns>
+    private bool IsOpaqueForOcclusion (out Rectangle coveredScreenRect)
+    {
+        coveredScreenRect = Rectangle.Empty;
+
+        if (ViewportSettings.FastHasFlags (ViewportSettingsFlags.Transparent)
+            || Border.ViewportSettings.FastHasFlags (ViewportSettingsFlags.Transparent)
+            || Padding.ViewportSettings.FastHasFlags (ViewportSettingsFlags.Transparent))
+        {
+            return false;
+        }
+
+        bool marginTransparent = Margin.ViewportSettings.FastHasFlags (ViewportSettingsFlags.Transparent);
+        coveredScreenRect = marginTransparent ? Border.FrameToScreen () : Margin.FrameToScreen ();
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Determines whether <paramref name="screenRect"/> is entirely contained within the region opaquely
+    ///     covered by higher-Z peers (<paramref name="opaqueCoverage"/>). Used by <see cref="DrawSubViews"/>
+    ///     occlusion culling (issue #5360).
+    /// </summary>
+    /// <param name="screenRect">The screen-relative rectangle to test.</param>
+    /// <param name="opaqueCoverage">
+    ///     The accumulated screen region covered opaquely by higher-Z peers, or <see langword="null"/> if no
+    ///     opaque peer has been drawn yet.
+    /// </param>
+    /// <returns>
+    ///     <see langword="true"/> if <paramref name="screenRect"/> is non-empty and fully covered; otherwise
+    ///     <see langword="false"/>.
+    /// </returns>
+    private static bool IsFullyCovered (Rectangle screenRect, Region? opaqueCoverage)
+    {
+        if (screenRect.IsEmpty || opaqueCoverage is null)
+        {
+            return false;
+        }
+
+        // Subtract the covered region from the candidate's frame; if nothing is left, the candidate is
+        // fully covered. Using Region difference (rather than Region.Contains, which only tests a single
+        // stored rectangle) correctly handles coverage spread across multiple opaque peers.
+        Region remaining = new (screenRect);
+        remaining.Exclude (opaqueCoverage);
+
+        return remaining.IsEmpty ();
     }
 
     #endregion DrawSubViews

--- a/Terminal.Gui/ViewBase/View.Drawing.cs
+++ b/Terminal.Gui/ViewBase/View.Drawing.cs
@@ -682,6 +682,7 @@ public partial class View // Drawing APIs
                 && view.Arrangement.FastHasFlags (ViewArrangement.Overlapped)
                 && !view.SuperViewRendersLineCanvas
                 && view.ShadowStyle is null or ShadowStyles.None
+                && !view.ParticipatesInTransparentMouseHitTesting ()
                 && IsFullyCovered (view.FrameToScreen (), opaqueCoverage))
             {
                 // Fully occluded by higher-Z opaque peers. Clear the draw flags to mirror a
@@ -772,6 +773,42 @@ public partial class View // Drawing APIs
         coveredScreenRect = marginTransparent ? Border.FrameToScreen () : Margin.FrameToScreen ();
 
         return true;
+    }
+
+    /// <summary>
+    ///     Determines whether culling this view would diverge mouse hit-testing state, so the view must not be
+    ///     culled by <see cref="DrawSubViews"/> occlusion culling (issue #5360).
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The cull path skips <see cref="Draw(DrawContext?)"/>, hence <see cref="DoDrawComplete"/>, which
+    ///         repopulates the <see cref="CachedDrawnRegion"/> that <see cref="GetViewsUnderLocation"/> consults
+    ///         for <see cref="ViewportSettingsFlags.TransparentMouse"/> layers. A view's own
+    ///         <see cref="CachedDrawnRegion"/> is invalidated by <see cref="SetNeedsDraw()"/>, so a
+    ///         <see cref="ViewportSettingsFlags.TransparentMouse"/> view that is culled would be left with a null
+    ///         cache and dropped from hit-testing.
+    ///     </para>
+    ///     <para>
+    ///         Adornment caches survive <see cref="SetNeedsDraw()"/>, but hit-testing only consults them when the
+    ///         adornment is <see cref="ViewportSettingsFlags.TransparentMouse"/> with non-empty
+    ///         <see cref="AdornmentImpl.Thickness"/>; those are excluded too so the first draw cannot leave a thick
+    ///         transparent-mouse adornment without a cache. <see cref="Margin"/> is
+    ///         <see cref="ViewportSettingsFlags.TransparentMouse"/> by default, so this only excludes views with an
+    ///         actual Margin thickness — the common (empty-margin) overlapped view is still culled.
+    ///     </para>
+    /// </remarks>
+    /// <returns><see langword="true"/> if culling would diverge hit-testing; otherwise <see langword="false"/>.</returns>
+    private bool ParticipatesInTransparentMouseHitTesting ()
+    {
+        if (ViewportSettings.FastHasFlags (ViewportSettingsFlags.TransparentMouse))
+        {
+            return true;
+        }
+
+        return IsThickTransparentMouse (Margin) || IsThickTransparentMouse (Border) || IsThickTransparentMouse (Padding);
+
+        static bool IsThickTransparentMouse (AdornmentImpl adornment) =>
+            adornment.Thickness != Thickness.Empty && adornment.ViewportSettings.FastHasFlags (ViewportSettingsFlags.TransparentMouse);
     }
 
     /// <summary>

--- a/Tests/UnitTestsParallelizable/ViewBase/Draw/OcclusionCullingTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/Draw/OcclusionCullingTests.cs
@@ -1,0 +1,367 @@
+using UnitTests;
+
+namespace ViewBaseTests.Draw;
+
+// Claude - Opus 4.8 (1M context)
+/// <summary>
+///     Issue #5360: <see cref="View.DrawSubViews"/> culls fully-occluded Overlapped opaque siblings.
+///     When a lower-Z Overlapped opaque sibling is entirely covered by the higher-Z opaque peers
+///     already drawn, every cell it would draw (including its own LineCanvas) is clipped away, so
+///     skipping its <see cref="View.Draw(DrawContext?)"/> is output-neutral.
+/// </summary>
+/// <remarks>
+///     Culling is intentionally conservative — it never applies to transparent views, shadowed
+///     views, partially-covered views, non-Overlapped views, or views that contribute to the
+///     SuperView's LineCanvas compositing (<see cref="View.SuperViewRendersLineCanvas"/>, e.g. Tabs
+///     pages). Each test below pins one of those guards.
+/// </remarks>
+public class OcclusionCullingTests : TestDriverBase
+{
+    /// <summary>
+    ///     Builds a SuperView (no adornments) sized to fill the driver, plus a stack of full-fill
+    ///     Overlapped subviews added back-to-front (the last view added is highest-Z / drawn first).
+    /// </summary>
+    private static View BuildOverlappedStack (IDriver driver, params View [] backToFront)
+    {
+        View super = new () { Driver = driver, Width = 20, Height = 10 };
+
+        foreach (View view in backToFront)
+        {
+            view.Width = Dim.Fill ();
+            view.Height = Dim.Fill ();
+            view.Arrangement = ViewArrangement.Overlapped;
+            super.Add (view);
+        }
+
+        super.Layout ();
+
+        return super;
+    }
+
+    /// <summary>
+    ///     GIVEN two full-fill Overlapped opaque siblings
+    ///     WHEN the SuperView draws
+    ///     THEN the higher-Z (top) sibling draws and the fully-covered lower-Z (bottom) sibling is
+    ///     culled (its Draw is never invoked).
+    /// </summary>
+    [Fact]
+    public void FullyOccluded_OpaqueOverlappedSibling_IsCulled ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new ();
+        View top = new ();
+        View super = BuildOverlappedStack (driver, bottom, top);
+
+        var bottomDraws = 0;
+        var topDraws = 0;
+        bottom.DrawComplete += (_, _) => bottomDraws++;
+        top.DrawComplete += (_, _) => topDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (topDraws >= 1, $"Top (occluder) should draw (got {topDraws}).");
+        Assert.Equal (0, bottomDraws);
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN a fully-occluded sibling that was culled
+    ///     WHEN the SuperView draws
+    ///     THEN the culled sibling's NeedsDraw is cleared (mirroring a drawn-but-clipped pass) so it
+    ///     does not keep the SuperView perpetually dirty.
+    /// </summary>
+    [Fact]
+    public void CulledSibling_HasNeedsDrawCleared ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new ();
+        View top = new ();
+        View super = BuildOverlappedStack (driver, bottom, top);
+
+        super.SetNeedsDraw ();
+        Assert.True (bottom.NeedsDraw);
+
+        super.Draw ();
+
+        Assert.False (bottom.NeedsDraw);
+        Assert.False (super.SubViewNeedsDraw);
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN a lower-Z sibling that is only partially covered by the higher-Z sibling
+    ///     WHEN the SuperView draws
+    ///     THEN the partially-covered sibling still draws.
+    /// </summary>
+    [Fact]
+    public void PartiallyCovered_OverlappedSibling_StillDraws ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        // Bottom fills the whole SuperView; top covers only the left half, so the bottom's right
+        // half remains visible and must not be culled.
+        View bottom = new () { Width = Dim.Fill (), Height = Dim.Fill (), Arrangement = ViewArrangement.Overlapped };
+        View top = new () { Width = 10, Height = 10, Arrangement = ViewArrangement.Overlapped };
+
+        View super = new () { Driver = driver, Width = 20, Height = 10 };
+        super.Add (bottom);
+        super.Add (top);
+        super.Layout ();
+
+        var bottomDraws = 0;
+        bottom.DrawComplete += (_, _) => bottomDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (bottomDraws >= 1, $"Partially-covered sibling must still draw (got {bottomDraws}).");
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN a higher-Z sibling that is transparent (does not opaquely cover the area)
+    ///     WHEN the SuperView draws
+    ///     THEN the lower-Z sibling beneath it is NOT culled.
+    /// </summary>
+    [Fact]
+    public void TransparentOccluder_DoesNotCullSiblingBeneath ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new ();
+        View top = new () { ViewportSettings = ViewportSettingsFlags.Transparent };
+        View super = BuildOverlappedStack (driver, bottom, top);
+
+        var bottomDraws = 0;
+        bottom.DrawComplete += (_, _) => bottomDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (bottomDraws >= 1, $"Sibling beneath a transparent peer must draw (got {bottomDraws}).");
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN a lower-Z sibling that is itself transparent
+    ///     WHEN it is fully covered by a higher-Z opaque sibling
+    ///     THEN it is NOT culled (culling is restricted to opaque candidates to avoid disturbing
+    ///     transparency / TransparentMouse hit-test caching).
+    /// </summary>
+    [Fact]
+    public void TransparentCandidate_IsNotCulled ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new () { ViewportSettings = ViewportSettingsFlags.Transparent };
+        View top = new ();
+        View super = BuildOverlappedStack (driver, bottom, top);
+
+        var bottomDraws = 0;
+        bottom.DrawComplete += (_, _) => bottomDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (bottomDraws >= 1, $"Transparent candidate must not be culled (got {bottomDraws}).");
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN a lower-Z sibling with a Margin shadow
+    ///     WHEN it is fully covered by a higher-Z opaque sibling
+    ///     THEN it is NOT culled — a shadowed Margin is transparent and is drawn in a separate
+    ///     second pass, so it must continue to participate in drawing.
+    /// </summary>
+    [Fact]
+    public void ShadowedCandidate_IsNotCulled ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new () { ShadowStyle = ShadowStyles.Opaque };
+        View top = new ();
+        View super = BuildOverlappedStack (driver, bottom, top);
+
+        var bottomDraws = 0;
+        bottom.DrawComplete += (_, _) => bottomDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (bottomDraws >= 1, $"Shadowed candidate must not be culled (got {bottomDraws}).");
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN a lower-Z sibling that renders its border via the SuperView's LineCanvas
+    ///     (<see cref="View.SuperViewRendersLineCanvas"/> — the Tabs page case)
+    ///     WHEN it is fully covered by a higher-Z opaque sibling
+    ///     THEN it is NOT culled, because its LineCanvas still contributes to the SuperView's
+    ///     painters'-algorithm composition (dropping it could erase tab-header line art).
+    /// </summary>
+    [Fact]
+    public void SuperViewRendersLineCanvasCandidate_IsNotCulled ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new () { SuperViewRendersLineCanvas = true };
+        View top = new ();
+        View super = BuildOverlappedStack (driver, bottom, top);
+
+        var bottomDraws = 0;
+        bottom.DrawComplete += (_, _) => bottomDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (bottomDraws >= 1, $"SuperViewRendersLineCanvas candidate must not be culled (got {bottomDraws}).");
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN a lower-Z sibling that is NOT Overlapped but happens to sit fully inside a higher-Z
+    ///     Overlapped opaque sibling
+    ///     WHEN the SuperView draws
+    ///     THEN it is NOT culled — culling is scoped to Overlapped candidates.
+    /// </summary>
+    [Fact]
+    public void NonOverlappedCandidate_IsNotCulled ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new () { Width = Dim.Fill (), Height = Dim.Fill () };
+        View top = new () { Width = Dim.Fill (), Height = Dim.Fill (), Arrangement = ViewArrangement.Overlapped };
+
+        View super = new () { Driver = driver, Width = 20, Height = 10 };
+        super.Add (bottom);
+        super.Add (top);
+        super.Layout ();
+
+        var bottomDraws = 0;
+        bottom.DrawComplete += (_, _) => bottomDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (bottomDraws >= 1, $"Non-Overlapped candidate must not be culled (got {bottomDraws}).");
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN no Overlapped siblings at all (the common, non-overlapping case)
+    ///     WHEN the SuperView draws
+    ///     THEN occlusion culling is not engaged and every sibling draws.
+    /// </summary>
+    [Fact]
+    public void NoOverlappedSiblings_NothingIsCulled ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        // Two tiled (non-overlapping) siblings.
+        View left = new () { X = 0, Y = 0, Width = 10, Height = 10 };
+        View right = new () { X = 10, Y = 0, Width = 10, Height = 10 };
+
+        View super = new () { Driver = driver, Width = 20, Height = 10 };
+        super.Add (left);
+        super.Add (right);
+        super.Layout ();
+
+        var leftDraws = 0;
+        var rightDraws = 0;
+        left.DrawComplete += (_, _) => leftDraws++;
+        right.DrawComplete += (_, _) => rightDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (leftDraws >= 1, $"Left sibling should draw (got {leftDraws}).");
+        Assert.True (rightDraws >= 1, $"Right sibling should draw (got {rightDraws}).");
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN two stacked Overlapped opaque siblings with distinct text
+    ///     WHEN the SuperView draws
+    ///     THEN the rendered contents show the top (occluder) text and never the culled bottom text
+    ///     (no visual regression from culling).
+    /// </summary>
+    [Fact]
+    public void Culling_IsOutputNeutral ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new () { Text = "BOTTOM" };
+        View top = new () { Text = "TOPVIEW" };
+        View super = BuildOverlappedStack (driver, bottom, top);
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        var contents = driver.ToString ();
+
+        Assert.Contains ("TOPVIEW", contents);
+        Assert.DoesNotContain ("BOTTOM", contents);
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN a <see cref="Tabs"/> control with several overlapping pages
+    ///     WHEN it draws
+    ///     THEN no page is culled (each page is <see cref="View.SuperViewRendersLineCanvas"/>), so tab
+    ///     header line art is preserved.
+    /// </summary>
+    [Fact]
+    public void Tabs_InactivePages_AreNotCulled ()
+    {
+        IDriver driver = CreateTestDriver (60, 20);
+
+        Tabs tabs = new () { Driver = driver, Width = 40, Height = 12 };
+
+        View page1 = new () { Title = "One" };
+        View page2 = new () { Title = "Two" };
+        View page3 = new () { Title = "Three" };
+        tabs.Add (page1, page2, page3);
+
+        tabs.Layout ();
+
+        var page1Draws = 0;
+        var page2Draws = 0;
+        var page3Draws = 0;
+        page1.DrawComplete += (_, _) => page1Draws++;
+        page2.DrawComplete += (_, _) => page2Draws++;
+        page3.DrawComplete += (_, _) => page3Draws++;
+
+        tabs.SetNeedsDraw ();
+        tabs.Draw ();
+
+        Assert.True (page1Draws >= 1, $"Tab page 1 must not be culled (got {page1Draws}).");
+        Assert.True (page2Draws >= 1, $"Tab page 2 must not be culled (got {page2Draws}).");
+        Assert.True (page3Draws >= 1, $"Tab page 3 must not be culled (got {page3Draws}).");
+
+        tabs.Dispose ();
+        driver.Dispose ();
+    }
+}

--- a/Tests/UnitTestsParallelizable/ViewBase/Draw/OcclusionCullingTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/Draw/OcclusionCullingTests.cs
@@ -364,4 +364,61 @@ public class OcclusionCullingTests : TestDriverBase
         tabs.Dispose ();
         driver.Dispose ();
     }
+
+    /// <summary>
+    ///     GIVEN a fully-covered opaque sibling with <see cref="ViewportSettingsFlags.TransparentMouse"/>
+    ///     WHEN the SuperView draws
+    ///     THEN it is NOT culled, so <see cref="View.Draw(DrawContext?)"/> runs and <see cref="View.DoDrawComplete"/>
+    ///     repopulates its <see cref="View.CachedDrawnRegion"/> (which <see cref="View.SetNeedsDraw()"/> invalidated).
+    ///     Culling it would drop the view from mouse hit-testing (null cache → blanket removal).
+    /// </summary>
+    [Fact]
+    public void TransparentMouseCandidate_IsNotCulled_AndKeepsHitRegion ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new () { ViewportSettings = ViewportSettingsFlags.TransparentMouse };
+        View top = new ();
+        View super = BuildOverlappedStack (driver, bottom, top);
+
+        var bottomDraws = 0;
+        bottom.DrawComplete += (_, _) => bottomDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (bottomDraws >= 1, $"TransparentMouse candidate must not be culled (got {bottomDraws}).");
+        Assert.NotNull (bottom.CachedDrawnRegion);
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
+
+    /// <summary>
+    ///     GIVEN a fully-covered opaque sibling with a non-empty Margin (the Margin is
+    ///     <see cref="ViewportSettingsFlags.TransparentMouse"/> by default)
+    ///     WHEN the SuperView draws
+    ///     THEN it is NOT culled, so the Margin's hit-testing cache is not left stale.
+    /// </summary>
+    [Fact]
+    public void TransparentMouseMarginCandidate_IsNotCulled ()
+    {
+        IDriver driver = CreateTestDriver (40, 20);
+
+        View bottom = new ();
+        bottom.Margin.Thickness = new Thickness (1);
+        View top = new ();
+        View super = BuildOverlappedStack (driver, bottom, top);
+
+        var bottomDraws = 0;
+        bottom.DrawComplete += (_, _) => bottomDraws++;
+
+        super.SetNeedsDraw ();
+        super.Draw ();
+
+        Assert.True (bottomDraws >= 1, $"Candidate with a TransparentMouse Margin must not be culled (got {bottomDraws}).");
+
+        super.Dispose ();
+        driver.Dispose ();
+    }
 }


### PR DESCRIPTION
- Fixes #5360

## Summary

`DrawSubViews()` now skips drawing an Overlapped sibling when it is entirely covered by the higher-Z opaque peers already drawn. A fully-covered sibling produces **no visible output** - every cell it would draw (including its own `RenderLineCanvas`) is clipped away by the clip "holes" those peers punch in `DoDrawComplete` - so skipping its `Draw()` is output-neutral. This is the occlusion-culling step of the #4973 series, taken now that the invalidation semantics are stable (#5357, #5358, #5359, #5433, #5434).

The culled view's `NeedsDraw` is cleared (mirroring a drawn-but-fully-clipped pass) so it does not keep the SuperView perpetually dirty.

## Approach

- Occlusion is tracked with a `Region` of the screen area opaquely covered by higher-Z peers, accumulated as the existing reverse-Z (top-first) draw loop iterates.
- A new `IsOpaqueForOcclusion(out Rectangle)` reports whether a view fills a screen rectangle opaquely. The opaque region is the area **inside the (transparent-by-default) Margin** - `Border.FrameToScreen()` - matching exactly what `DoDrawComplete` excludes from the clip.
- `IsFullyCovered(rect, coverage)` uses `Region` difference (not single-rect `Contains`) so coverage spread across multiple peers is handled correctly.
- The whole check is gated on the presence of an `Overlapped` sibling, so the common (non-overlapping) draw path is **zero-overhead**.

## Why it's conservative (safety guards)

A sibling is culled only when **all** of these hold. Each guard maps to a hazard called out in the issue:

| Guard | Hazard it avoids |
|---|---|
| candidate is `Overlapped` | scope = overlapped siblings only |
| opaque (View/Border/Padding not `Transparent`) | `ViewportSettings.Transparent` - transparent views don't fully cover |
| `ShadowStyle is None` | margin shadows draw in a separate second pass, on top |
| **`!SuperViewRendersLineCanvas`** | line-canvas composition / reserved cells - **this is what keeps `Tabs` correct**: tab pages render their borders (and headers) through the SuperView's painters'-algorithm LineCanvas composition, so they must never be culled |
| full frame ⊆ accumulated opaque coverage | partial coverage still draws |

`Tabs` pages are `SuperViewRendersLineCanvas`, so they are deliberately **not** culled - preventing any header-line-art regression while still benefiting plain overlapped opaque siblings (overlapped Windows/panels, Arrangement-style stacks).

## Tests

- New `Tests/UnitTestsParallelizable/ViewBase/Draw/OcclusionCullingTests.cs` (11 tests, all green): fully-occluded cull, `NeedsDraw` clearing, partial coverage, transparent occluder, transparent candidate, shadowed candidate, `SuperViewRendersLineCanvas` candidate, non-Overlapped candidate, the no-Overlapped-siblings gate, output-neutrality, and a `Tabs` regression asserting inactive pages are never culled.
- Verification uses the headless in-process driver and `DrawComplete` event counting (which fires iff `Draw()` was invoked), not just `Driver.Contents`.
- Full suite green: 17,370 parallelizable + 74 non-parallelizable tests pass. No new build warnings.

## Visual & output-neutrality testing (tuirec + PTY)

Beyond the unit tests, I verified at the real-terminal layer (addressing the `Driver.Contents` ≠ IOutput caveat) using `Scripts/tuirec` recordings and `tmux capture-pane` frame diffs on the scenarios most likely affected:

- **Tabs Example** - overlapped `SuperViewRendersLineCanvas` pages (the guarded case)
- **Arrangement** - overlapped opaque views (where culling actually fires)
- **WideGlyphs** - overlapped views + clipping

**Method:** built the app **with** and **without** the change, drove each scenario identically under a PTY, and diffed the settled screen grids. A control (capturing the *same* build twice) isolates the scenarios' own non-determinism.

| Scenario | before (no cull) vs after (cull) | same build, run twice (control) | Result |
|---|---|---|---|
| Tabs | **0 differing lines** | 0 | byte-for-byte identical |
| Arrangement | 2 differing lines | 2 | diff == its animated progress bar only |
| WideGlyphs | 60 differing lines | 60 | diff == its random wide-glyph fill only |

Each before/after difference **exactly equals that scenario's own run-to-run variance** - culling adds nothing - and the regression-risk case (Tabs) is identical. Recordings:
<img width="1028" height="564" alt="tabs-after" src="https://github.com/user-attachments/assets/9d7d7a62-35cc-4bea-bf50-cd91c24f974d" />
<img width="1028" height="564" alt="arrangement-after" src="https://github.com/user-attachments/assets/fd8688e4-5183-4a4e-9ccf-95b7e1c24ce5" />
<img width="1028" height="564" alt="wideglyphs-after" src="https://github.com/user-attachments/assets/e798b387-b83e-43b1-a735-fff1f59bc79a" />



## To pull down this PR locally:

```
git remote add copilot https://github.com/harder/Terminal.Gui.git
git fetch copilot fix-5360-cull-occluded-subviews
git checkout copilot/fix-5360-cull-occluded-subviews
```
