### PR TITLE
Fix #5543: release raster graphics when their view stops being rendered

### DIFF
--- a/Terminal.Gui/App/ApplicationImpl.Screen.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Screen.cs
@@ -289,6 +289,20 @@ internal partial class ApplicationImpl
             // the whole tree.
             View.Draw (views.ToArray ().Cast<View> (), forceRedraw);
 
+            // Release raster graphics (Sixel/Kitty) whose owning view is no longer rendered — hidden,
+            // removed from the hierarchy, or on a runnable that has ended. They are emitted out-of-band
+            // and persist on screen until explicitly deleted, so erasing their cells is not enough. See
+            // https://github.com/tui-cs/Terminal.Gui/issues/5543.
+            IOutputBuffer rasterBuffer = Driver.GetOutputBuffer ();
+            HashSet<string> activeRasterIds = [];
+
+            foreach (View? view in views)
+            {
+                view?.CollectActiveRasterImageIds (activeRasterIds);
+            }
+
+            rasterBuffer.RetainRasterImages (activeRasterIds);
+
             Driver.Clip = new Region (clipRect);
 
             // Cause the driver to flush any pending updates to the terminal

--- a/Terminal.Gui/Drivers/Output/IOutputBuffer.cs
+++ b/Terminal.Gui/Drivers/Output/IOutputBuffer.cs
@@ -125,6 +125,19 @@ public interface IOutputBuffer
     void RemoveRasterImage (string id);
 
     /// <summary>
+    ///     Removes every raster image command whose <see cref="RasterImageCommand.Id"/> is not in
+    ///     <paramref name="activeIds"/>, marking the cells they covered dirty so they are repainted.
+    /// </summary>
+    /// <remarks>
+    ///     Raster graphics (Sixel/Kitty) are emitted out-of-band and persist on screen until explicitly
+    ///     deleted, so they linger after the view that transmitted them is no longer rendered (hidden,
+    ///     removed, or on a runnable that has ended). The framework calls this after each draw with the ids
+    ///     of the images still owned by rendered views, releasing the rest. See <see cref="RemoveRasterImage"/>.
+    /// </remarks>
+    /// <param name="activeIds">The ids of raster images still owned by a rendered view.</param>
+    void RetainRasterImages (IReadOnlyCollection<string> activeIds);
+
+    /// <summary>
     ///     Gets the raster image commands currently held by the output buffer.
     /// </summary>
     /// <returns>The raster image commands.</returns>

--- a/Terminal.Gui/Drivers/Output/OutputBufferImpl.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBufferImpl.cs
@@ -353,6 +353,26 @@ public class OutputBufferImpl : IOutputBuffer
     }
 
     /// <inheritdoc/>
