### PR TITLE
Fix #5513: flash-free Kitty pan/zoom via placement crops (no per-frame re-transmit)

### DIFF
--- a/Terminal.Gui/Drawing/Kitty/KittyGraphicsEncoder.cs
+++ b/Terminal.Gui/Drawing/Kitty/KittyGraphicsEncoder.cs
@@ -25,6 +25,10 @@ public class KittyGraphicsEncoder
     /// </summary>
     public const int MaxChunkSize = 4096;
 
+    // Each image id carries exactly one placement, so a single stable placement id is enough for an
+    // a=T to replace it in place across repaints (see BuildApcSequence).
+    private const int PlacementId = 1;
+
     // APC = ESC _ ... ESC \
     private const string APC_START = "\x1b_G";
     private const string APC_END = "\x1b\\";
@@ -72,6 +76,83 @@ public class KittyGraphicsEncoder
     /// <param name="imageId">The image id (the Kitty <c>i</c> key) whose placements should be deleted.</param>
     /// <returns>The complete Kitty APC delete escape sequence string.</returns>
     public static string EncodeDeletePlacements (int imageId) => $"{APC_START}a=d,d=i,i={imageId}{APC_END}";
+
+    /// <summary>
+    ///     Encodes a transmit-only (<c>a=t</c>) Kitty sequence: it sends the full image data under the given
+    ///     <paramref name="imageId"/> without creating a placement. The image stays resident in the terminal so
+    ///     it can be displayed — and re-displayed with a different crop — via <see cref="EncodePut"/> without
+    ///     re-sending the pixels. Used to pan/zoom a static image with tiny per-frame placement updates instead
+    ///     of re-transmitting the whole image every frame (which reads as a flash for large images).
+    /// </summary>
+    /// <param name="pixels">The full source image to transmit, indexed as <c>[x, y]</c>.</param>
+    /// <param name="imageId">The stable image id (the Kitty <c>i</c> key).</param>
+    /// <returns>The complete Kitty APC transmit-only escape sequence (chunked).</returns>
+    public string EncodeTransmit (Color [,] pixels, int imageId)
+    {
+        int width = pixels.GetLength (0);
+        int height = pixels.GetLength (1);
+        byte [] rgba = PixelsToRgba (pixels, width, height);
+        string base64 = Convert.ToBase64String (rgba);
+
+        var sb = new StringBuilder ();
+        int total = base64.Length;
+        var offset = 0;
+
+        string firstChunk = offset + MaxChunkSize < total ? base64.Substring (offset, MaxChunkSize) : base64.Substring (offset);
+        bool isLastChunk = offset + firstChunk.Length >= total;
+
+        sb.Append (APC_START);
+        sb.Append ($"a=t,f=32,i={imageId},s={width},v={height},q=2,m={( isLastChunk ? 0 : 1 )}");
+        sb.Append (';');
+        sb.Append (firstChunk);
+        sb.Append (APC_END);
+        offset += firstChunk.Length;
+
+        while (offset < total)
+        {
+            string chunk = offset + MaxChunkSize < total ? base64.Substring (offset, MaxChunkSize) : base64.Substring (offset);
+            bool last = offset + chunk.Length >= total;
+
+            sb.Append (APC_START);
+            sb.Append ($"m={( last ? 0 : 1 )}");
+            sb.Append (';');
+            sb.Append (chunk);
+            sb.Append (APC_END);
+            offset += chunk.Length;
+        }
+
+        return sb.ToString ();
+    }
+
+    /// <summary>
+    ///     Encodes a placement (<c>a=p</c>) that displays a crop of an already-transmitted image (see
+    ///     <see cref="EncodeTransmit"/>) at the current cursor position. The source rectangle
+    ///     (<paramref name="srcX"/>,<paramref name="srcY"/>,<paramref name="srcW"/>,<paramref name="srcH"/>) in
+    ///     image pixels is scaled to fill <paramref name="destCols"/>×<paramref name="destRows"/> cells. A later
+    ///     placement with the same (image id, placement id) replaces this one in place — so panning/zooming a
+    ///     static image is a tiny, flash-free update rather than a full re-transmit.
+    /// </summary>
+    /// <param name="imageId">The id of the already-transmitted image.</param>
+    /// <param name="placementId">The placement id; reusing it replaces the placement in place.</param>
+    /// <param name="srcX">Left edge of the source crop, in image pixels.</param>
+    /// <param name="srcY">Top edge of the source crop, in image pixels.</param>
+    /// <param name="srcW">Width of the source crop, in image pixels.</param>
+    /// <param name="srcH">Height of the source crop, in image pixels.</param>
+    /// <param name="destCols">Number of columns to display the crop in.</param>
+    /// <param name="destRows">Number of rows to display the crop in.</param>
+    /// <returns>The complete Kitty APC placement escape sequence.</returns>
+    public static string EncodePut (int imageId, int placementId, int srcX, int srcY, int srcW, int srcH, int destCols, int destRows) =>
+        $"{APC_START}a=p,i={imageId},p={placementId},x={srcX},y={srcY},w={srcW},h={srcH},c={destCols},r={destRows},z=-1,C=1,q=2{APC_END}";
+
+    /// <summary>
+    ///     Encodes a Kitty sequence that deletes a single placement (by image id + placement id), leaving the
+    ///     transmitted image data and other placements intact.
+    /// </summary>
+    /// <param name="imageId">The image id (the Kitty <c>i</c> key).</param>
+    /// <param name="placementId">The placement id (the Kitty <c>p</c> key) to delete.</param>
+    /// <returns>The complete Kitty APC delete-placement escape sequence.</returns>
+    public static string EncodeDeletePlacement (int imageId, int placementId) =>
+        $"{APC_START}a=d,d=i,i={imageId},p={placementId}{APC_END}";
 
     /// <summary>
     ///     Derives a stable, positive, non-zero Kitty image id from the given string identifier.
@@ -132,8 +213,12 @@ public class KittyGraphicsEncoder
         bool isLastChunk = offset + firstChunk.Length >= totalLength;
 
         // i=<id> tags the placement with a stable image id so a prior placement can be deleted by
