### PR TITLE
Adds doc snippet compile validation; fixes v1 API rot in agent docs

### DIFF
--- a/.claude/cookbook/common-patterns.md
+++ b/.claude/cookbook/common-patterns.md
@@ -46,7 +46,7 @@ public sealed class FormWindow : Runnable<FormData?>
             X = 1,
             Y = 7,
             Width = Dim.Fill (1),
-            ColorScheme = Colors.ColorSchemes ["Error"]
+            SchemeName = "Error"
         };
 
         Button submitButton = new ()
@@ -96,11 +96,13 @@ public record FormData (string Name, string Email, int Age);
 A scrollable list with item selection and actions.
 
 ```csharp
+using System.Collections.ObjectModel;
+
 public sealed class ListWindow : Runnable
 {
     private readonly ListView _listView;
     private readonly Label _detailLabel;
-    private readonly List<string> _items = ["Apple", "Banana", "Cherry", "Date", "Elderberry"];
+    private readonly ObservableCollection<string> _items = ["Apple", "Banana", "Cherry", "Date", "Elderberry"];
 
     public ListWindow ()
     {
@@ -131,21 +133,21 @@ public sealed class ListWindow : Runnable
             Y = Pos.AnchorEnd (1)
         };
 
-        _listView.SelectedItemChanged += (_, e) =>
+        // ListView is IValue<int?> — the selected index. SelectedItem is int?.
+        _listView.ValueChanged += (_, e) =>
         {
-            if (e.Value >= 0 && e.Value < _items.Count)
+            if (e.NewValue is int index && index < _items.Count)
             {
-                _detailLabel.Text = $"Selected: {_items [e.Value]}";
+                _detailLabel.Text = $"Selected: {_items [index]}";
             }
         };
 
-        selectButton.Accepting += (_, e) =>
+        selectButton.Accepted += (_, _) =>
         {
-            if (_listView.SelectedItem >= 0)
+            if (_listView.SelectedItem is int selected)
             {
-                MessageBox.Query (App!, "Selection", $"You selected: {_items [_listView.SelectedItem]}", "OK");
+                MessageBox.Query (App!, "Selection", $"You selected: {_items [selected]}", "OK");
             }
-            e.Handled = true;
         };
 
         Add (_listView, _detailLabel, selectButton);
@@ -166,43 +168,33 @@ public sealed class MenuApp : Runnable
     {
         Title = "Menu Demo";
 
-        MenuBar menuBar = new ()
-        {
-            Menus =
-            [
-                new MenuBarItem (
-                    "File",
-                    [
-                        new MenuItem ("New", "", () => NewFile (), null, null, KeyCode.N | KeyCode.CtrlMask),
-                        new MenuItem ("Open...", "", () => OpenFile (), null, null, KeyCode.O | KeyCode.CtrlMask),
-                        new MenuItem ("Save", "", () => SaveFile (), null, null, KeyCode.S | KeyCode.CtrlMask),
-                        null, // Separator
-                        new MenuItem ("Exit", "", () => App!.RequestStop (), null, null, KeyCode.Q | KeyCode.CtrlMask)
-                    ]),
-                new MenuBarItem (
-                    "Edit",
-                    [
-                        new MenuItem ("Cut", "", null, null, null, KeyCode.X | KeyCode.CtrlMask),
-                        new MenuItem ("Copy", "", null, null, null, KeyCode.C | KeyCode.CtrlMask),
-                        new MenuItem ("Paste", "", null, null, null, KeyCode.V | KeyCode.CtrlMask)
-                    ]),
-                new MenuBarItem (
-                    "Help",
-                    [
-                        new MenuItem ("About...", "", () => ShowAbout ())
-                    ])
-            ]
-        };
+        MenuBar menuBar = new ();
 
-        TextView editor = new ()
+        menuBar.Add (new MenuBarItem ("_File",
+                                      [
+                                          new MenuItem { Title = "_New", Key = Key.N.WithCtrl, Action = NewFile },
+                                          new MenuItem { Title = "_Open...", Key = Key.O.WithCtrl, Action = OpenFile },
+                                          new MenuItem { Title = "_Save", Key = Key.S.WithCtrl, Action = SaveFile },
+                                          new Line (), // Separator
+                                          new MenuItem { Title = "_Quit", Key = Key.Q.WithCtrl, Action = () => App!.RequestStop () }
+                                      ]));
+
+        menuBar.Add (new MenuBarItem ("_Help",
+                                      [
+                                          new MenuItem { Title = "_About...", Action = ShowAbout }
+                                      ]));
+
+        // Main content area below the menu bar. (For a real multi-line editor,
+        // use gui-cs/Editor's EditorView — the core TextView is deprecated.)
+        View content = new ()
         {
             X = 0,
-            Y = 1,
+            Y = Pos.Bottom (menuBar),
             Width = Dim.Fill (),
             Height = Dim.Fill ()
         };
 
-        Add (menuBar, editor);
+        Add (menuBar, content);
     }
 
     private void NewFile () => MessageBox.Query (App!, "New", "New file created", "OK");
@@ -216,7 +208,7 @@ public sealed class MenuApp : Runnable
 
 ## Split View Layout
 
-Horizontal or vertical split layout with resizable panes.
+Side-by-side panes positioned with `Pos`/`Dim`. (`TileView` does not exist in v2 — use plain views and `ViewArrangement` for user-resizable panes.)
 
 ```csharp
 public sealed class SplitWindow : Runnable