+    public void RetainRasterImages (IReadOnlyCollection<string> activeIds)
+    {
+        ArgumentNullException.ThrowIfNull (activeIds);
+
+        lock (_contentsLock)
+        {
+            for (int i = _rasterImages.Count - 1; i >= 0; i--)
+            {
+                if (_rasterImages [i].Id is { } id && activeIds.Contains (id))
+                {
+                    continue;
+                }
+
+                MarkRasterImageCellsDirty (_rasterImages [i]);
+                _rasterImages.RemoveAt (i);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
     public IReadOnlyList<RasterImageCommand> GetRasterImages ()
     {
         lock (_contentsLock)

--- a/Terminal.Gui/ViewBase/View.Drawing.cs
+++ b/Terminal.Gui/ViewBase/View.Drawing.cs
@@ -67,6 +67,31 @@ public partial class View // Drawing APIs
     }
 
     /// <summary>
+    ///     Collects the ids of raster graphics (Sixel/Kitty) this view and its rendered SubViews currently keep
+    ///     resident in the terminal. The framework calls this after drawing and passes the result to
+    ///     <see cref="IOutputBuffer.RetainRasterImages"/> so raster graphics whose owning view is no longer
+    ///     rendered (hidden, removed, or on a runnable that has ended) are released instead of lingering on screen.
+    /// </summary>
+    /// <remarks>
+    ///     A view that transmits a raster image (e.g. <see cref="Views.ImageView"/>) overrides this to add its
+    ///     id when it is currently rendering. Invisible views and their SubViews are skipped, so a view that was
+    ///     hidden releases its raster graphics.
+    /// </remarks>
+    /// <param name="ids">The set to add active raster image ids to.</param>
+    internal virtual void CollectActiveRasterImageIds (HashSet<string> ids)
+    {
+        if (!Visible)
+        {
+            return;
+        }
+
+        foreach (View subView in InternalSubViews)
+        {
+            subView.CollectActiveRasterImageIds (ids);
+        }
+    }
+
+    /// <summary>
     ///     Draws the view if it needs to be drawn.
     /// </summary>
     /// <remarks>

--- a/Terminal.Gui/Views/ImageView/ImageView.Drawing.cs
+++ b/Terminal.Gui/Views/ImageView/ImageView.Drawing.cs
@@ -51,6 +51,22 @@ public partial class ImageView
         InvalidateScaledImage ();
     }
 
+    /// <inheritdoc/>
+    internal override void CollectActiveRasterImageIds (HashSet<string> ids)
+    {
+        if (!Visible)
+        {
+            return;
+        }
+
+        base.CollectActiveRasterImageIds (ids);
+
+        if (IsUsingRasterGraphics && _image is { })
+        {
+            ids.Add (RasterImageId);
+        }
+    }
+
     /// <summary>
     ///     Renders the image using cell-based rendering where each terminal cell
     ///     gets the background color of the corresponding pixel.

--- a/Terminal.Gui/Views/ProgressBar.cs
+++ b/Terminal.Gui/Views/ProgressBar.cs
@@ -93,6 +93,7 @@ public class ProgressBar : View, IDesignable
     private int _fireEncoderMaxColors;
     private int _fireFrame;
     private readonly string _fireRasterImageId = $"{nameof (ProgressBar)}.{Guid.NewGuid ():N}.Fire";
+    private bool _fireRasterImageActive;
     private float _fraction;
     private bool _isActivity;
     private bool _syncWithTerminal;
@@ -450,6 +451,7 @@ public class ProgressBar : View, IDesignable
         };
 
         driver.GetOutputBuffer ().AddRasterImage (command);
+        _fireRasterImageActive = true;
 
         return true;
     }
@@ -507,7 +509,27 @@ public class ProgressBar : View, IDesignable
         public List<Color> BuildPalette (int maxColors) => [.. _firePalette.Take (maxColors)];
     }
 
-    private void RemoveFireRasterImage () => Driver?.GetOutputBuffer ().RemoveRasterImage (_fireRasterImageId);
+    private void RemoveFireRasterImage ()
+    {
+        _fireRasterImageActive = false;
+        Driver?.GetOutputBuffer ().RemoveRasterImage (_fireRasterImageId);
+    }
+
+    /// <inheritdoc/>
+    internal override void CollectActiveRasterImageIds (HashSet<string> ids)
+    {
+        if (!Visible)
+        {
+            return;
+        }
+
+        base.CollectActiveRasterImageIds (ids);
+
+        if (_fireRasterImageActive)
+        {
+            ids.Add (_fireRasterImageId);
+        }
+    }
 
     private void UpdateTerminalProgress ()
     {

--- a/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
@@ -1178,6 +1178,71 @@ public class OutputBaseTests
         Assert.True (buffer.DirtyLines [0]);
     }
 
