### PR TITLE
Fixes #5509 branch color getter invoker now applies Active attribute

### DIFF
--- a/Examples/UICatalog/Scenarios/TreeUseCases.cs
+++ b/Examples/UICatalog/Scenarios/TreeUseCases.cs
@@ -7,8 +7,10 @@ namespace UICatalog.Scenarios;
 [ScenarioCategory ("TreeView")]
 public partial class TreeUseCases : Scenario
 {
+    private CheckBox? _customArmyColorsCheckBox;
     private EventLog? _eventLog;
     private Runnable? _appWindow;
+    private TreeView<GameObject>? _armyTree;
     private TreeViewEditor? _treeViewEditor;
     private ViewportSettingsEditor? _viewportSettingsEditor;
 
@@ -33,6 +35,15 @@ public partial class TreeUseCases : Scenario
                                        new MenuItem { Title = "Armies With _Builder", Action = () => LoadArmies (false) },
                                        new MenuItem { Title = "Armies With _Delegate", Action = () => LoadArmies (true) }
                                    ]));
+
+        _customArmyColorsCheckBox = new CheckBox
+        {
+            Title = "_Army Type Colors",
+            Value = CheckState.Checked
+        };
+        _customArmyColorsCheckBox.ValueChanged += (_, _) => SetArmyTypeColors ();
+
+        menu.Add (new MenuBarItem ("_Style", [new MenuItem { CommandView = _customArmyColorsCheckBox }]));
 
         // EventLog on the right
         _eventLog = new EventLog
@@ -153,12 +164,16 @@ public partial class TreeUseCases : Scenario
         }
 
         tree.AddObject (army);