@@ -225,27 +217,27 @@ public sealed class SplitWindow : Runnable
     {
         Title = "Split View Demo";
 
-        TileView tileView = new ()
+        FrameView leftPane = new ()
         {
-            X = 0,
-            Y = 0,
-            Width = Dim.Fill (),
+            Title = "Left Pane",
+            Width = Dim.Percent (50),
             Height = Dim.Fill (),
-            Orientation = Orientation.Vertical  // or Horizontal
-        };
 
-        // Left pane
-        FrameView leftPane = new () { Title = "Left Pane" };
+            // Let the user resize this pane with mouse or keyboard (optional)
+            Arrangement = ViewArrangement.RightResizable
+        };
         leftPane.Add (new Label { Text = "Left content", X = 1, Y = 1 });
 
-        // Right pane
-        FrameView rightPane = new () { Title = "Right Pane" };
+        FrameView rightPane = new ()
+        {
+            Title = "Right Pane",
+            X = Pos.Right (leftPane),
+            Width = Dim.Fill (),
+            Height = Dim.Fill ()
+        };
         rightPane.Add (new Label { Text = "Right content", X = 1, Y = 1 });
 
-        tileView.Tiles.ElementAt (0).ContentView.Add (leftPane);
-        tileView.Tiles.ElementAt (1).ContentView.Add (rightPane);
-
-        Add (tileView);
+        Add (leftPane, rightPane);
     }
 }
 ```
@@ -254,7 +246,7 @@ public sealed class SplitWindow : Runnable
 
 ## Tab View
 
-Tabbed interface with multiple content pages.
+Tabbed interface with multiple content pages. (v1's `TabView` is now `Tabs`: each added `View` becomes a tab, and its `Title` is the tab label.)
 
 ```csharp
 public sealed class TabbedWindow : Runnable
@@ -263,29 +255,25 @@ public sealed class TabbedWindow : Runnable
     {
         Title = "Tabbed Interface";
 
-        TabView tabView = new ()
-        {
-            X = 0,
-            Y = 0,
-            Width = Dim.Fill (),
-            Height = Dim.Fill ()
-        };
+        Tabs tabs = new ();
 
-        // Tab 1: Settings
-        View settingsTab = new ();
+        // Tab 1: Settings — Title becomes the tab label
+        View settingsTab = new () { Title = "Settings" };
         settingsTab.Add (
             new Label { Text = "Enable Feature:", X = 1, Y = 1 },
             new CheckBox { X = 20, Y = 1, Text = "Enabled" }
         );
 
         // Tab 2: About
-        View aboutTab = new ();
+        View aboutTab = new () { Title = "About" };
         aboutTab.Add (new Label { Text = "Version 1.0.0", X = 1, Y = 1 });
 
-        tabView.AddTab (new Tab { DisplayText = "Settings", View = settingsTab }, false);
-        tabView.AddTab (new Tab { DisplayText = "About", View = aboutTab }, false);
+        tabs.Add (settingsTab, aboutTab);
 
-        Add (tabView);
+        // Tabs is IValue<View?> — set Value to switch tabs programmatically
+        tabs.Value = settingsTab;
+
+        Add (tabs);
     }
 }
 ```
@@ -340,9 +328,14 @@ public sealed class ProgressWindow : Runnable
         Add (_statusLabel, _progressBar, cancelButton);
     }
 
-    public override void OnLoaded ()
+    protected override void OnIsRunningChanged (bool newIsRunning)
     {
-        base.OnLoaded ();
+        base.OnIsRunningChanged (newIsRunning);
+
+        if (!newIsRunning)
+        {
+            return;
+        }
 
         // Start simulated work
         App!.AddTimeout (TimeSpan.FromMilliseconds (100), () =>
@@ -376,7 +369,7 @@ private void OpenFile ()
     {
         Title = "Open File",
         AllowsMultipleSelection = false,
-        DirectoryPath = Environment.CurrentDirectory
+        Path = Environment.CurrentDirectory  // Starting directory
     };
 
     // Optional: filter by extension
@@ -397,15 +390,15 @@ private void SaveFile ()
     SaveDialog dialog = new ()
     {
         Title = "Save File",
-        DirectoryPath = Environment.CurrentDirectory,
-        FileName = "document.txt"
+        Path = Environment.CurrentDirectory  // Starting directory
     };
 
     App!.Run (dialog);
 
+    // FileName is the name portion of the chosen Path (null if canceled)
     if (!dialog.Canceled && !string.IsNullOrEmpty (dialog.FileName))
     {
-        string path = dialog.FileName;
+        string path = dialog.Path;
         // Save to path...
     }
 }
@@ -438,6 +431,8 @@ private void OpenMultipleFiles ()
 Display tabular data with TableView.
 
 ```csharp