+    // Claude - Opus 4.8
+    [Fact]
+    public void RetainRasterImages_RemovesUnlistedImages_AndInvalidatesTheirCells ()
+    {
+        // Arrange
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (4, 4);
+        buffer.Clip = new Region (new Rectangle (0, 0, 4, 4));
+
+        RasterImageCommand keep = new ()
+        {
+            Id = "keep",
+            Pixels = CreateSolidImage (2, 2, new Color (255, 0, 0)),
+            DestinationCells = new Rectangle (0, 0, 2, 2)
+        };
+
+        RasterImageCommand drop = new ()
+        {
+            Id = "drop",
+            Pixels = CreateSolidImage (2, 2, new Color (0, 255, 0)),
+            DestinationCells = new Rectangle (2, 2, 2, 2)
+        };
+
+        buffer.AddRasterImage (keep);
+        buffer.AddRasterImage (drop);
+        buffer.DirtyLines [2] = false;
+        buffer.DirtyLines [3] = false;
+
+        // Act
+        buffer.RetainRasterImages (["keep"]);
+
+        // Assert
+        RasterImageCommand remaining = Assert.Single (buffer.GetRasterImages ());
+        Assert.Equal ("keep", remaining.Id);
+
+        // The dropped image's cells are invalidated so they get repainted.
+        Assert.True (buffer.Contents! [3, 3].IsDirty);
+        Assert.True (buffer.DirtyLines [3]);
+    }
+
+    // Claude - Opus 4.8
+    [Fact]
+    public void RetainRasterImages_EmptyActiveIds_RemovesAll ()
+    {
+        // Arrange
+        AnsiOutput output = new ();
+        IOutputBuffer buffer = output.GetLastBuffer ()!;
+        buffer.SetSize (2, 2);
+        buffer.Clip = new Region (new Rectangle (0, 0, 2, 2));
+
+        buffer.AddRasterImage (new ()
+        {
+            Id = "image",
+            Pixels = CreateSolidImage (2, 2, new Color (255, 0, 0)),
+            DestinationCells = new Rectangle (0, 0, 2, 2)
+        });
+
+        // Act
+        buffer.RetainRasterImages ([]);
+
+        // Assert
+        Assert.Empty (buffer.GetRasterImages ());
+    }
+
     // Copilot - GPT-5.5
     [Fact]
     public void GetRasterImages_ReturnsReadOnlySnapshot ()

--- a/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ImageViewTests.cs
@@ -1748,6 +1748,139 @@ public class ImageViewTests
 
     #endregion Resolution Selection Consistency
 
+    #region Raster Cleanup (issue #5543)
+
+    // Claude - Opus 4.8
+    // A raster ImageView removed from its SuperView (without being disposed) must not leave its
+    // out-of-band Sixel/Kitty graphic resident in the output buffer. See issue #5543.
+    [Fact]
+    public void RasterImage_Released_WhenRemovedFromSuperView ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new () { IsSupported = true, Resolution = new (10, 10), MaxPaletteColors = 256 });
+
+        Runnable runnable = new () { Width = 10, Height = 10 };
+        app.Begin (runnable);
+
+        ImageView imageView = new () { Width = 4, Height = 4, Image = CreateCoordinateImage (4, 4) };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        Assert.Single (driver.GetOutputBuffer ().GetRasterImages ());
+
+        runnable.Remove (imageView);
+        app.LayoutAndDraw ();
+
+        Assert.Empty (driver.GetOutputBuffer ().GetRasterImages ());
+
+        imageView.Dispose ();
+        runnable.Dispose ();
+    }
+
+    // Claude - Opus 4.8
+    // A raster ImageView that becomes invisible must release its resident Sixel/Kitty graphic. See issue #5543.
+    [Fact]
+    public void RasterImage_Released_WhenHidden ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new () { IsSupported = true, Resolution = new (10, 10), MaxPaletteColors = 256 });
+
+        Runnable runnable = new () { Width = 10, Height = 10 };
+        app.Begin (runnable);
+
+        ImageView imageView = new () { Width = 4, Height = 4, Image = CreateCoordinateImage (4, 4) };
+        runnable.Add (imageView);
+        app.LayoutAndDraw ();
+
+        Assert.Single (driver.GetOutputBuffer ().GetRasterImages ());
+
+        imageView.Visible = false;
+        app.LayoutAndDraw ();
+
+        Assert.Empty (driver.GetOutputBuffer ().GetRasterImages ());
+
+        runnable.Dispose ();
+    }
+
+    // Claude - Opus 4.8
+    // A raster ImageView nested in a container that is removed (e.g. the container revealing the view
+    // beneath it) must release its resident Sixel/Kitty graphic. This generalizes the issue #5543 case
+    // beyond modal Dialogs to any overlapping container.
+    [Fact]
+    public void RasterImage_Released_WhenContainerRemoved ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new () { IsSupported = true, Resolution = new (10, 10), MaxPaletteColors = 256 });
+
+        Runnable runnable = new () { Width = 10, Height = 10 };
+        app.Begin (runnable);
+
+        View container = new () { Width = 6, Height = 6 };
+        ImageView imageView = new () { Width = 4, Height = 4, Image = CreateCoordinateImage (4, 4) };
+        container.Add (imageView);
+        runnable.Add (container);
+        app.LayoutAndDraw ();
+
+        Assert.Single (driver.GetOutputBuffer ().GetRasterImages ());
+
+        runnable.Remove (container);
+        app.LayoutAndDraw ();
+
+        Assert.Empty (driver.GetOutputBuffer ().GetRasterImages ());
+
+        container.Dispose ();
+        runnable.Dispose ();
+    }
+
+    // Claude - Opus 4.8
+    // The issue #5543 scenario: a modal runnable hosting a raster ImageView leaves its Sixel/Kitty graphic
+    // on screen after it closes. When the modal session ends, its raster graphic must be released.
+    [Fact]
+    public void RasterImage_Released_WhenModalRunnableEnds ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        DriverImpl driver = (DriverImpl)app.Driver!;
+        driver.SetSixelSupport (new () { IsSupported = true, Resolution = new (10, 10), MaxPaletteColors = 256 });
+        app.Driver!.SetScreenSize (10, 10);
+
+        Runnable main = new () { Width = 10, Height = 10 };
+        app.Begin (main);
+        app.LayoutAndDraw ();
+
+        Assert.Empty (driver.GetOutputBuffer ().GetRasterImages ());
+
+        // Run a modal runnable hosting a raster ImageView on top of the main view.
+        Runnable dialog = new () { Width = 6, Height = 6 };
+        ImageView imageView = new () { Width = 4, Height = 4, Image = CreateCoordinateImage (4, 4) };
+        dialog.Add (imageView);
+        SessionToken? dialogToken = app.Begin (dialog);
+        app.LayoutAndDraw ();
+
+        Assert.Single (driver.GetOutputBuffer ().GetRasterImages ());
+
+        // Close the modal — the main view is revealed and the dialog's graphic must not linger.
+        app.End (dialogToken!);
+        app.LayoutAndDraw ();
+
+        Assert.Empty (driver.GetOutputBuffer ().GetRasterImages ());
+
+        dialog.Dispose ();
+        main.Dispose ();
+    }
+
+    #endregion Raster Cleanup (issue #5543)
+
     #region Helper Methods
 
     /// <summary>Creates a solid-color image of the specified dimensions.</summary>