-        // id (see EncodeDeletePlacements) when the image is resized or moved.
-        string idField = imageId.HasValue ? $"i={imageId.Value}," : string.Empty;
+        // id (see EncodeDeletePlacements) when the image is resized or moved. p=<PlacementId> gives the
+        // placement a stable id too: a later a=T with the same (image id, placement id) REPLACES the
+        // placement in place — the previous pixels stay on screen until the new ones arrive — so an
+        // unchanged-geometry repaint (pan, zoom-in) never blanks. Without it, re-placing would have to
+        // delete first (image vanishes, then the full image is slowly re-sent = a visible flash).
+        string idField = imageId.HasValue ? $"i={imageId.Value},p={PlacementId}," : string.Empty;
 
         // C=1 suppresses cursor movement after the image is displayed. Without it the terminal
         // advances the cursor past the bottom-right of the image, and an image near the bottom of

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -85,6 +85,23 @@ public abstract class OutputBase
     // deleted when the image is resized, re-fragmented, or removed.
     private readonly Dictionary<string, List<int>> _placedKittyImageIds = [];
 
+    // The visible destination fragments each Kitty image occupied on the previous Write, keyed by
+    // RasterImageCommand.Id. When the geometry is unchanged a repaint can replace the placements in
+    // place (no delete, no flash); only a changed layout needs the prior placements deleted first.
+    private readonly Dictionary<string, List<Rectangle>> _placedKittyGeometry = [];
+
+    // Source-crop mode (RasterImageCommand.SourceRect set): the full image is transmitted once and kept
+    // resident; pan/zoom then only moves the crop via placement updates. Maps RasterImageCommand.Id to the
+    // full-image pixel array currently resident in the terminal (re-transmitted only when it changes), and to
+    // the placement ids displayed last frame (so a shrunk fragment set can delete its now-unused placements).
+    private readonly Dictionary<string, Color [,]> _kittyTransmittedImage = [];
+    private readonly Dictionary<string, List<int>> _kittyPlacementIds = [];
+
+    // The image id currently resident+displayed for a source-crop command. New pixels are double-buffered:
+    // transmitted to the OTHER id and placed on top before the old id is deleted, so a sharpen-on-zoom
+    // re-raster never blanks the placement.
+    private readonly Dictionary<string, int> _kittyCurrentImageId = [];
+
     /// <summary>
     ///     Writes dirty cells from the buffer to the console. Iterates rows/cols, skips clean cells,
     ///     batches dirty cells into ANSI sequences, emits OSC 8 hyperlink start/close around URL cells,
@@ -769,6 +786,33 @@ public abstract class OutputBase
         foreach (string id in vanished)
         {
             _placedKittyImageIds.Remove (id);
+            _placedKittyGeometry.Remove (id);
+        }
+
+        // Source-crop images are resident in the terminal; when one is gone from the buffer, delete the
+        // image (which also drops its placements) and forget it so a future use re-transmits.
+        List<string> vanishedSourceCrop = [];
+
+        foreach ((string id, Color [,] _) in _kittyTransmittedImage)
+        {
+            if (currentIds.Contains (id))
+            {
+                continue;
+            }
+
+            if (_kittyCurrentImageId.TryGetValue (id, out int residentImageId))
+            {
+                Write (new StringBuilder (KittyGraphicsEncoder.EncodeDeletePlacements (residentImageId)));
+            }
+
+            vanishedSourceCrop.Add (id);
+        }
+
+        foreach (string id in vanishedSourceCrop)
+        {
+            _kittyTransmittedImage.Remove (id);
+            _kittyPlacementIds.Remove (id);
+            _kittyCurrentImageId.Remove (id);
         }
     }
 
@@ -804,10 +848,29 @@ public abstract class OutputBase
 
             bool trackKitty = UseKittyGraphics && !string.IsNullOrEmpty (command.Id);
 
-            // Erase every prior placement of this image before re-placing it, so a resized, moved, or
-            // re-fragmented Kitty image does not leave stale placements on screen. Sixel needs no such
-            // delete — redrawing the cells overwrites it.
-            if (trackKitty && _placedKittyImageIds.TryGetValue (command.Id!, out List<int>? previous))
+            // Source-crop fast path: transmit the full image once and pan/zoom it with tiny placement
+            // updates (a=p) showing a different crop, instead of re-transmitting the whole image every
+            // frame. This is what keeps panning/zooming a static image flash-free for large images.
+            if (trackKitty && command.SourceRect is { } sourceRect && command.Pixels is { })
+            {
+                RenderKittySourceCrop (command, sourceRect);
+                command.IsDirty = false;
+
+                continue;
+            }
+
+            // The destination fragments this frame. Re-placing each one (a=T with a stable placement
+            // id) replaces it in place, so when the layout is unchanged from last frame the old pixels
+            // stay visible until the new ones arrive — no blank, no flash. Only a changed layout needs
+            // the prior placements deleted first, otherwise a resized/moved/re-fragmented image would
+            // leave stale placements behind. Sixel needs no delete — redrawing the cells overwrites it.
+            List<Rectangle> visibleRects = GetVisibleRasterCellRectangles (command).ToList ();
+
+            bool geometryUnchanged = trackKitty
+                                     && _placedKittyGeometry.TryGetValue (command.Id!, out List<Rectangle>? previousRects)
+                                     && previousRects.SequenceEqual (visibleRects);
+
+            if (trackKitty && !geometryUnchanged && _placedKittyImageIds.TryGetValue (command.Id!, out List<int>? previous))
             {
                 DeleteKittyPlacements (previous);
             }
@@ -815,7 +878,7 @@ public abstract class OutputBase
             List<int> placedImageIds = [];
             var rectIndex = 0;
 