+using System.Data;
+
 public sealed class DataTableWindow : Runnable
 {
     public DataTableWindow ()
@@ -474,12 +469,21 @@ public sealed class DataTableWindow : Runnable
             Text = "Select a row"
         };
 
-        tableView.SelectedCellChanged += (_, e) =>
+        // TableView is IValue<TableSelection?> — ValueChanged fires when the selection moves.
+        // SelectedCell is a Point: X = column, Y = row.
+        tableView.ValueChanged += (_, e) =>
         {
-            if (e.NewRow >= 0 && e.NewRow < table.Rows.Count)
+            if (e.NewValue is not { } selection)
             {
-                DataRow row = table.Rows [e.NewRow];
-                statusLabel.Text = $"Selected: {row ["Name"]} - ${row ["Price"]}";
+                return;
+            }
+
+            int row = selection.SelectedCell.Y;
+
+            if (row >= 0 && row < table.Rows.Count)
+            {
+                DataRow dataRow = table.Rows [row];
+                statusLabel.Text = $"Selected: {dataRow ["Name"]} - ${dataRow ["Price"]}";
             }
         };
 
@@ -495,6 +499,8 @@ public sealed class DataTableWindow : Runnable
 Hierarchical data display.
 
 ```csharp
+using System.IO;
+
 public sealed class TreeWindow : Runnable
 {
     public TreeWindow ()
@@ -568,7 +574,9 @@ public sealed class StatusBarApp : Runnable
     {
         Title = "Status Bar Demo";
 
-        TextView editor = new ()
+        // Main content area. (For a real multi-line editor, use gui-cs/Editor's
+        // EditorView — the core TextView is deprecated.)
+        View content = new ()
         {
             Width = Dim.Fill (),
             Height = Dim.Fill (1)  // Leave 1 row for StatusBar
@@ -604,7 +612,7 @@ public sealed class StatusBarApp : Runnable
                                   };
 
         statusBar.Add (saveShortcut, quitShortcut);
-        Add (editor, statusBar);
+        Add (content, statusBar);
     }
 }
 ```
@@ -652,7 +660,7 @@ if possible.
 
 ## Tips for All Patterns
 
-1. **Always use `e.Handled = true`** in `Accepting` event handlers
+1. **Use `-ed` events (`Accepted`) for side effects**; use `Accepting` + `e.Handled = true` only to inspect or cancel
 2. **Use `Dim.Fill()` and `Pos.Center()`** instead of hardcoded values
 3. **Call `App!.RequestStop()`** to close the current window
 4. **Use `MessageBox.Query`** for simple dialogs

--- a/.claude/tasks/build-app.md
+++ b/.claude/tasks/build-app.md
@@ -73,22 +73,27 @@ public sealed class MainWindow : Runnable
 
 ### With Return Value
 ```csharp
+// Usage:
+IApplication app = Application.Create ().Init ();
+string? username = app.Run<LoginWindow> ().GetResult<string> ();
+app.Dispose ();
+
 public sealed class LoginWindow : Runnable<string?>
 {
     public LoginWindow ()
     {
-        // ... setup UI ...
+        TextField usernameField = new () { X = 1, Y = 1, Width = 20 };
+        Button loginButton = new () { Text = "Login", X = 1, Y = 3, IsDefault = true };
 
         loginButton.Accepted += (_, _) =>
         {
             Result = usernameField.Text;  // Set return value
             App!.RequestStop ();          // Close window
         };
+
+        Add (usernameField, loginButton);
     }
 }
-
-// Usage:
-string? username = app.Run<LoginWindow> ().GetResult<string> ();
 ```
 
 ## Layout System