+        _armyTree = tree;
+        SetArmyTypeColors ();
 
         CurrentTree = tree;
     }
 
     private void LoadRooms ()
     {
+        _armyTree = null;
+
         House myHouse = new ()
         {
             Address = "23 Nowhere Street", Rooms = [new Room { Name = "Ballroom" }, new Room { Name = "Bedroom 1" }, new Room { Name = "Bedroom 2" }]
@@ -174,6 +189,8 @@ public partial class TreeUseCases : Scenario
 
     private void LoadEnableForDesign ()
     {
+        _armyTree = null;
+
         TreeView tree = new ();
         tree.EnableForDesign ();
         tree.Title = "_EnableForDesign";
@@ -182,6 +199,42 @@ public partial class TreeUseCases : Scenario
     }
 
     private void Quit () => _appWindow?.RequestStop ();
+
+    private void SetArmyTypeColors ()
+    {
+        if (_armyTree is null || _customArmyColorsCheckBox is null)
+        {
+            return;
+        }
+
+        if (_customArmyColorsCheckBox.Value != CheckState.Checked)
+        {
+            _armyTree.ColorGetter = null;
+            _armyTree.SetNeedsDraw ();
+
+            return;
+        }
+
+        _armyTree.ColorGetter = model => model switch
+                                  {
+                                      Army => CreateArmyTypeScheme (_armyTree, Color.BrightYellow),
+                                      CorpsObject => CreateArmyTypeScheme (_armyTree, Color.BrightCyan),
+                                      Division => CreateArmyTypeScheme (_armyTree, Color.BrightGreen),
+                                      Brigade => CreateArmyTypeScheme (_armyTree, Color.BrightMagenta),
+                                      Unit => CreateArmyTypeScheme (_armyTree, Color.Gray),
+                                      _ => null
+                                  };
+
+        _armyTree.SetNeedsDraw ();
+    }
+
+    private static Scheme CreateArmyTypeScheme (TreeView<GameObject> tree, Color foreground) =>
+        new ()
+        {
+            Normal = new Attribute (foreground, tree.GetAttributeForRole (VisualRole.Normal).Background),
+            Focus = new Attribute (foreground, tree.GetAttributeForRole (VisualRole.Focus).Background),
+            Active = new Attribute (foreground, tree.GetAttributeForRole (VisualRole.Active).Background)
+        };
 
     // ── House / Room model (unchanged) ─────────────────────────────────────
 

--- a/Examples/UICatalog/Scenarios/TreeUseCases.cs
+++ b/Examples/UICatalog/Scenarios/TreeUseCases.cs
@@ -231,9 +231,9 @@ public partial class TreeUseCases : Scenario
     private static Scheme CreateArmyTypeScheme (TreeView<GameObject> tree, Color foreground) =>
         new ()
         {
-            Normal = new Attribute (foreground, tree.GetAttributeForRole (VisualRole.Normal).Background),
-            Focus = new Attribute (foreground, tree.GetAttributeForRole (VisualRole.Focus).Background),
-            Active = new Attribute (foreground, tree.GetAttributeForRole (VisualRole.Active).Background)
+            Normal = tree.GetAttributeForRole (VisualRole.Normal) with { Foreground = foreground },
+            Focus = tree.GetAttributeForRole (VisualRole.Focus) with { Foreground = foreground },
+            Active = tree.GetAttributeForRole (VisualRole.Active) with { Foreground = foreground }
         };
 
     // ── House / Room model (unchanged) ─────────────────────────────────────

--- a/Terminal.Gui/Views/TreeView/Branch.cs
+++ b/Terminal.Gui/Views/TreeView/Branch.cs
@@ -210,7 +210,9 @@ internal class Branch<T> where T : class
             if (modelScheme is { })
             {
                 // use it
-                modelColor = isSelected ? modelScheme.Focus : modelScheme.Normal;
+                modelColor = isSelected
+                                 ? _tree.HasFocus ? modelScheme.Focus : modelScheme.Active
+                                 : modelScheme.Normal;
             }
             else
             {

--- a/Terminal.Gui/Views/TreeView/TreeViewT.cs
+++ b/Terminal.Gui/Views/TreeView/TreeViewT.cs
@@ -326,9 +326,32 @@ public partial class TreeView<T> : View, ITreeView where T : class
     public AspectGetterDelegate<T> AspectGetter { get; set; } = o => o.ToString () ?? "";
 
     /// <summary>
-    ///     Delegate for multi-colored tree views. Return the <see cref="Scheme"/> to use for each passed object or
-    ///     null to use the default.
+    ///     Delegate for basic multi-colored tree view use cases. Return the <see cref="Scheme"/> to use for each passed
+    ///     object, or <see langword="null"/> to use the default tree view scheme.
     /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         TreeView uses only <see cref="Scheme.Normal"/>, <see cref="Scheme.Focus"/>, and <see cref="Scheme.Active"/>
+    ///         from the returned scheme.
+    ///         <list type="bullet">
+    ///             <item>
+    ///                 <term>Normal</term>
+    ///                 <description>Used for unselected branches.</description>
+    ///             </item>
+    ///             <item>
+    ///                <term>Focus</term>
+    ///               <description>Used for selected branches when the tree view has focus.</description>
+    ///             </item>
+    ///             <item>
+    ///                 <term>Active</term>
+    ///                 <description>Used for selected branches when the tree view does not have focus.</description>
+    ///             </item>
+    ///         </list>
+    ///     </para>
+    ///     <para>
+    ///         For greater control over rendering, handle the <see cref="DrawLine"/> event instead.
+    ///     </para>
+    /// </remarks>
     public Func<T, Scheme?>? ColorGetter { get; set; }
 
     /// <summary>

--- a/Tests/UnitTestsParallelizable/Views/TreeViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TreeViewTests.cs
@@ -86,6 +86,63 @@ public class TreeViewTests (ITestOutputHelper output) : TestDriverBase
                                               output,
                                               driver);
     }
+
+    // Codex - gpt 5.5 medium
+    // Regression for issue #5509.
+    [Fact]
+    public void Draw_ColorGetter_UsesActiveForSelectedRow_WhenTreeViewDoesNotHaveFocus ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (20, 4);
+
+        const string selected = "selected";
+        Attribute normal = new (Color.BrightRed, Color.Black);
+        Attribute focus = new (Color.BrightYellow, Color.Blue);
+        Attribute active = new (Color.BrightYellow, Color.DarkGray);
+
+        Scheme treeScheme = new ()
+        {
+            Normal = new Attribute (Color.BrightGreen, Color.Black),
+            Focus = new Attribute (Color.Black, Color.BrightGreen),
+            Active = new Attribute (Color.BrightGreen, Color.DarkGray)
+        };
+
+        Scheme customScheme = new ()
+        {
+            Normal = normal,
+            Focus = focus,
+            Active = active
+        };
+
+        TreeView<string> tree = new (new DelegateTreeBuilder<string> (_ => [], _ => false))
+        {
+            Width = 20,
+            Height = 2,
+            ColorGetter = item => item == selected ? customScheme : null
+        };
+        tree.Style.ShowBranchLines = false;
+        tree.SetScheme (treeScheme);
+        tree.AddObject (selected);
+        tree.SelectedObject = selected;
+
+        View otherView = new () { Y = Pos.Bottom (tree), Width = 1, Height = 1, CanFocus = true };
+
+        using Runnable top = new ();
+        top.Add (tree, otherView);
+
+        app.Begin (top);
+        tree.SetFocus ();
+        app.LayoutAndDraw ();
+        Assert.Equal (focus, app.Driver.Contents! [0, 1].Attribute);
+
+        otherView.SetFocus ();
+        app.LayoutAndDraw ();
+
+        Assert.False (tree.HasFocus);
+        Assert.Equal (active, app.Driver.Contents! [0, 1].Attribute);
+    }
+
     [Fact]
     public void CollectionNavigatorMatcher_KeybindingsOverrideNavigator ()
     {


### PR DESCRIPTION
## Fixes

- Fixes #5509 

## Proposed Changes/Todos

- [x] Extends Tree View scenario to include a custom color delegate. Enable/disable using new Style menu.
- [x] Fixes delegate invoker to also apply `Active` attribute.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/gui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/gui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

### Before

<img width="1208" height="792" alt="WindowsTerminal_wniYIxLAuo" src="https://github.com/user-attachments/assets/22a19591-9ce8-47a5-9086-1029f7f42941" />

### After

<img width="1208" height="792" alt="WindowsTerminal_MSFGFpX2T3" src="https://github.com/user-attachments/assets/9ce9f07c-0537-4fc7-971a-d9637fe1f0ae" />