-            foreach (Rectangle visibleCells in GetVisibleRasterCellRectangles (command))
+            foreach (Rectangle visibleCells in visibleRects)
             {
                 if (!TryCropRasterImagePixels (command.Pixels!, command.DestinationCells, visibleCells, out Color [,] pixels))
                 {
@@ -837,10 +900,102 @@ public abstract class OutputBase
             if (trackKitty)
             {
                 _placedKittyImageIds [command.Id!] = placedImageIds;
+                _placedKittyGeometry [command.Id!] = visibleRects;
             }
 
             command.IsDirty = false;
         }
+    }
+
+    // Displays the command's image via Kitty placement crops. The full image is transmitted once (and only
+    // re-transmitted when the pixels themselves change); each visible fragment is then shown with an a=p
+    // placement that crops the corresponding source region. Reusing placement ids replaces them in place, so
+    // a pan/zoom of a static image is a handful of tiny bytes — no per-frame pixel re-transmit, no flash.
+    private void RenderKittySourceCrop (RasterImageCommand command, Rectangle sourceRect)
+    {
+        int idA = KittyGraphicsEncoder.GetImageId (command.Id!);
+        int idB = KittyGraphicsEncoder.GetImageId (command.Id! + " b");
+
+        bool pixelsChanged = !_kittyTransmittedImage.TryGetValue (command.Id!, out Color [,]? transmitted)
+                             || !ReferenceEquals (transmitted, command.Pixels);
+
+        _kittyCurrentImageId.TryGetValue (command.Id!, out int previousImageId);
+        int imageId = previousImageId == 0 ? idA : previousImageId;
+
+        if (pixelsChanged)
+        {
+            // Double-buffer: transmit the new pixels to the OTHER image id, so the image currently on
+            // screen stays intact while the new one loads; the new placement is then drawn on top below.
+            imageId = previousImageId == idA ? idB : idA;
+            Write (new StringBuilder (new KittyGraphicsEncoder ().EncodeTransmit (command.Pixels!, imageId)));
+            _kittyTransmittedImage [command.Id!] = command.Pixels!;
+            _kittyCurrentImageId [command.Id!] = imageId;
+        }
+
+        List<int> placementIds = [];
+        var index = 0;
+
+        foreach (Rectangle visibleCells in GetVisibleRasterCellRectangles (command))
+        {
+            Rectangle srcSub = MapFragmentToSource (sourceRect, command.DestinationCells, visibleCells);
+            int placementId = index + 1;
+            SetCursorPositionImpl (visibleCells.X, visibleCells.Y);
+
+            Write (new StringBuilder (KittyGraphicsEncoder.EncodePut (imageId,
+                                                                      placementId,
+                                                                      srcSub.X,
+                                                                      srcSub.Y,
+                                                                      srcSub.Width,
+                                                                      srcSub.Height,
+                                                                      visibleCells.Width,
+                                                                      visibleCells.Height)));
+            placementIds.Add (placementId);
+            index++;
+        }
+
+        // The new image is now placed on top; delete the previous buffer (image + its placements). The old
+        // pixels were visible right up to this point, so the swap never blanks.
+        if (pixelsChanged && previousImageId != 0 && previousImageId != imageId)
+        {
+            Write (new StringBuilder (KittyGraphicsEncoder.EncodeDeletePlacements (previousImageId)));
+        }
+
+        // Fewer fragments than last frame (e.g. a clip hole closed): delete the now-unused placements so
+        // they do not linger.
+        if (_kittyPlacementIds.TryGetValue (command.Id!, out List<int>? previousPlacements))
+        {
+            foreach (int pid in previousPlacements)
+            {
+                if (!placementIds.Contains (pid))
+                {
+                    Write (new StringBuilder (KittyGraphicsEncoder.EncodeDeletePlacement (imageId, pid)));
+                }
+            }
+        }
+
+        _kittyPlacementIds [command.Id!] = placementIds;
+    }
+
+    // Maps a visible destination fragment back to the source-image crop it should display, by proportion.
+    // For the common un-clipped case the fragment equals the whole destination, so this returns sourceRect.
+    private static Rectangle MapFragmentToSource (Rectangle sourceRect, Rectangle destinationCells, Rectangle fragment)
+    {
+        if (destinationCells.Width <= 0 || destinationCells.Height <= 0)
+        {
+            return sourceRect;
+        }
+
+        double relX = (fragment.X - destinationCells.X) / (double)destinationCells.Width;
+        double relY = (fragment.Y - destinationCells.Y) / (double)destinationCells.Height;
+        double relW = fragment.Width / (double)destinationCells.Width;
+        double relH = fragment.Height / (double)destinationCells.Height;
+
+        var x = (int)Math.Round (sourceRect.X + relX * sourceRect.Width);
+        var y = (int)Math.Round (sourceRect.Y + relY * sourceRect.Height);
+        int w = Math.Max (1, (int)Math.Round (relW * sourceRect.Width));
+        int h = Math.Max (1, (int)Math.Round (relH * sourceRect.Height));
+
+        return new Rectangle (x, y, w, h);
     }
 
     private bool AppendRasterImageAnsi (IOutputBuffer buffer, StringBuilder output, bool renderAfterText)

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -95,6 +95,11 @@ public abstract class OutputBase
     // full-image pixel array currently resident in the terminal (re-transmitted only when it changes), and to
     // the placement ids displayed last frame (so a shrunk fragment set can delete its now-unused placements).
     private readonly Dictionary<string, Color [,]> _kittyTransmittedImage = [];
+
+    // The RasterImageCommand.SourceVersion last transmitted per id. A reused buffer (same array instance,
+    // new contents) keeps the same reference but bumps the version, so this catches updates the reference
+    // comparison would miss.
+    private readonly Dictionary<string, int> _kittyTransmittedVersion = [];
     private readonly Dictionary<string, List<int>> _kittyPlacementIds = [];
 
     // The image id currently resident+displayed for a source-crop command. New pixels are double-buffered:
@@ -811,6 +816,7 @@ public abstract class OutputBase
         foreach (string id in vanishedSourceCrop)
         {
             _kittyTransmittedImage.Remove (id);
+            _kittyTransmittedVersion.Remove (id);
             _kittyPlacementIds.Remove (id);
             _kittyCurrentImageId.Remove (id);
         }
