### PR TITLE
docs(ai-primer): document four high-value v2 gotchas agents miss

### DIFF
--- a/ai-v2-primer.md
+++ b/ai-v2-primer.md
@@ -180,6 +180,10 @@ view.KeyBindings.Add (Key.F5, Command.Refresh);
    Do not use the static `Application.Init ()` / `Application.Run ()` / `Application.Shutdown ()` pattern.
 4. **Use `App!.RequestStop ()`** to close a window from inside a `Runnable`, not `Application.RequestStop ()`.
 5. **SubView/SuperView** — Never say "child", "parent", or "container". Use SubView/SuperView.
+6. **Dialog/MessageBox button order = the default** — The **last button added is the default** (Enter-activated) for both `Dialog` and `MessageBox`. Add buttons so the affirmative action is **last** (e.g. `Cancel` then `OK`); `Esc`/Cancel goes first. Do **not** hand-set `IsDefault` in a `Dialog` unless you intend to override the last-button default.
+7. **`AddCommand` is `protected`** — Register commands *inside* your `View` subclass (in the constructor), then bind keys with `KeyBindings.Add (Key.F5, Command.Refresh)`. You cannot call `view.AddCommand (...)` on an instance from outside.
+8. **`Terminal.Gui.Drawing.Attribute`** — The color/style `Attribute` is a `readonly record struct` in `Terminal.Gui.Drawing`; it collides with `System.Attribute`. Qualify or alias it when `System` is also imported.
+9. **Typed views expose `.Value`, not guessed names** — Value-bearing views implement `IValue<T>`: use `.Value` and `ValueChanged`/`ValueChanging` (e.g. `datePicker.Value` is a `DateTime`, not `.Date`). Don't guess property-specific names like `.Date`, `.Time`, or `.Color`.
 
 ### Code Style (Library Contributors Only)
 


### PR DESCRIPTION
First, safe slice of #5525. Adds the verified, high-frequency gotchas to `ai-v2-primer.md`'s **Gotchas → API Correctness** list — the ones agents get wrong even once they know it's v2, and which the primer didn't cover:

1. **Dialog/MessageBox button order = the default** — last button added is the default; order `Cancel … OK`; don't hand-set `IsDefault`. (`Views/Dialog.cs`, `Views/MessageBox.cs`)
2. **`AddCommand` is `protected`** — register inside the View, bind via `KeyBindings`. (`ViewBase/View.Command.cs`)
3. **`Terminal.Gui.Drawing.Attribute`** collides with `System.Attribute`. (`Drawing/Attribute.cs`)
4. **Typed views expose `.Value`** via `IValue<T>`, not `.Date`/`.Color`. (`Views/DatePicker.cs`)

All inline prose (no fenced snippets), so `validate-doc-snippets` is unaffected. Each verified against current `develop` source.

### Remaining #5525 items — flagged for a maintainer call (not in this PR)
These are contentious or cross-file, so they want your decision rather than a unilateral edit:
- **`Accepted` vs `Accepting`**: the primer says "Accepted for side effects, Accepting to cancel," but live `UICatalog` scenarios use `Accepting` for side effects ~139:10, and `getting-started.md` says event handling "uses `Accepting`." Pick one and make the docs + examples agree (then `validate-doc-snippets` can enforce it).
- **Cookbook / `llms.txt`** model manual `IsDefault = true` and obsolete `SelectedItemChanged` — update to match gotchas #1/#4 above.
- **Unify version/maturity strings** (`@2.0.*` vs `alpha.*` vs `beta.*`; "Alpha" vs "Beta") now that v2 is stable 2.4.x.
- **Add `llms.txt`** (and the dialog/`IValue` snippets) to `validate-doc-snippets.yml` so they can't rot.

Sourced while building the agent-optimized templates (tui-cs/Terminal.Gui.templates#22).