### PR TITLE
Fix relative markdown link handling

### DIFF
--- a/Terminal.Gui/Drawing/Markdown/MarkdownAttributeHelper.cs
+++ b/Terminal.Gui/Drawing/Markdown/MarkdownAttributeHelper.cs
@@ -122,11 +122,45 @@ internal static class MarkdownAttributeHelper
         return segments;
     }
 
-    private static Attribute MakeLinkAttribute (Attribute normal, StyledSegment segment)
-    {
-        bool isClickable = !string.IsNullOrWhiteSpace (segment.Url)
-                           && (Uri.IsWellFormedUriString (segment.Url, UriKind.Absolute) || segment.Url!.StartsWith ('#'));
+    private static Attribute MakeLinkAttribute (Attribute normal, StyledSegment segment) =>
+        IsMarkdownLinkTarget (segment.Url) ? normal with { Style = normal.Style | TextStyle.Underline } : normal;
 
-        return isClickable ? normal with { Style = normal.Style | TextStyle.Underline } : normal;
+    internal static bool IsMarkdownLinkTarget (string? url)
+    {
+        if (string.IsNullOrWhiteSpace (url))
+        {
+            return false;
+        }
+
+        if (url.StartsWith ('#'))
+        {
+            return true;
+        }
+
+        if (TryCreateSafeAbsoluteUri (url, out _))
+        {
+            return true;
+        }
+
+        return Uri.TryCreate (url, UriKind.Relative, out _);
+    }
+
+    internal static bool TryCreateSafeAbsoluteUri (string? url, out Uri? absoluteUri)
+    {
+        absoluteUri = null;
+
+        if (!Uri.TryCreate (url, UriKind.Absolute, out Uri? parsed) || parsed is null)
+        {
+            return false;
+        }
+
+        if (!Link.SafeSchemes.Contains (parsed.Scheme))
+        {
+            return false;
+        }
+
+        absoluteUri = parsed;
+
+        return true;
     }
 }

--- a/Terminal.Gui/Views/Markdown/Markdown.cs
+++ b/Terminal.Gui/Views/Markdown/Markdown.cs
@@ -528,6 +528,7 @@ public partial class Markdown : View, IDesignable
                                                           ## Links
 
                                                           * [Markdown API docs](https://gui-cs.github.io/Terminal.Gui/api/Terminal.Gui.Views.Markdown.html) for more info.
+                                                          * [Relative local link](docs/getting-started.md) renders as a link without opening a URI handler by default.
 
                                                           ## Checklist
 

--- a/Terminal.Gui/Views/Markdown/MarkdownTable.cs
+++ b/Terminal.Gui/Views/Markdown/MarkdownTable.cs
@@ -595,7 +595,7 @@ public sealed class MarkdownTable : View, IDesignable
                     }
 
                     bool hasUrl = !string.IsNullOrWhiteSpace (seg.Url);
-                    bool isAbsoluteUrl = hasUrl && Uri.IsWellFormedUriString (seg.Url, UriKind.Absolute);
+                    bool isAbsoluteUrl = hasUrl && MarkdownAttributeHelper.TryCreateSafeAbsoluteUri (seg.Url, out _);
                     bool isActive = hasUrl && HasFocus && IsActiveLinkAt (rowIndex, col, seg.Url!);
 
                     if (isActive)