@@ -157,7 +162,7 @@ button.Accepted += (_, _) =>
 // Use Accepting (pre-event) ONLY to inspect or cancel the in-flight action
 button.Accepting += (_, e) =>
 {
-    if (!CanProceed ())
+    if (usernameField.Text.Length == 0)
     {
         e.Handled = true;  // Cancel — prevents Accepted from firing
     }
@@ -174,25 +179,32 @@ textField.TextChanged += (_, _) =>
 
 ### Selection Changed
 ```csharp
-listView.SelectedItemChanged += (_, e) =>
+// Typed views expose their data via IValue<T> — ListView is IValue<int?> (the selected index)
+listView.ValueChanged += (_, e) =>
 {
-    SelectedItem item = e.Value;
+    int? selectedIndex = e.NewValue;
 };
 ```
 
 ### Keyboard Shortcuts
 ```csharp
-// Add a key binding
-view.AddCommand (Command.Accept, myHandler);
-view.KeyBindings.Add (Key.F5, Command.Accept);
+// In your View subclass: add a command handler, then bind a key to it.
+// (AddCommand is protected — call it from inside the view, not on an instance.)
+AddCommand (Command.Refresh, () =>
+{
+    // Reload data here
+
+    return true;
+});
+KeyBindings.Add (Key.F5, Command.Refresh);
 ```
 
 ## Dialogs
 
 ### Message Box
 ```csharp
-int result = MessageBox.Query (App!, "Title", "Message", "Yes", "No");
-// result: 0 = Yes, 1 = No
+int? result = MessageBox.Query (App!, "Title", "Message", "Yes", "No");
+// result: 0 = Yes, 1 = No, null = dismissed without choosing
 ```
 
 ### Error Dialog

--- a/.github/workflows/validate-doc-snippets.yml
+++ b/.github/workflows/validate-doc-snippets.yml
@@ -1,0 +1,64 @@
+name: Validate Doc Snippets
+
+# Compiles every C# code block in the AI agent docs against the built Terminal.Gui
+# assembly (see Scripts/DocSnippetValidator/README.md). Runs when the docs change
+# AND when the library changes, so API changes that break documented examples fail
+# here instead of silently rotting the docs.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'ai-v2-primer.md'
+      - '.claude/tasks/build-app.md'
+      - '.claude/cookbook/common-patterns.md'
+      - 'Terminal.Gui/**'
+      - 'Scripts/DocSnippetValidator/**'
+      - '.github/workflows/validate-doc-snippets.yml'
+  pull_request:
+    paths:
+      - 'ai-v2-primer.md'
+      - '.claude/tasks/build-app.md'
+      - '.claude/cookbook/common-patterns.md'
+      - 'Terminal.Gui/**'
+      - 'Scripts/DocSnippetValidator/**'
+      - '.github/workflows/validate-doc-snippets.yml'
+
+jobs:
+  validate-doc-snippets:
+    name: Validate Doc Snippets
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.x
+          dotnet-quality: 'ga'
+
+      - name: Build Terminal.Gui
+        run: dotnet build Terminal.Gui/Terminal.Gui.csproj --configuration Debug
+
+      - name: Validate snippets
+        run: |
+          dotnet run --project Scripts/DocSnippetValidator --configuration Debug -- \
+            Terminal.Gui/bin/Debug/net10.0/Terminal.Gui.dll \
+            ai-v2-primer.md \
+            .claude/tasks/build-app.md \
+            .claude/cookbook/common-patterns.md
+
+      # Negative test: the validator must REJECT a snippet using obsolete v1 APIs
+      # (CS0618/CS0612), so the v1 rot this workflow prevents cannot slip back in
+      # as "compiled". Expect a non-zero exit on the fixture.
+      - name: Validate rejects obsolete APIs (negative test)
+        run: |
+          if dotnet run --project Scripts/DocSnippetValidator --configuration Debug -- \
+            Terminal.Gui/bin/Debug/net10.0/Terminal.Gui.dll \
+            Scripts/DocSnippetValidator/testdata/obsolete-api.md; then
+            echo "::error::validator accepted an obsolete-API snippet; CS0618/CS0612 must fail"
+            exit 1
+          fi
+          echo "negative test passed: validator rejected the obsolete-API fixture"

--- a/.github/workflows/validate-doc-snippets.yml
+++ b/.github/workflows/validate-doc-snippets.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # GitVersion.MsBuild needs full history
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v5

--- a/Scripts/DocSnippetValidator/DocSnippetValidator.csproj
+++ b/Scripts/DocSnippetValidator/DocSnippetValidator.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+  </ItemGroup>
+
+</Project>

--- a/Scripts/DocSnippetValidator/Program.cs
+++ b/Scripts/DocSnippetValidator/Program.cs
@@ -1,0 +1,69 @@
+// Compiles every fenced C# block in the given markdown files against the built
+// Terminal.Gui assembly. Blocks demonstrating anti-patterns (containing "// WRONG",
+// "❌", or "✗") and blocks preceded by `<!-- snippet: ignore -->` are skipped.
+//
+// Usage: dotnet run --project Scripts/DocSnippetValidator -- <Terminal.Gui.dll> <file.md>...
+
+using DocSnippetValidator;
+
+if (args.Length < 2)
+{
+    Console.Error.WriteLine ("Usage: DocSnippetValidator <path-to-Terminal.Gui.dll> <markdown-file>...");
+
+    return 2;
+}
+
+string libPath = Path.GetFullPath (args [0]);
+
+if (!File.Exists (libPath))
+{
+    Console.Error.WriteLine ($"Library not found: {libPath} — build Terminal.Gui first.");
+
+    return 2;
+}
+
+SnippetCompiler compiler = new (libPath);
+int failed = 0;
+int compiled = 0;
+int skipped = 0;
+
+foreach (string mdPath in args.Skip (1))
+{
+    if (!File.Exists (mdPath))
+    {
+        Console.Error.WriteLine ($"File not found: {mdPath}");
+        failed++;
+
+        continue;
+    }
+
+    foreach (Snippet snippet in SnippetExtractor.Extract (mdPath))
+    {
+        if (snippet.Ignored)
+        {
+            skipped++;
+
+            continue;
+        }
+
+        IReadOnlyList<string> errors = compiler.Compile (snippet);
+        compiled++;
+
+        if (errors.Count == 0)
+        {
+            continue;
+        }
+
+        failed++;
+        Console.Error.WriteLine ($"{snippet.FilePath}({snippet.StartLine}): snippet does not compile:");
+
+        foreach (string error in errors)
+        {
+            Console.Error.WriteLine ($"    {error}");
+        }
+    }
+}
+
+Console.WriteLine ($"Doc snippets: {compiled} compiled, {skipped} skipped, {failed} failed.");
+
+return failed == 0 ? 0 : 1;

--- a/Scripts/DocSnippetValidator/README.md
+++ b/Scripts/DocSnippetValidator/README.md
@@ -1,0 +1,32 @@
+# DocSnippetValidator
+
+Compiles every fenced ` ```csharp ` block in the AI agent docs against the built `Terminal.Gui.dll`, so example rot (v1 APIs, renamed members, invalid constructors) fails CI instead of misleading agents and users.
+
+## Usage
+
+```bash
+dotnet build Terminal.Gui/Terminal.Gui.csproj -c Debug
+dotnet run --project Scripts/DocSnippetValidator -- \
+    Terminal.Gui/bin/Debug/net10.0/Terminal.Gui.dll \
+    ai-v2-primer.md .claude/tasks/build-app.md .claude/cookbook/common-patterns.md
+```
+
+## How blocks are compiled
+
+- **Complete units** (blocks containing type declarations or `using` directives) compile as-is, with a standard set of `using` directives prepended. Blocks that also contain top-level statements compile as programs.
+- **Statement fragments** (e.g. `X = Pos.Center ();`) are wrapped in a method inside a harness class deriving from `Runnable<string?>`, with common fields (`app`, `view`, `button`, `textField`, ...) in scope. If that fails, the block is retried as class members (for fragments that declare methods).
+
+## Opting a block out
+
+- Blocks containing `// WRONG`, `❌`, or `✗` are skipped automatically (anti-pattern examples are intentionally wrong).
+- Precede a fence with `<!-- snippet: ignore -->` to skip it explicitly.
+
+## Obsolete APIs fail
+
+Obsolete-API use (`CS0618`/`CS0612`) is treated as a **failure**, not a warning, so v1 rot like the legacy static `Application.Init` cannot pass as "compiled" just because the member still exists as an `[Obsolete]` shim. (For a deprecated-but-intentional usage, mark the block as opted out above.)
+
+## Tests
+
+`testdata/obsolete-api.md` is a negative-test fixture: it uses an obsolete API and is **not** in the validated doc set. CI (`validate-doc-snippets.yml`) runs the validator against it and asserts a non-zero exit, so a regression that stops failing on obsolete APIs is itself caught.
+
+Run via `.github/workflows/validate-doc-snippets.yml`.

--- a/Scripts/DocSnippetValidator/Snippet.cs
+++ b/Scripts/DocSnippetValidator/Snippet.cs
@@ -1,0 +1,8 @@
+namespace DocSnippetValidator;
+
+/// <summary>A fenced C# code block extracted from a markdown file.</summary>
+/// <param name="FilePath">The markdown file the block came from.</param>
+/// <param name="StartLine">The 1-based line of the opening fence.</param>
+/// <param name="Code">The code inside the fence, with fence indentation stripped.</param>
+/// <param name="Ignored">Whether the block is excluded from compilation (marked WRONG or `snippet: ignore`).</param>
+public record Snippet (string FilePath, int StartLine, string Code, bool Ignored);

--- a/Scripts/DocSnippetValidator/SnippetCompiler.cs
+++ b/Scripts/DocSnippetValidator/SnippetCompiler.cs
@@ -1,0 +1,138 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DocSnippetValidator;
+
+/// <summary>
+///     Compiles extracted snippets against the built Terminal.Gui assembly. Complete compilation
+///     units compile as-is (with standard usings prepended); statement fragments are wrapped in a
+///     harness class so references to <c>X</c>, <c>App</c>, <c>Result</c>, etc. resolve.
+/// </summary>
+public class SnippetCompiler
+{
+    private const string StandardUsings = """
+                                          using System;
+                                          using System.Collections.Generic;
+                                          using System.Collections.ObjectModel;
+                                          using System.Data;
+                                          using System.IO;
+                                          using System.Linq;
+                                          using Terminal.Gui.App;
+                                          using Terminal.Gui.Configuration;
+                                          using Terminal.Gui.Drawing;
+                                          using Terminal.Gui.Input;
+                                          using Terminal.Gui.Text;
+                                          using Terminal.Gui.ViewBase;
+                                          using Terminal.Gui.Views;
+
+                                          """;
+
+    // Fields (not parameters) so snippet locals may shadow them without CS0136.
+    // No blanket "#pragma warning disable" here: it would also suppress the
+    // obsolete-API warnings (CS0618/CS0612) this validator elevates to errors to
+    // catch v1 API rot. Harness-induced warnings (unused fields, nullability) are
+    // harmless because CompileSource only fails on errors.
+    private const string HarnessHeader = """
+                                         class __SnippetHost : Runnable<string?>
+                                         {
+                                             IApplication app = null!;
+                                             View view = null!;
+                                             View otherView = null!;
+                                             Button button = null!;
+                                             Button loginButton = null!;
+                                             TextField textField = null!;
+                                             TextField usernameField = null!;
+                                             ListView listView = null!;
+                                             CheckBox checkbox = null!;
+                                             Label label = null!;
+
+                                         """;
+
+    private static readonly CSharpParseOptions _parseOptions = CSharpParseOptions.Default.WithLanguageVersion (LanguageVersion.Preview);
+
+    private readonly List<MetadataReference> _references = [];
+
+    public SnippetCompiler (string libPath)
+    {
+        string tpa = (string)AppContext.GetData ("TRUSTED_PLATFORM_ASSEMBLIES")!;
+
+        foreach (string path in tpa.Split (Path.PathSeparator))
+        {
+            _references.Add (MetadataReference.CreateFromFile (path));
+        }
+
+        _references.Add (MetadataReference.CreateFromFile (libPath));
+    }
+
+    /// <summary>Compiles <paramref name="snippet"/>; returns compile errors (empty when it compiles).</summary>
+    public IReadOnlyList<string> Compile (Snippet snippet)
+    {
+        SyntaxTree probe = CSharpSyntaxTree.ParseText (snippet.Code, _parseOptions);
+        CompilationUnitSyntax root = probe.GetCompilationUnitRoot ();
+
+        bool hasTypes = root.Members.Any (m => m is not GlobalStatementSyntax);
+        bool hasGlobals = root.Members.OfType<GlobalStatementSyntax> ().Any ();
+
+        if (hasTypes || root.Usings.Count > 0)
+        {
+            string source = StandardUsings + snippet.Code;
+            OutputKind kind = hasGlobals ? OutputKind.ConsoleApplication : OutputKind.DynamicallyLinkedLibrary;
+
+            return CompileSource (source, kind, preambleLines: CountLines (StandardUsings));
+        }
+
+        // Statement fragment: try as a method body first, then as class members.
+        string methodWrap = StandardUsings + HarnessHeader + "    void __Demo ()\n    {\n" + snippet.Code + "\n    }\n}\n";
+        int methodPreamble = CountLines (StandardUsings) + CountLines (HarnessHeader) + 2;
+        IReadOnlyList<string> statementErrors = CompileSource (methodWrap, OutputKind.DynamicallyLinkedLibrary, methodPreamble);
+
+        if (statementErrors.Count == 0)
+        {
+            return statementErrors;
+        }
+
+        string memberWrap = StandardUsings + HarnessHeader + snippet.Code + "\n}\n";
+        int memberPreamble = CountLines (StandardUsings) + CountLines (HarnessHeader);
+        IReadOnlyList<string> memberErrors = CompileSource (memberWrap, OutputKind.DynamicallyLinkedLibrary, memberPreamble);
+
+        return memberErrors.Count == 0 ? memberErrors : statementErrors;
+    }
+
+    private IReadOnlyList<string> CompileSource (string source, OutputKind kind, int preambleLines)
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText (source, _parseOptions);
+
+        CSharpCompilationOptions options = new (
+                                                kind,
+                                                nullableContextOptions: NullableContextOptions.Enable,
+                                                specificDiagnosticOptions:
+                                                [
+                                                    // Duplicate-using noise from prepending StandardUsings.
+                                                    new ("CS0105", ReportDiagnostic.Suppress),
+
+                                                    // Treat obsolete-API use as a failure so v1 rot (e.g. the
+                                                    // legacy static Application.Init) cannot pass as "compiled".
+                                                    new ("CS0612", ReportDiagnostic.Error),
+                                                    new ("CS0618", ReportDiagnostic.Error)
+                                                ]);
+
+        CSharpCompilation compilation = CSharpCompilation.Create ("Snippet", [tree], _references, options);
+
+        return
+        [
+            .. compilation.GetDiagnostics ()
+                          .Where (d => d.Severity == DiagnosticSeverity.Error)
+                          .Select (d => Format (d, preambleLines))
+        ];
+    }
+
+    private static string Format (Diagnostic diagnostic, int preambleLines)
+    {
+        int line = diagnostic.Location.GetLineSpan ().StartLinePosition.Line + 1 - preambleLines;
+
+        return $"(snippet line {line}) {diagnostic.Id}: {diagnostic.GetMessage ()}";
+    }
+
+    private static int CountLines (string text) => text.Count (c => c == '\n');
+}

