### PR TITLE
Fix #5518: Padding adornment fills with stale attribute when parent skips ClearViewport (#5358)

### DIFF
--- a/Terminal.Gui/ViewBase/View.Drawing.Adornments.cs
+++ b/Terminal.Gui/ViewBase/View.Drawing.Adornments.cs
@@ -218,6 +218,12 @@ public partial class View
             }
             else if (Padding.Thickness != Thickness.Empty)
             {
+                // Thickness.Draw fills via the driver's CurrentAttribute and does not set one itself, so
+                // set the view's Normal here. Otherwise the padding inherits whatever attribute was last
+                // used — which is stale (e.g. a sibling raster view's Color.None) when the parent skipped
+                // its ClearViewport on a child-only redraw, bleeding foreign content into the padding
+                // column. (gui-cs/Terminal.Gui#5518.)
+                SetAttributeForRole (VisualRole.Normal);
                 Padding.Thickness.Draw (Driver, Padding.FrameToScreen (), Padding.Diagnostics);
                 Padding.LastDrawnRegion = null;
             }

--- a/Tests/UnitTestsParallelizable/Views/ImageViewNeighbourPaddingTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ImageViewNeighbourPaddingTests.cs
@@ -1,0 +1,86 @@
+namespace ViewsTests;
+
+/// <summary>
+///     Regression for gui-cs/Terminal.Gui#5518.
+///     <para>
+///         A raster <see cref="ImageView"/> placed at <see cref="Pos.Right"/> of a view that has a right
+///         <see cref="Adornment"/> padding column overwrites that padding column — the cell one to the
+///         LEFT of the ImageView's frame — when it redraws. The full first draw repaints the neighbour so
+///         it looks correct; a <em>partial</em> redraw (a focus round-trip here) leaves the overwrite
+///         behind, bleeding the image pane's background into the neighbour.
+///     </para>
+///     <para>
+///         Surfaced in winprint (gui-cs/Terminal.Gui#5518) as the page-preview pane bleeding its canvas
+///         colour into the settings panel's seam, on both Sixel and Kitty. It is not actually
+///         raster-specific — a plain <see cref="View"/> at <see cref="Pos.Right"/> reproduces it too — so
+///         the fix most likely belongs in the View draw/clip path, not the raster code.
+///     </para>
+/// </summary>
+public class ImageViewNeighbourPaddingTests
+{
+    [Fact]
+    public void Draw_RightOfPaddedNeighbour_DoesNotOverwriteNeighboursPaddingColumn ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (40, 12);
+
+        Runnable runnable = new () { Width = 40, Height = 12 };
+        runnable.SetScheme (new Scheme { Normal = new Attribute (new Color (255, 255, 255), new Color (26, 26, 26)) });
+        app.Begin (runnable);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new SixelSupportResult { IsSupported = true, Resolution = new Size (9, 20), MaxPaletteColors = 256 });
+
+        // Left pane with a one-column right Padding — that padding column is the "seam".
+        View left = new () { X = 0, Y = 0, Width = 10, Height = Dim.Fill (), CanFocus = true };
+        left.Padding!.Thickness = new Thickness (0, 0, 1, 0);
+        left.SetScheme (new Scheme { Normal = new Attribute (new Color (255, 255, 255), new Color (200, 0, 0)) });
+
+        // Raster ImageView immediately to the right of the seam.
+        Color gray = new (224, 224, 224);
+        ImageView img = new () { X = Pos.Right (left), Y = 0, Width = Dim.Fill (), Height = Dim.Fill (), CanFocus = true };
+        img.SetScheme (new Scheme { Normal = new Attribute (new Color (0, 0, 0), gray) });
+        img.Image = CreateSolidImage (90, 200, gray);
+
+        // ImageView added first, neighbour on top: the full first draw repaints the seam correctly.
+        runnable.Add (img, left);
+
+        img.SetFocus ();
+        app.LayoutAndDraw ();
+        app.LayoutAndDraw ();
+
+        int seam = img.ViewportToScreen ().X - 1; // the neighbour's padding column, outside the image frame
+        int row = img.ViewportToScreen ().Y + 2;
+
+        Attribute? before = driver.GetOutputBuffer ().Contents! [row, seam].Attribute;
+
+        // Partial redraw: focus the neighbour, then focus back to the image.
+        left.SetFocus ();
+        app.LayoutAndDraw ();
+        img.SetFocus ();
+        app.LayoutAndDraw ();
+
+        Attribute? after = driver.GetOutputBuffer ().Contents! [row, seam].Attribute;
+
+        // The ImageView must not have changed a cell outside (to the left of) its own frame.
+        Assert.Equal (before, after);
+
+        runnable.Dispose ();
+    }
+
+    private static Color [,] CreateSolidImage (int width, int height, Color color)
+    {
+        Color [,] image = new Color [width, height];
+
+        for (var x = 0; x < width; x++)
+        {
+            for (var y = 0; y < height; y++)
+            {
+                image [x, y] = color;
+            }
+        }
+
+        return image;
+    }
+}


### PR DESCRIPTION
Fixes #5518.

## Symptom
A view with a right `Padding` next to a raster `ImageView` (winprint's settings panel ↔ page preview) shows the image pane's background bleeding into the padding "seam" column after a partial (focus) redraw — on **both Sixel and Kitty**, so not encoder-specific. In fact it isn't ImageView-specific at all: a plain `View` reproduces it.

## Root cause
`Thickness.Draw` fills an adornment via `driver.CurrentAttribute` and **never sets an attribute itself** — it relies on the caller having set one. The parent's `ClearViewport` → `SetAttributeForRole` used to set `CurrentAttribute` to the parent's background right before adornments drew.

Since **#5358 (`584c02526`)** the parent **skips `ClearViewport` on a child-only redraw** (the intended fan-out optimization). So on a partial redraw the `Padding` adornment inherits a **stale `CurrentAttribute`** — `Color.None` left behind by a sibling raster `ImageView`'s transparent-marking (or the sibling's background for a plain `View`) — and fills the padding column with it. Driver-level tracing pinned the writer exactly:

```
WRITE r2c9 attr=[None,None,None] via:
   OutputBufferImpl.FillRect
   Thickness.Draw          ← the neighbour's Padding adornment
   View.DrawAdornments
```

(Bisect: passes at `584c02526^`, fails from `584c02526` on.)

## Fix
Set the view's `Normal` attribute before the no-subview `Padding.Thickness.Draw`, so the fill is deterministic regardless of prior draw state. It does **not** touch the #5358 clear optimization, so the fan-out tests keep passing.

The same latent pattern exists for `Margin`/`Border` `Thickness.Draw` (they also fill with the ambient attribute); I scoped this PR to the demonstrated `Padding` case and left those, since their "correct" attribute differs (border scheme, transparent margin) and no repro exercises them.

## Validation
- New regression test `ImageViewNeighbourPaddingTests` (fails before, passes after).
- **UnitTestsParallelizable: 17449 / 0 failed.** UnitTests.NonParallelizable: 74 / 0 failed. The fan-out / clipping tests that the naive "always clear" approach broke (`SubViewOnlyRedrawTests`, `TabsFanOutDiagnosticTests`, `ViewDrawingClippingTests`, `BorderArrangementTests`) all stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