--- a/Terminal.Gui/Views/Markdown/MarkdownView.Drawing.cs
+++ b/Terminal.Gui/Views/Markdown/MarkdownView.Drawing.cs
@@ -229,8 +229,9 @@ public partial class Markdown
                 {
                     Attribute linkAttr = GetAttributeForSegment (segment);
                     Attribute reversed = new (linkAttr.Background, linkAttr.Foreground, linkAttr.Style);
+                    bool isSafeAbsoluteLink = MarkdownAttributeHelper.TryCreateSafeAbsoluteUri (segment.Url, out _);
 
-                    if (!string.IsNullOrWhiteSpace (segment.Url) && Uri.IsWellFormedUriString (segment.Url, UriKind.Absolute) && Driver is { })
+                    if (isSafeAbsoluteLink && Driver is { })
                     {
                         Driver.CurrentUrl = segment.Url;
 
@@ -276,7 +277,7 @@ public partial class Markdown
     {
         Attribute attr = GetAttributeForSegment (segment);
 
-        if (!string.IsNullOrWhiteSpace (segment.Url) && Uri.IsWellFormedUriString (segment.Url, UriKind.Absolute) && Driver is { })
+        if (MarkdownAttributeHelper.TryCreateSafeAbsoluteUri (segment.Url, out _) && Driver is { })
         {
             Driver.CurrentUrl = segment.Url;
 

--- a/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/Markdown/MarkdownViewTests.cs
@@ -202,6 +202,37 @@ public class MarkdownViewTests (ITestOutputHelper output)
         window.Dispose ();
     }
 
+    // Codex - GPT-5
+    [Fact]
+    public void Mouse_Click_On_Relative_Link_Raises_LinkClicked ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable window = new () { Width = Dim.Fill (), Height = Dim.Fill (), BorderStyle = LineStyle.None };
+
+        Terminal.Gui.Views.Markdown markdownView = new () { Text = "[Local](docs/readme.md)", Width = 20, Height = 3 };
+
+        window.Add (markdownView);
+
+        string clickedUrl = "";
+
+        markdownView.LinkClicked += (_, e) =>
+                                    {
+                                        clickedUrl = e.Url;
+                                        e.Handled = true;
+                                    };
+
+        app.Begin (window);
+        app.LayoutAndDraw ();
+
+        markdownView.NewMouseEvent (new Mouse { Position = new Point (0, 0), Flags = MouseFlags.LeftButtonClicked });
+
+        Assert.Equal ("docs/readme.md", clickedUrl);
+
+        window.Dispose ();
+    }
+
     // Copilot
     [Fact]
     public void Mouse_Click_On_Link_In_Table_Cell_Raises_LinkClicked ()
@@ -252,6 +283,45 @@ public class MarkdownViewTests (ITestOutputHelper output)
         tableView.NewMouseEvent (new Mouse { Position = new Point (2, 3), Flags = MouseFlags.LeftButtonClicked });
 
         Assert.Equal ("https://example.com", clickedUrl);
+
+        window.Dispose ();
+    }
+
+    // Codex - GPT-5
+    [Fact]
+    public void Mouse_Click_On_Relative_Link_In_Table_Cell_Raises_LinkClicked ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable window = new () { Width = 80, Height = 20, BorderStyle = LineStyle.None };
+
+        string markdown = """
+                          | Name | Description |
+                          |------|-------------|
+                          | [local](docs/readme.md) | Pick one item |
+                          """;
+
+        Terminal.Gui.Views.Markdown markdownView = new () { Text = markdown, Width = 60, Height = 15 };
+        window.Add (markdownView);
+
+        string clickedUrl = "";
+
+        markdownView.LinkClicked += (_, e) =>
+                                    {
+                                        clickedUrl = e.Url;
+                                        e.Handled = true;
+                                    };
+
+        app.Begin (window);
+        app.LayoutAndDraw ();
+
+        MarkdownTable? tableView = markdownView.SubViews.OfType<MarkdownTable> ().FirstOrDefault ();
+        Assert.NotNull (tableView);
+
+        tableView.NewMouseEvent (new Mouse { Position = new Point (2, 3), Flags = MouseFlags.LeftButtonClicked });
+
+        Assert.Equal ("docs/readme.md", clickedUrl);
 
         window.Dispose ();
     }
@@ -749,11 +819,11 @@ public class MarkdownViewTests (ITestOutputHelper output)
     }
 
     [Fact]
-    public void Style_Link_Relative_No_Underline_No_OSC8 ()
+    public void Style_Link_Relative_Underline_No_OSC8 ()
     {
         (IApplication app, Runnable window) = SetupStyleTest ("[Go](foo.md)");
 
-        DriverAssert.AssertDriverOutputIs (@"\x1b[30m\x1b[107mGo", output, app.Driver);
+        DriverAssert.AssertDriverOutputIs (@"\x1b[30m\x1b[107m\x1b[4mGo\x1b[30m\x1b[107m\x1b[24m", output, app.Driver);
 
         window.Dispose ();
         app.Dispose ();


### PR DESCRIPTION
## Summary

- Treat relative Markdown link targets as clickable links alongside anchors and safe absolute URIs
- Restrict OSC8 hyperlink emission to safe absolute URI schemes
- Add regression tests for relative links in Markdown text and table cells
- Add a relative-link example to the Markdown demo content

Fixes #5504

## Testing

- `dotnet build Terminal.Gui/Terminal.Gui.csproj --no-restore`
- `dotnet test --project Tests/UnitTestsParallelizable --no-restore --filter-class "*MarkdownViewTests" /p:BuildProjectReferences=false`
