### PR TITLE
Fixes #5474. Progress scenario crashes on exit when threaded timer is running

### DIFF
--- a/Examples/UICatalog/Scenarios/Progress.cs
+++ b/Examples/UICatalog/Scenarios/Progress.cs
@@ -40,14 +40,22 @@ public class Progress : Scenario
 
                                             _systemTimer = new Timer (_ =>
                                                                       {
-                                                                          // System.Threading.Timer callbacks run on thread-pool threads and can fire
-                                                                          // after the application has been shut down. Invoke throws
-                                                                          // NotInitializedException once the application is no longer initialized, and
-                                                                          // that exception would be unhandled here and crash the process. Only Invoke
-                                                                          // while the application is still initialized.
-                                                                          if (_app is { Initialized: true })
+                                                                          // System.Threading.Timer callbacks run on thread-pool threads and can race
+                                                                          // with shutdown. Invoke throws NotInitializedException once the
+                                                                          // application is no longer initialized, and that exception would be
+                                                                          // unhandled here and crash the process.
+                                                                          if (_app is not { Initialized: true })
+                                                                          {
+                                                                              return;
+                                                                          }
+
+                                                                          try
                                                                           {
                                                                               _app.Invoke (_ => systemTimerDemo.Pulse ());
+                                                                          }
+                                                                          catch (NotInitializedException)
+                                                                          {
+                                                                              // A callback can pass the Initialized check before shutdown completes.
                                                                           }
                                                                       },
                                                                       null,

--- a/Examples/UICatalog/Scenarios/Progress.cs
+++ b/Examples/UICatalog/Scenarios/Progress.cs
@@ -40,9 +40,15 @@ public class Progress : Scenario
 
                                             _systemTimer = new Timer (_ =>
                                                                       {
-                                                                          // Note the check for Mainloop being valid. System.Timers can run after they are Disposed.
-                                                                          // This code must be defensive for that.
-                                                                          _app?.Invoke (_ => systemTimerDemo.Pulse ());
+                                                                          // System.Threading.Timer callbacks run on thread-pool threads and can fire
+                                                                          // after the application has been shut down. Invoke throws
+                                                                          // NotInitializedException once the application is no longer initialized, and
+                                                                          // that exception would be unhandled here and crash the process. Only Invoke
+                                                                          // while the application is still initialized.
+                                                                          if (_app is { Initialized: true })
+                                                                          {
+                                                                              _app.Invoke (_ => systemTimerDemo.Pulse ());
+                                                                          }
                                                                       },
                                                                       null,
                                                                       0,
@@ -138,14 +144,38 @@ public class Progress : Scenario
                                };
         _win.Add (startBoth);
 
+        // Stop the background timers as soon as the window stops running (e.g. on Quit), while the
+        // application is still initialized. Waiting for Dispose is too late: by then the application
+        // has been torn down (so Invoke throws) and this window's SubViews have been disposed (so the
+        // Dispose-time cleanup below can no longer reach the demos). See issue #5474.
+        win.IsRunningChanged += (_, e) =>
+                                {
+                                    if (e.Value)
+                                    {
+                                        return;
+                                    }
+
+                                    _systemTimer?.Dispose ();
+                                    _systemTimer = null;
+
+                                    if (_mainLoopTimeout is { })
+                                    {
+                                        _app?.RemoveTimeout (_mainLoopTimeout);
+                                        _mainLoopTimeout = null;
+                                    }
+                                };
+
         app.Run (_win);
     }
 
     protected override void Dispose (bool disposing)
     {
-        foreach (ProgressDemo v in _win.SubViews.OfType<ProgressDemo> ())
+        // Backstop: the System.Timer is normally stopped in win.IsRunningChanged (see Main). This
+        // also covers the case where the scenario is disposed without ever having run.
+        if (disposing)
         {
-            v._stopBtnClick ();
+            _systemTimer?.Dispose ();
+            _systemTimer = null;
         }
 
         base.Dispose (disposing);

--- a/Tests/IntegrationTests/ProgressScenarioTests.cs
+++ b/Tests/IntegrationTests/ProgressScenarioTests.cs
@@ -1,0 +1,162 @@
+// Claude - Opus 4.8 (1M context)
+
+using System.Runtime.ExceptionServices;
+using UICatalog;
+using UICatalog.Scenarios;
+
+namespace IntegrationTests;
+
+/// <summary>
+///     Regression coverage for issue #5474: the Progress scenario crashed on exit ("Esc") when the
+///     threaded <see cref="System.Threading.Timer"/> demo was running.
+/// </summary>
+/// <remarks>
+///     The threaded demo's timer callback runs on a thread-pool thread and calls
+///     <see cref="IApplication.Invoke(System.Action)"/>. Once the application is disposed, Invoke throws
+///     <see cref="NotInitializedException"/>; thrown on a thread-pool thread it is unhandled and
+///     terminates the process. The scenario previously only stopped the timer in
+///     <see cref="System.IDisposable.Dispose"/>, which runs after the application (and the window's
+///     SubViews) have already been disposed, so the timer was never stopped. The fix stops the timer in
+///     <c>win.IsRunningChanged</c>, while the application is still initialized.
+/// </remarks>
+public class ProgressScenarioTests (ITestOutputHelper output)
+{
+    [Fact]
+    public void Progress_With_Running_Threaded_Timer_Quits_Without_Crashing ()
+    {
+        ConfigurationManager.Disable (true);
+        Application.ResetState (true);
+
+        IApplication? app = null;
+        var iterationCount = 0;
+        var startInvoked = false;
+        var timerRunningConfirmed = false;
+        var notInitializedThrows = 0;
+
+        // The threaded timer's post-shutdown Invoke throws NotInitializedException on a thread-pool
+        // thread. FirstChanceException records the throw even though it occurs off the test thread.
+        void OnFirstChance (object? s, FirstChanceExceptionEventArgs e)
+        {
+            if (e.Exception is NotInitializedException)
+            {
+                Interlocked.Increment (ref notInitializedThrows);
+            }
+        }
+
+        AppDomain.CurrentDomain.FirstChanceException += OnFirstChance;
+
+        Progress scenario = new ();
+
+        Application.InstanceInitialized += OnInit;
+        Application.InstanceDisposed += OnDisposed;
+        Application.ForceDriver = DriverRegistry.Names.ANSI;
+
+        try
+        {
+            scenario.Main ();
+            scenario.Dispose ();
+        }
+        finally
+        {
+            Application.ForceDriver = string.Empty;
+            Application.InstanceInitialized -= OnInit;
+            Application.InstanceDisposed -= OnDisposed;
+        }
+
+        // The scenario started the threaded System.Timer and then quit. Before the fix, the timer was
+        // never stopped and kept calling Invoke on the disposed application, throwing
+        // NotInitializedException. Give any leaked timer time to fire after shutdown.
+        Thread.Sleep (300);
+
+        AppDomain.CurrentDomain.FirstChanceException -= OnFirstChance;
+
+        output.WriteLine ($"NotInitializedException throws after run: {notInitializedThrows}");
+
+        Assert.True (startInvoked, "Failed to activate the 'Start Both' button.");
+        Assert.True (timerRunningConfirmed, "The threaded timer demo never reported as Started.");
+        Assert.False (app?.Initialized ?? true);
+        Assert.Equal (0, notInitializedThrows);
+
+        return;
+
+        void OnInit (object? s, EventArgs<IApplication> a)
+        {
+            app = a.Value;
+
+            // Safety net so the test can never hang if RequestStop is missed.
+            app.AddTimeout (TimeSpan.FromMilliseconds (5000), ForceClose);
+            app.Iteration += OnIteration;
+        }
+
+        void OnDisposed (object? s, EventArgs<IApplication> a)
+        {
+            if (app is { })
+            {
+                app.Iteration -= OnIteration;
+            }
+        }
+
+        void OnIteration (object? s, EventArgs<IApplication?> a)
+        {
+            iterationCount++;
+
+            if (!startInvoked)
+            {
+                Button? startBoth = FindRecursive<Button> (app!.TopRunnableView, b => b.Text == "Start Both");
+
+                if (startBoth is { })
+                {
+                    startBoth.InvokeCommand (Command.Accept);
+                    startInvoked = true;
+                }
+
+                return;
+            }
+
+            // Confirm the threaded demo actually started (its label flips to "Started"), so the timer
+            // is genuinely running when we quit.
+            if (!timerRunningConfirmed)
+            {
+                timerRunningConfirmed = FindRecursive<Label> (app!.TopRunnableView, l => l.Text == "Started") is { };
+
+                return;
+            }
+
+            if (iterationCount > 8)
+            {
+                app!.RequestStop ();
+            }
+        }
+
+        bool ForceClose ()
+        {
+            output.WriteLine ("Force-closing Progress scenario via timeout.");
+            app?.RequestStop ();
+
+            return false;
+        }
+    }
+
+    private static T? FindRecursive<T> (View? current, Func<T, bool> predicate) where T : View
+    {
+        if (current is null)
+        {
+            return null;
+        }
+
+        foreach (View subView in current.GetSubViews (includeBorder: true, includePadding: true))
+        {
+            if (subView is T match && predicate (match))
+            {
+                return match;
+            }
+
+            if (FindRecursive (subView, predicate) is { } deep)
+            {
+                return deep;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
- Fixes #5474

## Summary

The UICatalog **Progress** scenario crashed the process on exit ("Esc") when the System.Timer ("threads") demo was running.

### Root cause

Demo #1 drives a `System.Threading.Timer` whose callback runs on a thread-pool thread and calls `IApplication.Invoke(...)`. `Invoke` throws `NotInitializedException` once the application is no longer initialized (an intentional contract — see `ApplicationInvokeLifecycleTests`). On a thread-pool thread that exception is unhandled and terminates the process.

The timer was only stopped in `Scenario.Dispose`, which `Runner` calls **after** `Main()` returns — i.e. after the `using` application and window have already been disposed. Worse, `View.Dispose` empties `SubViews`, so the old cleanup loop:

```csharp
foreach (ProgressDemo v in _win.SubViews.OfType<ProgressDemo> ())
{
    v._stopBtnClick ();
}
```

iterated **nothing** (the window was already disposed and emptied). The timer was therefore never stopped and kept firing `Invoke` on the disposed application → consistent crash.

### Fix (local to the example)

1. Stop the timers in `win.IsRunningChanged` — raised during the stop sequence while the application is still initialized, before teardown (matching the existing pattern in `ProgressBarStyles.cs`). `Initialized` only flips to `false` later, in `Application.Dispose`.
2. Guard the timer callback with `if (_app is { Initialized: true })` — defense-in-depth that makes the existing "this code must be defensive" comment actually true.
3. Replace the broken `Dispose` cleanup (which reached into the already-disposed window) with a direct timer-disposal backstop.

No framework behavior changes; the `Invoke`-throws-when-uninitialized contract is intentional and untouched.

## Tests done

- **New regression test** `Tests/IntegrationTests/ProgressScenarioTests.cs` — runs the real `Progress` scenario, activates the "Start Both" button to start the threaded timer, confirms the timer is running, then quits and asserts a clean shutdown with **0** post-shutdown `NotInitializedException` throws (tracked via `AppDomain.FirstChanceException`).
  - Verified it reproduces the bug: on the unfixed code this test crashes the test host with a thread-pool exception (the exact "fatal crash on Esc" mechanism).
  - On the fixed code it is deterministically green (ran 3× clean).
- **Full `IntegrationTests` assembly: 435/435 pass**, including the existing `UICatalogScenarioTests.All_Scenarios_Dispose_Properly` for Progress.
- UICatalog builds with no new warnings.

## To pull down this PR locally:

```
git remote add copilot https://github.com/harder/Terminal.Gui.git
git fetch copilot kh/5474-progress-esc-crash
git checkout copilot/kh/5474-progress-esc-crash
```