### PR DESCRIPTION
Fixes #5543.

## Problem

A modal `Dialog` (or any overlapping view) hosting a raster `ImageView` (`UseRasterGraphics = true`, rendering via Sixel or the Kitty graphics protocol) **left its graphics on screen after it stopped being rendered**. Closing the dialog erased the cell grid, but the out-of-band Sixel DCS / Kitty placement lingered over the restored view until the next full-screen clear.

## Root cause

A `RasterImageCommand` lives in the driver-level output buffer keyed by the owning view, but nothing removed it when the owning view stopped drawing — only explicit `Dispose` / `Image = null` did. Closing a modal doesn't dispose its subviews, so the command (and the terminal-resident graphic) survived. This is general to any overlapping `ImageView`, not specific to `Dialog`/`Runnable`.

## Fix

Reconcile the buffer's raster images against the rendered view hierarchy on each draw:

- **`IOutputBuffer` / `OutputBufferImpl`**: add `RetainRasterImages(activeIds)` — drops every raster command whose id is not active and marks its covered cells dirty.
- **`View`**: add `internal virtual CollectActiveRasterImageIds` (skips invisible subtrees).
- **`ImageView` / `ProgressBar`**: override to report their active raster id while rendering.
- **`ApplicationImpl.LayoutAndDraw`**: after `View.Draw`, collect the ids still owned by rendered views and call `RetainRasterImages` to release the rest.

Dropping a command marks its cells dirty, so the next `Refresh` repaints them (overwriting Sixel) and emits the Kitty delete for vanished placements. Callers no longer need the `ClearScreenNextIteration` / `ClearContents` workaround from the issue.

## Tests

`UnitTestsParallelizable`:
- `ImageView` raster released when removed from SuperView, hidden, its container removed, and when a modal runnable ends (the exact issue scenario).
- Direct `RetainRasterImages` buffer tests (unlisted images removed + cells invalidated; empty active set removes all).

Full parallelizable suite: **17,442 passed, 0 failed, 17 skipped**. No new build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)