--- a/Scripts/DocSnippetValidator/SnippetExtractor.cs
+++ b/Scripts/DocSnippetValidator/SnippetExtractor.cs
@@ -1,0 +1,75 @@
+namespace DocSnippetValidator;
+
+/// <summary>Extracts fenced C# code blocks from markdown files.</summary>
+public static class SnippetExtractor
+{
+    /// <summary>
+    ///     Markers that exclude a block from compilation. Blocks demonstrating anti-patterns are
+    ///     intentionally wrong; blocks preceded by <c>&lt;!-- snippet: ignore --&gt;</c> are opted out.
+    /// </summary>
+    private static readonly string [] _wrongMarkers = ["// WRONG", "❌", "✗"];
+
+    /// <summary>Extracts all fenced <c>```csharp</c> / <c>```cs</c> blocks from <paramref name="filePath"/>.</summary>
+    public static IEnumerable<Snippet> Extract (string filePath)
+    {
+        string [] lines = File.ReadAllLines (filePath);
+        List<Snippet> snippets = [];
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string trimmed = lines [i].TrimStart ();
+
+            if (!trimmed.StartsWith ("```csharp", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals (trimmed, "```cs", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            string indent = lines [i] [..(lines [i].Length - trimmed.Length)];
+            bool ignored = HasIgnoreMarker (lines, i);
+            int fenceLine = i + 1;
+            List<string> code = [];
+            i++;
+
+            while (i < lines.Length && lines [i].TrimStart () != "```")
+            {
+                code.Add (StripIndent (lines [i], indent));
+                i++;
+            }
+
+            string body = string.Join ('\n', code);
+
+            if (_wrongMarkers.Any (body.Contains))
+            {
+                ignored = true;
+            }
+
+            snippets.Add (new (filePath, fenceLine, body, ignored));
+        }
+
+        return snippets;
+    }
+
+    private static bool HasIgnoreMarker (string [] lines, int fenceIndex)
+    {
+        for (int i = Math.Max (0, fenceIndex - 2); i < fenceIndex; i++)
+        {
+            if (lines [i].Contains ("snippet: ignore", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string StripIndent (string line, string indent)
+    {
+        if (indent.Length > 0 && line.StartsWith (indent, StringComparison.Ordinal))
+        {
+            return line [indent.Length..];
+        }
+
+        return line;
+    }
+}

--- a/Scripts/DocSnippetValidator/testdata/obsolete-api.md
+++ b/Scripts/DocSnippetValidator/testdata/obsolete-api.md
@@ -1,0 +1,11 @@
+# Negative-test fixture: obsolete v1 API must be rejected
+
+This file is **not** part of the documented snippets. It exists so the validator's
+own behavior can be regression-tested: the block below uses the obsolete v1 static
+`Application` API (`CS0618`) and is **not** marked `// WRONG`, so a correct validator
+must reject it. See `Scripts/DocSnippetValidator/README.md`.
+
+```csharp
+Application.Init ();
+Application.Shutdown ();
+```


### PR DESCRIPTION
## Summary

Adds `Scripts/DocSnippetValidator` — a Roslyn-based tool that compiles every fenced C# block in the agent-facing docs (`ai-v2-primer.md`, `.claude/tasks/build-app.md`, `.claude/cookbook/common-patterns.md`) against the freshly built `Terminal.Gui.dll` — plus a CI workflow that runs it when either the docs **or the library** change, so API renames break loudly instead of silently rotting the examples agents copy from.

> **Stacked on #5478** (based on `fix/agent-doc-inconsistencies`); will retarget to `develop` when that merges.

## What the first run found

14 of 30 snippets did not compile. `ai-v2-primer.md` was fully green; the cookbook had substantial v1 rot. All fixed against the current API:

| Doc said | v2 reality |
|---|---|
| `ColorScheme = Colors.ColorSchemes ["Error"]` | `SchemeName = "Error"` |
| `new MenuItem ("New", "", action, null, null, KeyCode.N \| KeyCode.CtrlMask)` | `new MenuItem { Title = "_New", Key = Key.N.WithCtrl, Action = ... }` |
| `TileView` | removed — Pos/Dim panes + `ViewArrangement.RightResizable` |
| `TabView` / `Tab` | `Tabs` — `Add` views, `Title` is the tab label, `Value` selects |
| `listView.SelectedItemChanged` | `ValueChanged` (`IValue<int?>`); `SelectedItem` is `int?` |
| `tableView.SelectedCellChanged` / `SelectedRow` | `ValueChanged` (`IValue<TableSelection?>`), `SelectedCell` Point |
| `override OnLoaded ()` on `Runnable` | `OnIsRunningChanged (bool)` |
| `OpenDialog.DirectoryPath`, settable `SaveDialog.FileName` | `Path`; `FileName` is read-only |
| `ListWrapper<string> (List<string>)` | requires `ObservableCollection<T>` |
| `int result = MessageBox.Query (...)` | returns `int?` |
| `view.AddCommand (...)` on an instance | `AddCommand` is protected — call inside the subclass |

Also of note: the compressed type index in AGENTS.md claims `TableView` has `SelectedRow`/`SelectedColumn` — it does not. Worth regenerating that index in a follow-up.

## How it works

- Complete compilation units compile as-is (standard usings prepended); blocks with top-level statements compile as programs.
- Statement fragments are wrapped in a method inside a `Runnable<string?>` harness with common fields (`app`, `view`, `button`, ...) in scope; fragments that declare methods are retried as class members.
- Blocks containing `// WRONG` / `❌` / `✗` are skipped automatically; `<!-- snippet: ignore -->` opts a block out explicitly.

## Testing

`dotnet run --project Scripts/DocSnippetValidator -- Terminal.Gui/bin/Debug/net10.0/Terminal.Gui.dll ai-v2-primer.md .claude/tasks/build-app.md .claude/cookbook/common-patterns.md` → **29 compiled, 1 skipped, 0 failed** (and correctly reported all 14 failures before the doc fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)