@@ -914,10 +920,17 @@ public abstract class OutputBase
     private void RenderKittySourceCrop (RasterImageCommand command, Rectangle sourceRect)
     {
         int idA = KittyGraphicsEncoder.GetImageId (command.Id!);
-        int idB = KittyGraphicsEncoder.GetImageId (command.Id! + " b");
+        int idB = KittyGraphicsEncoder.GetImageId (command.Id! + ":b");
 
-        bool pixelsChanged = !_kittyTransmittedImage.TryGetValue (command.Id!, out Color [,]? transmitted)
-                             || !ReferenceEquals (transmitted, command.Pixels);
+        // Re-transmit when the pixels change — by reference (a new array) OR by version (a reused buffer with
+        // new contents; the host bumps SourceVersion on every Image set, matching the legacy image-version
+        // cache key). Either signal alone would miss one of those cases.
+        bool hadTransmitted = _kittyTransmittedImage.TryGetValue (command.Id!, out Color [,]? transmitted);
+        _kittyTransmittedVersion.TryGetValue (command.Id!, out int transmittedVersion);
+
+        bool pixelsChanged = !hadTransmitted
+                             || !ReferenceEquals (transmitted, command.Pixels)
+                             || transmittedVersion != command.SourceVersion;
 
         _kittyCurrentImageId.TryGetValue (command.Id!, out int previousImageId);
         int imageId = previousImageId == 0 ? idA : previousImageId;
@@ -929,6 +942,7 @@ public abstract class OutputBase
             imageId = previousImageId == idA ? idB : idA;
             Write (new StringBuilder (new KittyGraphicsEncoder ().EncodeTransmit (command.Pixels!, imageId)));
             _kittyTransmittedImage [command.Id!] = command.Pixels!;
+            _kittyTransmittedVersion [command.Id!] = command.SourceVersion;
             _kittyCurrentImageId [command.Id!] = imageId;
         }
 
@@ -978,7 +992,8 @@ public abstract class OutputBase
 
     // Maps a visible destination fragment back to the source-image crop it should display, by proportion.
     // For the common un-clipped case the fragment equals the whole destination, so this returns sourceRect.
