### PR TITLE
fix(input): decode raw 0x08 (BS) as Backspace, not Ctrl+Backspace

### DIFF
--- a/Terminal.Gui/Drivers/AnsiHandling/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/EscSeqUtils/EscSeqUtils.cs
@@ -403,11 +403,16 @@ public static class EscSeqUtils
                 {
                     key = ConsoleKey.Backspace;
 
+                    // BS (0x08) is the legacy Backspace code (some terminals/configs send it for the
+                    // Backspace key instead of DEL 0x7F). Honor the real Control state here — do NOT
+                    // force it on. Forcing Control turned a plain Backspace into Ctrl+Backspace, which
+                    // editors bind to "delete word", so one keypress wiped the whole word. Mirrors the
+                    // DEL (127) branch below. (gui-cs/Terminal.Gui)
                     newConsoleKeyInfo = new ConsoleKeyInfo (consoleKeyInfo.KeyChar,
                                                             key,
                                                             (consoleKeyInfo.Modifiers & ConsoleModifiers.Shift) != 0,
                                                             (consoleKeyInfo.Modifiers & ConsoleModifiers.Alt) != 0,
-                                                            true);
+                                                            (consoleKeyInfo.Modifiers & ConsoleModifiers.Control) != 0);
                 }
                 else if (consoleKeyInfo.Key == 0)
                 {

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/EscSeqUtilsTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/EscSeqUtilsTests.cs
@@ -80,6 +80,12 @@ public class EscSeqUtilsTests
         cki = new ('R', 0, false, false, false);
         expectedCki = new ('R', ConsoleKey.R, true, false, false);
         Assert.Equal (expectedCki.ToString(), EscSeqUtils.MapConsoleKeyInfo(cki).ToString());
+
+        // BS (0x08) maps to Backspace WITHOUT a forced Control modifier (regression: it used to
+        // become Ctrl+Backspace, which editors treat as delete-word). Matches the DEL (0x7F) case.
+        cki = new ('\b', 0, false, false, false);
+        expectedCki = new ('\b', ConsoleKey.Backspace, false, false, false);
+        Assert.Equal (expectedCki.ToString(), EscSeqUtils.MapConsoleKeyInfo(cki).ToString());
     }
 
     [Theory]


### PR DESCRIPTION
## Fixes #5521

Raw `0x08` (BS / Ctrl+H) on the ANSI input path was decoded as **Ctrl+Backspace** because the `'\b'` branch in `EscSeqUtils.MapConsoleKeyInfo` hard-coded the `ConsoleKeyInfo` `control` argument to `true`. Editors bind Ctrl+Backspace to *delete-word*, so on terminals/configs that send `0x08` for the Backspace key (rather than `0x7F`/DEL) a single Backspace press deleted the whole preceding word — easily mistaken for a select-all-and-delete.

## Change

One line in `EscSeqUtils.MapConsoleKeyInfo`: derive the Control flag from the real modifier state, exactly like the sibling DEL (`case 127`) and `'\r'` branches, so `0x08` → plain `Backspace`. Legacy BS now behaves as Backspace (not Ctrl+H), which is what terminal editors expect.

## Tests

Added a `0x08 → Backspace (no Control)` case to `EscSeqUtilsTests.GetConsoleInputKey_ConsoleKeyInfo`, mirroring the existing DEL assertion.

Verified green locally: `EscSeqUtilsTests` (20), `AnsiKeyboardParserTests` (103), `AnsiKeyboardEncoderTests` (117), `AnsiInputTestableTests` (38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
