### PR TITLE
docs(getting-started): use Accepted for side effects (canonical rule)

### DIFF
--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -57,8 +57,8 @@ app.Run (window);
 - The application initializes automatically when you call `Run<T>()`
 - Use `app.Run<ExampleWindow>()` to run a window that implements <xref:Terminal.Gui.App.IRunnable>
 - Call `app.Dispose()` to clean up resources and restore the terminal
-- Event handling uses <xref:Terminal.Gui.ViewBase.View.Accepting> event instead of legacy `Accept` event
-- Set `e.Handled = true` in event handlers to prevent further processing
+- Use the <xref:Terminal.Gui.ViewBase.View.Accepted> event for side effects (e.g. handling a button press); the legacy `Accept` event is gone
+- Use the <xref:Terminal.Gui.ViewBase.View.Accepting> event only to inspect or cancel an action, setting `e.Handled = true` to cancel it
 
 When run the application looks as follows:
 


### PR DESCRIPTION
Cascade of the maintainer ruling that **`Accepted` is canonical for side effects** (`Accepting` only to cancel).

`getting-started.md` said *"event handling uses the `Accepting` event"*, which contradicts the rule. Reworded to:
- Use **`Accepted`** for side effects (e.g. handling a button press); the legacy `Accept` event is gone.
- Use **`Accepting`** only to inspect or cancel an action (`e.Handled = true`).

Both are public events on `View` (`ViewBase/View.Command.cs`), so the xrefs resolve.

Part of #5525. (Companion: the templates were aligned in tui-cs/Terminal.Gui.templates#38. The cookbook examples were checked and are already correct — they use `Accepting` *with* `e.Handled` for genuine validation/cancel.)