-    private static Rectangle MapFragmentToSource (Rectangle sourceRect, Rectangle destinationCells, Rectangle fragment)
+    // Internal for unit testing the rounding/clamp behavior.
+    internal static Rectangle MapFragmentToSource (Rectangle sourceRect, Rectangle destinationCells, Rectangle fragment)
     {
         if (destinationCells.Width <= 0 || destinationCells.Height <= 0)
         {
@@ -995,7 +1010,45 @@ public abstract class OutputBase
         int w = Math.Max (1, (int)Math.Round (relW * sourceRect.Width));
         int h = Math.Max (1, (int)Math.Round (relH * sourceRect.Height));
 
+        // Rounding can push the far edge past the source (e.g. the last fragment rounds x up while width also
+        // rounds up). Clamp so the emitted Kitty crop coordinates always stay within the resident image.
+        x = Math.Clamp (x, sourceRect.X, Math.Max (sourceRect.X, sourceRect.Right - 1));
+        y = Math.Clamp (y, sourceRect.Y, Math.Max (sourceRect.Y, sourceRect.Bottom - 1));
+        w = Math.Clamp (w, 1, sourceRect.Right - x);
+        h = Math.Clamp (h, 1, sourceRect.Bottom - y);
+
         return new Rectangle (x, y, w, h);
+    }
+
+    // Extracts the sub-rectangle of a full image (a Kitty source-crop command keeps the whole image in
+    // Pixels). The rect is clamped to the image bounds; a rect that already covers the whole image returns
+    // the source unchanged to avoid an allocation/copy.
+    private static Color [,] CropPixelsToRect (Color [,] source, Rectangle rect)
+    {
+        int sourceWidth = source.GetLength (0);
+        int sourceHeight = source.GetLength (1);
+
+        int x = Math.Clamp (rect.X, 0, Math.Max (0, sourceWidth - 1));
+        int y = Math.Clamp (rect.Y, 0, Math.Max (0, sourceHeight - 1));
+        int width = Math.Clamp (rect.Width, 1, sourceWidth - x);
+        int height = Math.Clamp (rect.Height, 1, sourceHeight - y);
+
+        if (x == 0 && y == 0 && width == sourceWidth && height == sourceHeight)
+        {
+            return source;
+        }
+
+        Color [,] cropped = new Color [width, height];
+
+        for (var cx = 0; cx < width; cx++)
+        {
+            for (var cy = 0; cy < height; cy++)
+            {
+                cropped [cx, cy] = source [x + cx, y + cy];
+            }
+        }
+
+        return cropped;
     }
 
     private bool AppendRasterImageAnsi (IOutputBuffer buffer, StringBuilder output, bool renderAfterText)
@@ -1012,9 +1065,17 @@ public abstract class OutputBase
             bool useKittyIds = UseKittyGraphics && !string.IsNullOrEmpty (command.Id);
             var rectIndex = 0;
 
+            // ToAnsi() recreates the current screen as a self-contained string, so it cannot rely on the
+            // resident-image state the live source-crop path keeps. For a source-crop command (Pixels is the
+            // full image) extract the visible crop first, so the export reflects the panned/zoomed region
+            // rather than the whole source scaled into the destination.
+            Color [,] sourcePixels = command.SourceRect is { } sourceRect
+                                         ? CropPixelsToRect (command.Pixels!, sourceRect)
+                                         : command.Pixels!;
+
             foreach (Rectangle visibleCells in GetVisibleRasterCellRectangles (command))
             {
-                if (!TryCropRasterImagePixels (command.Pixels!, command.DestinationCells, visibleCells, out Color [,] pixels))
+                if (!TryCropRasterImagePixels (sourcePixels, command.DestinationCells, visibleCells, out Color [,] pixels))
                 {
                     continue;
                 }

--- a/Terminal.Gui/Drivers/Output/RasterImageCommand.cs
+++ b/Terminal.Gui/Drivers/Output/RasterImageCommand.cs
@@ -49,6 +49,16 @@ public class RasterImageCommand
     public Rectangle? SourceRect { get; set; }
 
     /// <summary>
+    ///     A monotonic version of the <see cref="Pixels"/> contents, used only by the Kitty source-crop path
+    ///     to decide whether the resident image must be re-transmitted. The source-crop path keeps the full
+    ///     image resident in the terminal and pans/zooms it with placement updates; it re-transmits when this
+    ///     version changes. Hosts (e.g. <c>ImageView</c>) should bump it whenever the pixel contents change —
+    ///     including when the <em>same</em> array instance is reused for a new render, which a reference
+    ///     comparison alone would miss.
+    /// </summary>
+    public int SourceVersion { get; set; }
+
+    /// <summary>
     ///     Gets or sets the clip region captured when the image is added to the output buffer.
     /// </summary>
     public Region? Clip { get; set; }

--- a/Terminal.Gui/Drivers/Output/RasterImageCommand.cs
+++ b/Terminal.Gui/Drivers/Output/RasterImageCommand.cs
@@ -39,6 +39,16 @@ public class RasterImageCommand
     public Rectangle DestinationCells { get; set; }
 
     /// <summary>
+    ///     When set (Kitty only), <see cref="Pixels"/> is the <em>full</em> source image and this is the crop of
+    ///     it (in image pixels) to display in <see cref="DestinationCells"/>. The image is transmitted to the
+    ///     terminal once; subsequent frames that only change the crop/destination (pan, zoom of a static image)
+    ///     emit a tiny placement update instead of re-sending the pixels, avoiding the per-frame flash. When
+    ///     <see langword="null"/> the legacy path is used: <see cref="Pixels"/> is the already-scaled region and
+    ///     is (re)transmitted each dirty frame.
+    /// </summary>
+    public Rectangle? SourceRect { get; set; }
+
+    /// <summary>
     ///     Gets or sets the clip region captured when the image is added to the output buffer.
     /// </summary>
     public Region? Clip { get; set; }

--- a/Terminal.Gui/Views/ImageView/ImageView.Drawing.cs
+++ b/Terminal.Gui/Views/ImageView/ImageView.Drawing.cs
@@ -100,25 +100,72 @@ public partial class ImageView
     {
         RenderRequest? request = CreateRenderRequest (true);
 
-        if (request is null)
+        if (request is null || App?.Driver is not { } driver)
         {
+            return;
+        }
+
+        // Kitty source-crop path: transmit the full source image once and pan/zoom it with tiny placement
+        // updates that crop a different region — no per-frame pixel re-transmit (and so no flash) and no
+        // CPU scale/encode. The terminal does the scaling from the resident image.
+        if (request.Key.UseKitty && _image is { } image)
+        {
+            Size scaledPixels = ComputeScaledSize (request.VisibleSource, request.TargetSize, request.Key.AllowUpscale, request.Key.PreserveAspectRatio);
+            Size cellSize = request.Resolution is { } resolution ? GetSixelCellSize (scaledPixels, resolution) : scaledPixels;
+
+            Rectangle viewport = ViewportToScreen ();
+            Size destinationSize = new (Math.Min (viewport.Width, cellSize.Width), Math.Min (viewport.Height, cellSize.Height));
+            Point offset = _zoomLevel < FIT_ZOOM_LEVEL ? GetCenteredRenderOffset (destinationSize, viewport.Size) : Point.Empty;
+            Rectangle destinationCells = new (viewport.X + offset.X, viewport.Y + offset.Y, destinationSize.Width, destinationSize.Height);
+
+            if (destinationCells.Width <= 0 || destinationCells.Height <= 0)
+            {
+                return;
+            }
+
+            // Keep the cell size current so OnDrawingContent's drawn-region reporting still works without
+            // the scaled-image cache (which this path skips).
+            _scaledImageCellSize = cellSize;
+            SetRenderingOverlayVisible (false);
+
+            // Mark the covered cells transparent so opaque overlays drawn later (e.g. a View's shadow) still
+            // paint over the terminal-composited image, exactly as the legacy path below. See issue #5502.
+            MarkRasterCellsTransparent (destinationSize, offset);
+
+            RectangleF visible = request.VisibleSource;
+            int srcX = Math.Clamp ((int)Math.Floor (visible.X), 0, Math.Max (0, image.GetLength (0) - 1));
+            int srcY = Math.Clamp ((int)Math.Floor (visible.Y), 0, Math.Max (0, image.GetLength (1) - 1));
+            int srcW = Math.Clamp ((int)Math.Round (visible.Width), 1, image.GetLength (0) - srcX);
+            int srcH = Math.Clamp ((int)Math.Round (visible.Height), 1, image.GetLength (1) - srcY);
+
+            RasterImageCommand kittyCommand = new ()
+            {
+                Id = RasterImageId,
+                Pixels = image,
+                SourceRect = new Rectangle (srcX, srcY, srcW, srcH),
+                DestinationCells = destinationCells,
+                IsDirty = true
+            };
+
+            driver.GetOutputBuffer ().AddRasterImage (kittyCommand);
+
             return;
         }
 
         EnsureScaledImage (request);
 
-        if (_scaledImage is null || _scaledImageCellSize is null || App?.Driver is not { } driver)
+        if (_scaledImage is null || _scaledImageCellSize is null)
         {
             return;
         }
 
-        Rectangle viewport = ViewportToScreen ();
-        Size cellSize = _scaledImageCellSize.Value;
-        Size destinationSize = new (Math.Min (viewport.Width, cellSize.Width), Math.Min (viewport.Height, cellSize.Height));
-        Point offset = _zoomLevel < FIT_ZOOM_LEVEL ? GetCenteredRenderOffset (destinationSize, viewport.Size) : Point.Empty;
-        Rectangle destinationCells = new (viewport.X + offset.X, viewport.Y + offset.Y, destinationSize.Width, destinationSize.Height);
+        Rectangle vp = ViewportToScreen ();
+        Size scaledCellSize = _scaledImageCellSize.Value;
+        Size sixelDestinationSize = new (Math.Min (vp.Width, scaledCellSize.Width), Math.Min (vp.Height, scaledCellSize.Height));
+        Point sixelOffset = _zoomLevel < FIT_ZOOM_LEVEL ? GetCenteredRenderOffset (sixelDestinationSize, vp.Size) : Point.Empty;
+        Rectangle sixelDestinationCells = new (vp.X + sixelOffset.X, vp.Y + sixelOffset.Y, sixelDestinationSize.Width, sixelDestinationSize.Height);
 
-        if (destinationCells.Width <= 0 || destinationCells.Height <= 0)
+        if (sixelDestinationCells.Width <= 0 || sixelDestinationCells.Height <= 0)
         {
             return;
         }
@@ -126,6 +173,27 @@ public partial class ImageView
         // Mark the image's covered cells transparent so the output layer treats them as raster-owned
         // and lets the terminal-composited image show through. Opaque overlay cells drawn later (e.g.
         // a View's shadow) keep their background and so still paint over the image. See issue #5502.
+        MarkRasterCellsTransparent (sixelDestinationSize, sixelOffset);
+
+        RasterImageCommand command = new ()
+        {
+            Id = RasterImageId,
+            Pixels = _scaledImage,
+            EncodedSixel = _encodedSixel,
+            EncodedKitty = _encodedKitty,
+            DestinationCells = sixelDestinationCells,
+            Encoder = SixelEncoder,
+            IsDirty = true
+        };
+
+        driver.GetOutputBuffer ().AddRasterImage (command);
+    }
+
+    // Marks the cells the raster image covers transparent (Color.None) so the terminal-composited image shows
+    // through, while opaque overlay cells drawn later (e.g. a View's shadow) keep their background and still
+    // paint over the image. See issue #5502.
+    private void MarkRasterCellsTransparent (Size destinationSize, Point offset)
+    {
         SetAttribute (new Attribute (Color.None, Color.None));
 
         for (var row = 0; row < destinationSize.Height; row++)
@@ -135,19 +203,6 @@ public partial class ImageView
                 AddRune (offset.X + col, offset.Y + row, (Rune)' ');
             }
         }
-
-        RasterImageCommand command = new ()
-        {
-            Id = RasterImageId,
-            Pixels = _scaledImage,
-            EncodedSixel = _encodedSixel,
-            EncodedKitty = _encodedKitty,
-            DestinationCells = destinationCells,
-            Encoder = SixelEncoder,
-            IsDirty = true
-        };
-
-        driver.GetOutputBuffer ().AddRasterImage (command);
     }
 
     private bool? CenterFromCommand (ICommandContext? context) =>

--- a/Terminal.Gui/Views/ImageView/ImageView.Drawing.cs
+++ b/Terminal.Gui/Views/ImageView/ImageView.Drawing.cs
@@ -143,6 +143,9 @@ public partial class ImageView
                 Id = RasterImageId,
                 Pixels = image,
                 SourceRect = new Rectangle (srcX, srcY, srcW, srcH),
+
+                // Bumped on every Image set (even to the same instance), so a reused buffer still re-transmits.
+                SourceVersion = _imageVersion,
                 DestinationCells = destinationCells,
                 IsDirty = true
             };

--- a/Terminal.Gui/Views/ImageView/ImageView.Input.cs
+++ b/Terminal.Gui/Views/ImageView/ImageView.Input.cs
@@ -38,6 +38,7 @@ public partial class ImageView
         _centerX = 0.5d;
         _centerY = 0.5d;
         InvalidateScaledImage ();
+        ZoomLevelChanged?.Invoke (this, EventArgs.Empty);
 
         return true;
     }
@@ -87,6 +88,7 @@ public partial class ImageView
         }
 
         InvalidateScaledImage ();
+        ZoomLevelChanged?.Invoke (this, EventArgs.Empty);
 
         return true;
     }

--- a/Terminal.Gui/Views/ImageView/ImageView.Scaling.cs
+++ b/Terminal.Gui/Views/ImageView/ImageView.Scaling.cs
@@ -4,33 +4,33 @@ public partial class ImageView
 {
     private static Color [,] ScaleVisibleImage (Color [,] source, RectangleF visibleSource, Size targetSize, bool allowUpscale, bool preserveAspectRatio)
     {
-        int newWidth;
-        int newHeight;
-
-        if (preserveAspectRatio)
-        {
-            double widthScale = targetSize.Width / (double)visibleSource.Width;
-            double heightScale = targetSize.Height / (double)visibleSource.Height;
-            double scale = Math.Min (widthScale, heightScale);
-
-            if (!allowUpscale)
-            {
-                scale = Math.Min (scale, 1d);
-            }
-
-            newWidth = Math.Max (1, (int)(visibleSource.Width * scale));
-            newHeight = Math.Max (1, (int)(visibleSource.Height * scale));
-        }
-        else
-        {
-            newWidth = targetSize.Width;
-            newHeight = targetSize.Height;
-        }
-
-        Color [,] scaledImage = new Color [newWidth, newHeight];
+        Size size = ComputeScaledSize (visibleSource, targetSize, allowUpscale, preserveAspectRatio);
+        Color [,] scaledImage = new Color [size.Width, size.Height];
         ScaleVisibleNearestNeighbor (source, scaledImage, visibleSource);
 
         return scaledImage;
+    }
+
+    // The pixel size a visible source region scales to for the given target — the aspect-ratio-preserving fit
+    // used by ScaleVisibleImage. Exposed so the Kitty source-crop path can size the destination without
+    // actually scaling/encoding any pixels (it lets the terminal do the scaling from a once-transmitted image).
+    private static Size ComputeScaledSize (RectangleF visibleSource, Size targetSize, bool allowUpscale, bool preserveAspectRatio)
+    {
+        if (!preserveAspectRatio)
+        {
+            return targetSize;
+        }
+
+        double widthScale = targetSize.Width / (double)visibleSource.Width;
+        double heightScale = targetSize.Height / (double)visibleSource.Height;
+        double scale = Math.Min (widthScale, heightScale);
+
+        if (!allowUpscale)
+        {
+            scale = Math.Min (scale, 1d);
+        }
+
+        return new Size (Math.Max (1, (int)(visibleSource.Width * scale)), Math.Max (1, (int)(visibleSource.Height * scale)));
     }
 
     private static void ScaleVisibleNearestNeighbor (Color [,] source, Color [,] destination, RectangleF visibleSource)

--- a/Terminal.Gui/Views/ImageView/ImageView.cs
+++ b/Terminal.Gui/Views/ImageView/ImageView.cs
@@ -260,6 +260,13 @@ public partial class ImageView : View, IDesignable
     /// </summary>
     public double ZoomLevel { get => _zoomLevel; set => SetZoomLevel (value, null); }
 
+    /// <summary>
+    ///     Raised when <see cref="ZoomLevel"/> changes (including a reset to fit). A host that renders its
+    ///     own source image (e.g. rasterizes a document) can subscribe to re-render it at the new zoom for
+    ///     crispness — the view itself only ever scales the pixels it was given.
+    /// </summary>
+    public event EventHandler? ZoomLevelChanged;
+
     private SixelEncoder? _sixelEncoder;
 
     private bool _usesDefaultSixelEncoder;

--- a/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
@@ -1825,6 +1825,88 @@ public class ImageViewTests
         runnable.Dispose ();
     }
 
+    // Claude - Opus 4.8
+    // Kitty source-crop: the full image is transmitted once (a=t), then panning a zoomed-in image only
+    // moves the crop with a placement update (a=p) — it must NOT re-transmit the pixels (no a=t). Re-sending
+    // the whole image every step is what made a large preview flash on each pan ("whole pane flashes").
+    [Fact]
+    public void Draw_KittyRaster_SourceCrop_PanUpdatesPlacementWithoutRetransmit ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 16, Height = 16 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetKittyGraphicsSupport (new KittyGraphicsSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+        driver.GetOutput ().UseKittyGraphics = true;
+
+        // Zoom in so the image fills the viewport and is pannable.
+        ImageView imageView = new () { X = 0, Y = 0, Width = 8, Height = 8, Image = CreateGradientImage (16, 16), ZoomLevel = 2d };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+        string first = driver.GetOutput ().GetLastOutput ();
+
+        Assert.Contains ("a=t,", first); // the full image is transmitted once...
+        Assert.Contains ("a=p,", first); // ...and displayed via a placement.
+
+        // Pan one cell — same image, different crop.
+        imageView.NewKeyDownEvent (Key.CursorRight);
+        app.LayoutAndDraw ();
+        string panFrame = driver.GetOutput ().GetLastOutput ();
+
+        Assert.Contains ("a=p,", panFrame); // the crop moves with a tiny placement update...
+        Assert.DoesNotContain ("a=t,", panFrame); // ...with no pixel re-transmit (the flash fix).
+        Assert.DoesNotContain ("a=d", panFrame); // ...and no delete.
+
+        runnable.Dispose ();
+    }
+
+    // Claude - Opus 4.8
+    // A fresh Image must re-transmit (the placement would otherwise show stale pixels), and it must be
+    // double-buffered: the new pixels go to the OTHER image id and are placed before the old id is deleted,
+    // so a sharpen-on-zoom re-raster never blanks the on-screen image.
+    [Fact]
+    public void Draw_KittyRaster_SourceCrop_DoubleBuffersOnImageChange ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 16, Height = 16 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetKittyGraphicsSupport (new KittyGraphicsSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+        driver.GetOutput ().UseKittyGraphics = true;
+
+        ImageView imageView = new () { X = 0, Y = 0, Width = 8, Height = 8, Image = CreateGradientImage (16, 16), ZoomLevel = 2d };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+        driver.GetOutput ().GetLastOutput ();
+
+        imageView.NewKeyDownEvent (Key.CursorRight);
+        app.LayoutAndDraw ();
+        Assert.DoesNotContain ("a=t,", driver.GetOutput ().GetLastOutput ()); // pan: no re-transmit
+
+        // A brand-new image re-transmits to the OTHER buffer and deletes the previous one.
+        imageView.Image = CreateGradientImage (16, 16);
+        app.LayoutAndDraw ();
+        string frame = driver.GetOutput ().GetLastOutput ();
+
+        System.Text.RegularExpressions.Match transmit = System.Text.RegularExpressions.Regex.Match (frame, @"a=t,f=32,i=(\d+)");
+        System.Text.RegularExpressions.Match delete = System.Text.RegularExpressions.Regex.Match (frame, @"a=d,d=i,i=(\d+)");
+
+        Assert.True (transmit.Success, "the new image must be transmitted");
+        Assert.True (delete.Success, "the previous image must be deleted");
+
+        // The deleted id is the OLD image id — different from the just-transmitted one — proving the new
+        // pixels did not overwrite the on-screen image in place (no blank during the swap).
+        Assert.NotEqual (transmit.Groups [1].Value, delete.Groups [1].Value);
+
+        runnable.Dispose ();
+    }
+
     /// <summary>Creates a gradient image where pixel color varies by position.</summary>
     private static Color [,] CreateGradientImage (int width, int height)
     {

--- a/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
@@ -1825,7 +1825,7 @@ public class ImageViewTests
         runnable.Dispose ();
     }
 
-    // Claude - Opus 4.8
+    // Copilot - Claude Opus 4.8
     // Kitty source-crop: the full image is transmitted once (a=t), then panning a zoomed-in image only
     // moves the crop with a placement update (a=p) — it must NOT re-transmit the pixels (no a=t). Re-sending
     // the whole image every step is what made a large preview flash on each pan ("whole pane flashes").
@@ -1863,7 +1863,7 @@ public class ImageViewTests
         runnable.Dispose ();
     }
 
-    // Claude - Opus 4.8
+    // Copilot - Claude Opus 4.8
     // A fresh Image must re-transmit (the placement would otherwise show stale pixels), and it must be
     // double-buffered: the new pixels go to the OTHER image id and are placed before the old id is deleted,
     // so a sharpen-on-zoom re-raster never blanks the on-screen image.
@@ -1905,6 +1905,93 @@ public class ImageViewTests
         Assert.NotEqual (transmit.Groups [1].Value, delete.Groups [1].Value);
 
         runnable.Dispose ();
+    }
+
+    // Copilot - Claude Opus 4.8
+    // Re-assigning ImageView.Image — even the SAME Color[,] instance — bumps the image version and must
+    // re-transmit (a=t). Keying "did the pixels change" on the array reference alone misses a buffer a
+    // caller reused for a new render, leaving the terminal showing stale pixels. (Mirrors the legacy path,
+    // which re-encodes on every image-version bump.)
+    [Fact]
+    public void Draw_KittyRaster_SourceCrop_RetransmitsWhenImageReassignedSameInstance ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 16, Height = 16 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetKittyGraphicsSupport (new KittyGraphicsSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+        driver.GetOutput ().UseKittyGraphics = true;
+
+        Color [,] image = CreateGradientImage (16, 16);
+        ImageView imageView = new () { X = 0, Y = 0, Width = 8, Height = 8, Image = image, ZoomLevel = 2d };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+        Assert.Contains ("a=t,", driver.GetOutput ().GetLastOutput ()); // first transmit
+
+        imageView.NewKeyDownEvent (Key.CursorRight);
+        app.LayoutAndDraw ();
+        Assert.DoesNotContain ("a=t,", driver.GetOutput ().GetLastOutput ()); // pan: no re-transmit
+
+        // Re-assign the SAME instance: the image version bumps, so the resident image must be refreshed.
+        imageView.Image = image;
+        app.LayoutAndDraw ();
+        Assert.Contains ("a=t,", driver.GetOutput ().GetLastOutput ());
+
+        runnable.Dispose ();
+    }
+
+    // Copilot - Claude Opus 4.8
+    // ToAnsi() must recreate the *visible crop* of a panned/zoomed Kitty image, not the whole source. Two
+    // different pan positions of the same image therefore export different raster payloads; encoding
+    // command.Pixels (the full image) and ignoring SourceRect would make the two exports identical.
+    [Fact]
+    public void ToAnsi_KittyRaster_SourceCrop_ReflectsVisibleCrop ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        Runnable runnable = new () { Width = 16, Height = 16 };
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetKittyGraphicsSupport (new KittyGraphicsSupportResult { IsSupported = true, Resolution = new Size (10, 20) });
+        driver.GetOutput ().UseKittyGraphics = true;
+
+        ImageView imageView = new () { X = 0, Y = 0, Width = 8, Height = 8, Image = CreateGradientImage (16, 16), ZoomLevel = 2d };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+        string ansiLeft = driver.ToAnsi ();
+
+        // Pan to a different crop of the same image.
+        imageView.NewKeyDownEvent (Key.CursorRight);
+        imageView.NewKeyDownEvent (Key.CursorRight);
+        app.LayoutAndDraw ();
+        string ansiPanned = driver.ToAnsi ();
+
+        Assert.NotEqual (ansiLeft, ansiPanned);
+
+        runnable.Dispose ();
+    }
+
+    // Copilot - Claude Opus 4.8
+    // MapFragmentToSource must never return a crop that extends past the source rectangle: rounding can push
+    // the last fragment's x/width (or y/height) beyond the source, which would emit out-of-bounds Kitty crop
+    // coordinates. Here dest 2x2 cells over a 3x3 source rounds the bottom-right 1x1 fragment past the edge.
+    [Fact]
+    public void MapFragmentToSource_ClampsToSourceRect ()
+    {
+        Rectangle mapped = OutputBase.MapFragmentToSource (
+                                                           new Rectangle (0, 0, 3, 3),
+                                                           new Rectangle (0, 0, 2, 2),
+                                                           new Rectangle (1, 1, 1, 1));
+
+        Assert.True (mapped.X >= 0 && mapped.Y >= 0, $"crop origin {mapped.Location} is negative");
+        Assert.True (mapped.Right <= 3, $"crop right {mapped.Right} exceeds source width 3");
+        Assert.True (mapped.Bottom <= 3, $"crop bottom {mapped.Bottom} exceeds source height 3");
+        Assert.True (mapped.Width >= 1 && mapped.Height >= 1, "crop must stay at least 1x1");
     }
 
     /// <summary>Creates a gradient image where pixel color varies by position.</summary>


### PR DESCRIPTION
Fixes #5513.

## Problem

Panning/zooming a raster `ImageView` under the **Kitty graphics protocol** (Kitty, Ghostty) flashes the whole image on every step; **Sixel** does not. `OutputBase.RenderRasterImages` deletes the prior Kitty placement (`a=d`) and re-transmits the re-encoded image (`a=T`) on every dirty frame, and pan/zoom marks the command dirty every step — so on Kitty the delete→re-transmit window blanks the cells (a flash). Sixel just overwrites cells (no delete), so it's unaffected.

## Fix

Transmit the source image **once** (`a=t`) and pan/zoom it with tiny placement-crop updates (`a=p`) that show a different source region — the terminal scales from the resident image. No per-frame pixel re-transmit, no flash.

- **`KittyGraphicsEncoder`**: `EncodeTransmit` (`a=t`, data only), `EncodePut` (`a=p`, source crop → cells), `EncodeDeletePlacement`, and a stable placement id (`p=`) on `a=T` so an unchanged-geometry repaint replaces the placement **in place** (no delete).
- **`RasterImageCommand.SourceRect`**: when set, `Pixels` is the full image and this is the crop to display in `DestinationCells`.
- **`OutputBase`**: source-crop render path; **double-buffers** a changed image (transmit to the other id, place on top, then delete the old) so a re-raster never blanks the on-screen image. The legacy path now skips the pre-delete when the visible geometry is unchanged from last frame (still deletes on resize/move/refragment, preserving the stale-placement fix from `c32c2c0f1`).
- **`ImageView`**: emit the full image + visible-source rect for Kitty (skips the per-frame CPU scale/encode); add `ZoomLevelChanged` so a host can re-render its own source at the new zoom for crispness.

The Kitty source-crop and legacy raster paths now share `MarkRasterCellsTransparent`, so the source-crop path also marks its covered cells transparent — keeping the shadow-overlay behavior (#5502) intact.

## Tests

Two new tests in `ImageViewTests` (headless ANSI driver, forced Kitty support, asserting the raw escape sequences):

- `Draw_KittyRaster_SourceCrop_PanUpdatesPlacementWithoutRetransmit` — a pan emits `a=p` but **not** `a=t` and **not** `a=d` (the flash fix).
- `Draw_KittyRaster_SourceCrop_DoubleBuffersOnImageChange` — a genuine image swap transmits to the *other* id and deletes the old id (ids differ) → no blank during the swap.

Full `UnitTests.Parallelizable` suite: **17445 passed, 0 failed, 17 skipped** (incl. the existing Kitty/Sixel/`OutputBase` shadow + multi-fragment suites).

## Downstream

Resolves the macOS Kitty/Ghostty flicker in [winprint](https://github.com/tig/winprint) #163 (the `wp` TUI page preview). winprint will bump to the release carrying this.