### PR TITLE
Fixes #5499. Skip SetNeedsLayout when Dim.Auto text recompute yields unchanged size

### DIFF
--- a/Terminal.Gui/ViewBase/View.Layout.cs
+++ b/Terminal.Gui/ViewBase/View.Layout.cs
@@ -665,53 +665,11 @@ public partial class View // Layout APIs
         // TODO: Should move to View.LayoutSubViews?
         SetTextFormatterSize ();
 
-        int newX, newW, newY, newH;
-
-        try
+        if (!TryComputeRelativeFrame (superviewContentSize, out Rectangle newFrame))
         {
-            // Calculate the new X, Y, Width, and Height
-            // If the Width or Height is Dim.Auto, calculate the Width or Height first. Otherwise, calculate the X or Y first.
-            if (_width.Has<DimAuto> (out _))
-            {
-                newW = _width.Calculate (0, superviewContentSize.Width, this, Dimension.Width);
-                newX = _x.Calculate (superviewContentSize.Width, newW, this, Dimension.Width);
-
-                if (newW != Frame.Width)
-                {
-                    // Pos.Calculate got us a new position. We need to redo dimension
-                    newW = _width.Calculate (newX, superviewContentSize.Width, this, Dimension.Width);
-                }
-            }
-            else
-            {
-                newX = _x.Calculate (superviewContentSize.Width, _width, this, Dimension.Width);
-                newW = _width.Calculate (newX, superviewContentSize.Width, this, Dimension.Width);
-            }
-
-            if (_height.Has<DimAuto> (out _))
-            {
-                newH = _height.Calculate (0, superviewContentSize.Height, this, Dimension.Height);
-                newY = _y.Calculate (superviewContentSize.Height, newH, this, Dimension.Height);
-
-                if (newH != Frame.Height)
-                {
-                    // Pos.Calculate got us a new position. We need to redo dimension
-                    newH = _height.Calculate (newY, superviewContentSize.Height, this, Dimension.Height);
-                }
-            }
-            else
-            {
-                newY = _y.Calculate (superviewContentSize.Height, _height, this, Dimension.Height);
-                newH = _height.Calculate (newY, superviewContentSize.Height, this, Dimension.Height);
-            }
-        }
-        catch (LayoutException)
-        {
-            //Debug.WriteLine ($"A Dim/PosFunc function threw (typically this is because a dependent View was not laid out)\n{le}.");
+            //Debug.WriteLine ($"A Dim/PosFunc function threw (typically this is because a dependent View was not laid out)");
             return false;
         }
-
-        Rectangle newFrame = new (newX, newY, newW, newH);
 
         if (Frame != newFrame)
         {
@@ -777,6 +735,72 @@ public partial class View // Layout APIs
         {
             TextFormatter.ConstrainToHeight = GetContentHeight ();
         }
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Resolves this view's <see cref="Pos"/>/<see cref="Dim"/> expressions into the absolute <see cref="Frame"/>
+    ///     they would produce, without applying it. This is the size/position computation
+    ///     <see cref="SetRelativeLayout"/> performs and is the single source of truth for both that method and any
+    ///     speculative "would the Frame change?" check.
+    /// </summary>
+    /// <param name="superviewContentSize">The size of the SuperView's content.</param>
+    /// <param name="frame">The resolved Frame. Valid only when the method returns <see langword="true"/>.</param>
+    /// <returns>
+    ///     <see langword="true"/> if the Frame could be resolved; <see langword="false"/> if a dependency was not ready
+    ///     (a <see cref="LayoutException"/> was thrown during calculation).
+    /// </returns>
+    private bool TryComputeRelativeFrame (Size superviewContentSize, out Rectangle frame)
+    {
+        frame = Rectangle.Empty;
+
+        int newX, newW, newY, newH;
+
+        try
+        {
+            // Calculate the new X, Y, Width, and Height
+            // If the Width or Height is Dim.Auto, calculate the Width or Height first. Otherwise, calculate the X or Y first.
+            if (_width.Has<DimAuto> (out _))
+            {
+                newW = _width.Calculate (0, superviewContentSize.Width, this, Dimension.Width);
+                newX = _x.Calculate (superviewContentSize.Width, newW, this, Dimension.Width);
+
+                if (newW != Frame.Width)
+                {
+                    // Pos.Calculate got us a new position. We need to redo dimension
+                    newW = _width.Calculate (newX, superviewContentSize.Width, this, Dimension.Width);
+                }
+            }
+            else
+            {
+                newX = _x.Calculate (superviewContentSize.Width, _width, this, Dimension.Width);
+                newW = _width.Calculate (newX, superviewContentSize.Width, this, Dimension.Width);
+            }
+
+            if (_height.Has<DimAuto> (out _))
+            {
+                newH = _height.Calculate (0, superviewContentSize.Height, this, Dimension.Height);
+                newY = _y.Calculate (superviewContentSize.Height, newH, this, Dimension.Height);
+
+                if (newH != Frame.Height)
+                {
+                    // Pos.Calculate got us a new position. We need to redo dimension
+                    newH = _height.Calculate (newY, superviewContentSize.Height, this, Dimension.Height);
+                }
+            }
+            else
+            {
+                newY = _y.Calculate (superviewContentSize.Height, _height, this, Dimension.Height);
+                newH = _height.Calculate (newY, superviewContentSize.Height, this, Dimension.Height);
+            }
+        }
+        catch (LayoutException)
+        {
+            return false;
+        }
+
+        frame = new (newX, newY, newW, newH);
 
         return true;
     }

--- a/Terminal.Gui/ViewBase/View.Layout.cs
+++ b/Terminal.Gui/ViewBase/View.Layout.cs
@@ -726,6 +726,23 @@ public partial class View // Layout APIs
             }
         }
 
+        FinalizeTextFormatterConstraints ();
+
+        return true;
+    }
+
+    /// <summary>
+    ///     Finalizes <see cref="TextFormatter"/>'s size constraints after the <see cref="Frame"/> has been resolved.
+    ///     Any constraint left unset by <see cref="SetTextFormatterSize"/> (e.g. for fixed dimensions whose content
+    ///     size was not explicitly set) is filled from the view's content size so wrapped/clipped text formats
+    ///     correctly.
+    /// </summary>
+    /// <remarks>
+    ///     Called by <see cref="SetRelativeLayout"/> and by the <see cref="Text"/> setter's same-frame fast path, which
+    ///     skips <see cref="SetRelativeLayout"/> but must leave <see cref="TextFormatter"/> in the same state.
+    /// </remarks>
+    private void FinalizeTextFormatterConstraints ()
+    {
         if (TextFormatter.ConstrainToWidth is null)
         {
             TextFormatter.ConstrainToWidth = GetContentWidth ();
@@ -735,8 +752,6 @@ public partial class View // Layout APIs
         {
             TextFormatter.ConstrainToHeight = GetContentHeight ();
         }
-
-        return true;
     }
 
     /// <summary>

--- a/Terminal.Gui/ViewBase/View.Text.cs
+++ b/Terminal.Gui/ViewBase/View.Text.cs
@@ -65,9 +65,72 @@ public partial class View // Text Property APIs
             _text = value;
 
             UpdateTextFormatterText ();
+
+            if (IsTextOnlyAutoSizeUnchanged ())
+            {
+                // The view is sized solely by its Text and the new Text produces the same Frame size as before.
+                // The content changed, so it must be reformatted and redrawn, but nothing outside this view can be
+                // affected, so the layout pass (and the ancestor propagation SetNeedsLayout would trigger) is skipped.
+                // See issue #5499.
+                TextFormatter.NeedsFormat = true;
+                SetNeedsDraw ();
+                OnTextChanged ();
+
+                return;
+            }
+
             SetNeedsLayout ();
             OnTextChanged ();
         }
+    }
+
+    /// <summary>
+    ///     Determines whether this view is sized solely by its <see cref="Text"/> and the current
+    ///     <see cref="TextFormatter"/> state produces the same <see cref="Frame"/> size it has now.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Used by the <see cref="Text"/> setter to skip <see cref="SetNeedsLayout"/> — and the ancestor layout
+    ///         propagation it triggers — when a text change does not change the view's size. See issue #5499.
+    ///     </para>
+    ///     <para>
+    ///         The optimization applies only when both <see cref="Width"/> and <see cref="Height"/> are exactly
+    ///         <see cref="DimAutoStyle.Text"/> (so <see cref="DimAutoStyle.Auto"/> — which also depends on content and
+    ///         subviews — is excluded) and the view has already been laid out.
+    ///     </para>
+    ///     <para>
+    ///         The prediction reuses <see cref="Dim.Calculate"/> — the exact code the layout engine runs in
+    ///         <see cref="SetRelativeLayout"/> — so it can never disagree with the size a real layout pass would
+    ///         produce. For a Text-only <see cref="DimAuto"/> view <see cref="DimAuto.Calculate"/> only reads view state
+    ///         and updates <see cref="TextFormatter"/> sizing; it does not lay out subviews.
+    ///     </para>
+    /// </remarks>
+    /// <returns>
+    ///     <see langword="true"/> if the optimization applies and the resulting size is unchanged; otherwise
+    ///     <see langword="false"/>.
+    /// </returns>
+    private bool IsTextOnlyAutoSizeUnchanged ()
+    {
+        if (_frame is null)
+        {
+            // Not yet laid out; let the normal layout pass establish the Frame.
+            return false;
+        }
+
+        if (!IsExactlyTextAuto (_width) || !IsExactlyTextAuto (_height))
+        {
+            return false;
+        }
+
+        Size container = GetContainerSize ();
+
+        // Mirror SetRelativeLayout's order: Width first (it caches TextFormatter.ConstrainToWidth/Height), then Height.
+        int newWidth = _width.Calculate (0, container.Width, this, Dimension.Width);
+        int newHeight = _height.Calculate (0, container.Height, this, Dimension.Height);
+
+        return newWidth == Frame.Width && newHeight == Frame.Height;
+
+        static bool IsExactlyTextAuto (Dim dim) => dim.Has (out DimAuto auto) && auto.Style == DimAutoStyle.Text;
     }
 
     /// <summary>

--- a/Terminal.Gui/ViewBase/View.Text.cs
+++ b/Terminal.Gui/ViewBase/View.Text.cs
@@ -66,13 +66,8 @@ public partial class View // Text Property APIs
 
             UpdateTextFormatterText ();
 
-            if (IsTextDrivenFrameUnchanged ())
+            if (TryRedrawWithoutLayout ())
             {
-                // The new Text produces the same Frame (position and size) as before. The content changed, so it must
-                // be reformatted and redrawn, but nothing outside this view can be affected, so the layout pass (and
-                // the ancestor propagation SetNeedsLayout would trigger) is skipped. See issue #5499.
-                TextFormatter.NeedsFormat = true;
-                SetNeedsDraw ();
                 OnTextChanged ();
 
                 return;
@@ -84,8 +79,9 @@ public partial class View // Text Property APIs
     }
 
     /// <summary>
-    ///     Determines whether the new <see cref="Text"/> resolves to the same <see cref="Frame"/> (position and size)
-    ///     the view has now, so a text change can skip <see cref="SetNeedsLayout"/> and only redraw. See issue #5499.
+    ///     If the new <see cref="Text"/> resolves to the same <see cref="Frame"/> (position and size) the view has now,
+    ///     handles the change with a redraw only — skipping <see cref="SetNeedsLayout"/> and the ancestor layout
+    ///     propagation it triggers. See issue #5499.
     /// </summary>
     /// <remarks>
     ///     <para>
@@ -101,12 +97,17 @@ public partial class View // Text Property APIs
     ///         lays out subviews while calculating, so resolving it here would have side effects; those views fall back
     ///         to <see cref="SetNeedsLayout"/>.
     ///     </para>
+    ///     <para>
+    ///         On the fast path this mirrors the <see cref="TextFormatter"/> setup <see cref="SetRelativeLayout"/>
+    ///         performs (<see cref="SetTextFormatterSize"/> plus the post-resolve constraint finalization) so wrapped or
+    ///         clipped text stays correctly constrained, then marks the view for reformat and redraw.
+    ///     </para>
     /// </remarks>
     /// <returns>
-    ///     <see langword="true"/> if the optimization applies and the resolved <see cref="Frame"/> is unchanged;
-    ///     otherwise <see langword="false"/>.
+    ///     <see langword="true"/> if the change was handled by redraw only; <see langword="false"/> if a normal layout
+    ///     pass is required.
     /// </returns>
-    private bool IsTextDrivenFrameUnchanged ()
+    private bool TryRedrawWithoutLayout ()
     {
         if (_frame is null)
         {
@@ -122,7 +123,19 @@ public partial class View // Text Property APIs
         // Mirror SetRelativeLayout's preamble so the prediction sees the same TextFormatter state.
         SetTextFormatterSize ();
 
-        return TryComputeRelativeFrame (GetContainerSize (), out Rectangle predicted) && predicted == Frame;
+        if (!TryComputeRelativeFrame (GetContainerSize (), out Rectangle predicted) || predicted != Frame)
+        {
+            return false;
+        }
+
+        // The Frame is unchanged, so nothing outside this view can be affected. Mirror SetRelativeLayout's formatter
+        // finalization (skipped because we bypass it) so wrapped/clipped text stays constrained, then reformat and
+        // redraw without a layout pass.
+        FinalizeTextFormatterConstraints ();
+        TextFormatter.NeedsFormat = true;
+        SetNeedsDraw ();
+
+        return true;
 
         // A dimension is safe to resolve here only when doing so has no side effects beyond this view's own
         // TextFormatter. DimAbsolute is constant; a Text-only DimAuto depends solely on the TextFormatter.

--- a/Terminal.Gui/ViewBase/View.Text.cs
+++ b/Terminal.Gui/ViewBase/View.Text.cs
@@ -66,12 +66,11 @@ public partial class View // Text Property APIs
 
             UpdateTextFormatterText ();
 
-            if (IsTextOnlyAutoSizeUnchanged ())
+            if (IsTextDrivenFrameUnchanged ())
             {
-                // The view is sized solely by its Text and the new Text produces the same Frame size as before.
-                // The content changed, so it must be reformatted and redrawn, but nothing outside this view can be
-                // affected, so the layout pass (and the ancestor propagation SetNeedsLayout would trigger) is skipped.
-                // See issue #5499.
+                // The new Text produces the same Frame (position and size) as before. The content changed, so it must
+                // be reformatted and redrawn, but nothing outside this view can be affected, so the layout pass (and
+                // the ancestor propagation SetNeedsLayout would trigger) is skipped. See issue #5499.
                 TextFormatter.NeedsFormat = true;
                 SetNeedsDraw ();
                 OnTextChanged ();
@@ -85,31 +84,29 @@ public partial class View // Text Property APIs
     }
 
     /// <summary>
-    ///     Determines whether this view is sized solely by its <see cref="Text"/> and the current
-    ///     <see cref="TextFormatter"/> state produces the same <see cref="Frame"/> size it has now.
+    ///     Determines whether the new <see cref="Text"/> resolves to the same <see cref="Frame"/> (position and size)
+    ///     the view has now, so a text change can skip <see cref="SetNeedsLayout"/> and only redraw. See issue #5499.
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Used by the <see cref="Text"/> setter to skip <see cref="SetNeedsLayout"/> — and the ancestor layout
-    ///         propagation it triggers — when a text change does not change the view's size. See issue #5499.
+    ///         The prediction reuses <see cref="TryComputeRelativeFrame"/> — the exact computation
+    ///         <see cref="SetRelativeLayout"/> runs — so it can never disagree with the Frame a real layout pass would
+    ///         produce, and it compares the whole <see cref="Frame"/> (a <see cref="Pos"/> can depend on
+    ///         <see cref="Text"/>, so a same-size change can still move the view).
     ///     </para>
     ///     <para>
-    ///         The optimization applies only when both <see cref="Width"/> and <see cref="Height"/> are exactly
-    ///         <see cref="DimAutoStyle.Text"/> (so <see cref="DimAutoStyle.Auto"/> — which also depends on content and
-    ///         subviews — is excluded) and the view has already been laid out.
-    ///     </para>
-    ///     <para>
-    ///         The prediction reuses <see cref="Dim.Calculate"/> — the exact code the layout engine runs in
-    ///         <see cref="SetRelativeLayout"/> — so it can never disagree with the size a real layout pass would
-    ///         produce. For a Text-only <see cref="DimAuto"/> view <see cref="DimAuto.Calculate"/> only reads view state
-    ///         and updates <see cref="TextFormatter"/> sizing; it does not lay out subviews.
+    ///         The optimization applies only when the view has already been laid out and both <see cref="Width"/> and
+    ///         <see cref="Height"/> are either a fixed dimension or exactly <see cref="DimAutoStyle.Text"/>. A
+    ///         <see cref="DimAuto"/> with <see cref="DimAutoStyle.Content"/> (including <see cref="DimAutoStyle.Auto"/>)
+    ///         lays out subviews while calculating, so resolving it here would have side effects; those views fall back
+    ///         to <see cref="SetNeedsLayout"/>.
     ///     </para>
     /// </remarks>
     /// <returns>
-    ///     <see langword="true"/> if the optimization applies and the resulting size is unchanged; otherwise
-    ///     <see langword="false"/>.
+    ///     <see langword="true"/> if the optimization applies and the resolved <see cref="Frame"/> is unchanged;
+    ///     otherwise <see langword="false"/>.
     /// </returns>
-    private bool IsTextOnlyAutoSizeUnchanged ()
+    private bool IsTextDrivenFrameUnchanged ()
     {
         if (_frame is null)
         {
@@ -117,20 +114,19 @@ public partial class View // Text Property APIs
             return false;
         }
 
-        if (!IsExactlyTextAuto (_width) || !IsExactlyTextAuto (_height))
+        if (!IsEagerlyResolvable (_width) || !IsEagerlyResolvable (_height))
         {
             return false;
         }
 
-        Size container = GetContainerSize ();
+        // Mirror SetRelativeLayout's preamble so the prediction sees the same TextFormatter state.
+        SetTextFormatterSize ();
 
-        // Mirror SetRelativeLayout's order: Width first (it caches TextFormatter.ConstrainToWidth/Height), then Height.
-        int newWidth = _width.Calculate (0, container.Width, this, Dimension.Width);
-        int newHeight = _height.Calculate (0, container.Height, this, Dimension.Height);
+        return TryComputeRelativeFrame (GetContainerSize (), out Rectangle predicted) && predicted == Frame;
 
-        return newWidth == Frame.Width && newHeight == Frame.Height;
-
-        static bool IsExactlyTextAuto (Dim dim) => dim.Has (out DimAuto auto) && auto.Style == DimAutoStyle.Text;
+        // A dimension is safe to resolve here only when doing so has no side effects beyond this view's own
+        // TextFormatter. DimAbsolute is constant; a Text-only DimAuto depends solely on the TextFormatter.
+        static bool IsEagerlyResolvable (Dim dim) => dim is DimAbsolute or DimAuto { Style: DimAutoStyle.Text };
     }
 
     /// <summary>

--- a/Tests/UnitTestsParallelizable/ViewBase/Layout/Dim.AutoTests.TextOptimization.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/Layout/Dim.AutoTests.TextOptimization.cs
@@ -94,6 +94,57 @@ public partial class DimAutoTests
     }
 
     [Fact]
+    public void Text_RepeatedSameWidthUpdates_NoFrameDrift_NoAncestorLayout ()
+    {
+        // Clock simulation: a Text-auto label whose text changes every "tick" to the same width must never drift its
+        // Frame and never mark its SuperView for layout. See issue #5499.
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = Auto (DimAutoStyle.Text), Text = "00:00:00" };
+        View superView = new () { Width = 40, Height = 5 };
+        superView.Add (view);
+        superView.Layout (new Size (40, 5));
+        Rectangle frame0 = view.Frame;
+
+        for (var i = 0; i < 100; i++)
+        {
+            superView.NeedsLayout = false;
+            view.NeedsLayout = false;
+
+            view.Text = $"{i % 24:D2}:{i % 60:D2}:{i % 60:D2}"; // always 8 wide
+
+            Assert.False (view.NeedsLayout);
+            Assert.False (superView.NeedsLayout);
+            Assert.Equal (frame0, view.Frame);
+        }
+    }
+
+    [Fact]
+    public void Text_ReentrantTextChanged_Settles ()
+    {
+        // A TextChanged handler that sets Text again (to another same-width value) on the fast path must settle
+        // without an infinite loop and apply the final value.
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = Auto (DimAutoStyle.Text), Text = "aaa" };
+        view.Layout ();
+
+        var count = 0;
+        view.TextChanged += (sender, _) =>
+                            {
+                                count++;
+
+                                if (count == 1)
+                                {
+                                    ((View)sender!).Text = "bbb";
+                                }
+                            };
+
+        view.NeedsLayout = false;
+
+        view.Text = "ccc";
+
+        Assert.Equal ("bbb", view.Text);
+        Assert.Equal (new Rectangle (0, 0, 3, 1), view.Frame);
+    }
+
+    [Fact]
     public void Text_AutoStyle_BypassesOptimization ()
     {
         // DimAutoStyle.Auto (Content | Text) also depends on content/subviews, so the optimization must not apply
@@ -124,6 +175,62 @@ public partial class DimAutoTests
 
         Assert.False (view.NeedsLayout);
         Assert.True (view.NeedsDraw);
+    }
+
+    [Fact]
+    public void Text_FixedDimensions_WordWrap_FormatterConstraintsMatchFullLayout ()
+    {
+        // Regression: the same-frame fast path must mirror SetRelativeLayout's formatter finalization. Otherwise
+        // UpdateTextFormatterText clears the constraints and they are never restored, so a null (= int.MaxValue) width
+        // breaks wrapping/clipping for fixed-size text. See issue #5499 review.
+        View view = new () { Width = 5, Height = 2 };
+        view.TextFormatter.WordWrap = true;
+        view.Text = "abc";
+        view.Layout ();
+
+        view.NeedsLayout = false;
+
+        // Different content, same fixed Frame - takes the redraw-only fast path
+        view.Text = "abcdefghi";
+
+        Assert.False (view.NeedsLayout);
+
+        // Contract: the fast path leaves TextFormatter in the same state a full layout pass would.
+        int? fastWidth = view.TextFormatter.ConstrainToWidth;
+        int? fastHeight = view.TextFormatter.ConstrainToHeight;
+        Assert.NotNull (fastWidth);
+        Assert.NotNull (fastHeight);
+
+        view.SetNeedsLayout ();
+        view.Layout ();
+        Assert.Equal (view.TextFormatter.ConstrainToWidth, fastWidth);
+        Assert.Equal (view.TextFormatter.ConstrainToHeight, fastHeight);
+    }
+
+    [Fact]
+    public void Text_OneAxisAuto_WordWrap_FormatterConstraintsMatchFullLayout ()
+    {
+        // One axis Text-auto, the other fixed - same contract: fast-path constraints equal a full layout's.
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = 2 };
+        view.TextFormatter.WordWrap = true;
+        view.Text = "abc";
+        view.Layout ();
+
+        view.NeedsLayout = false;
+
+        view.Text = "xyz"; // same 3x2 Frame
+
+        Assert.False (view.NeedsLayout);
+
+        int? fastWidth = view.TextFormatter.ConstrainToWidth;
+        int? fastHeight = view.TextFormatter.ConstrainToHeight;
+        Assert.NotNull (fastWidth);
+        Assert.NotNull (fastHeight);
+
+        view.SetNeedsLayout ();
+        view.Layout ();
+        Assert.Equal (view.TextFormatter.ConstrainToWidth, fastWidth);
+        Assert.Equal (view.TextFormatter.ConstrainToHeight, fastHeight);
     }
 
     [Fact]

--- a/Tests/UnitTestsParallelizable/ViewBase/Layout/Dim.AutoTests.TextOptimization.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/Layout/Dim.AutoTests.TextOptimization.cs
@@ -1,0 +1,202 @@
+using static Terminal.Gui.ViewBase.Dim;
+
+namespace ViewBaseTests.Layout;
+
+// Claude - Opus 4.8
+// Diagnostics for issue #5499: changing Text on a view sized solely by its Text (both Width and Height are exactly
+// DimAutoStyle.Text) must skip SetNeedsLayout - and the ancestor propagation it triggers - when the new Text produces
+// the same Frame size. The content still changes, so a reformat and redraw must still happen.
+public partial class DimAutoTests
+{
+    [Fact]
+    public void Text_SameSize_DoesNotSetNeedsLayout_ButStillRedraws ()
+    {
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = Auto (DimAutoStyle.Text), Text = "12:00:00" };
+        view.Layout ();
+        Assert.Equal (new Rectangle (0, 0, 8, 1), view.Frame);
+
+        view.NeedsLayout = false;
+        view.ClearNeedsDraw ();
+
+        // Same width and height (8x1), different content
+        view.Text = "12:00:01";
+
+        Assert.False (view.NeedsLayout);
+        Assert.True (view.NeedsDraw);
+    }
+
+    [Fact]
+    public void Text_SameSize_SetsTextFormatterNeedsFormat ()
+    {
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = Auto (DimAutoStyle.Text), Text = "12:00:00" };
+        view.Layout ();
+
+        view.NeedsLayout = false;
+        view.TextFormatter.NeedsFormat = false;
+
+        view.Text = "12:00:01";
+
+        Assert.True (view.TextFormatter.NeedsFormat);
+    }
+
+    [Fact]
+    public void Text_SameSize_DoesNotPropagateNeedsLayoutToSuperView ()
+    {
+        // This is the key diagnostic the issue asked for: an identical-size text update must not mark the ancestor
+        // chain as needing layout.
+        View superView = new () { Width = 50, Height = 10 };
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = Auto (DimAutoStyle.Text), Text = "12:00:00" };
+        superView.Add (view);
+        superView.Layout (new Size (50, 10));
+        Assert.Equal (new Rectangle (0, 0, 8, 1), view.Frame);
+
+        superView.NeedsLayout = false;
+        view.NeedsLayout = false;
+
+        view.Text = "12:00:01";
+
+        Assert.False (view.NeedsLayout);
+        Assert.False (superView.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_DifferentSize_SetsNeedsLayout_AndPropagatesToSuperView ()
+    {
+        View superView = new () { Width = 50, Height = 10 };
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = Auto (DimAutoStyle.Text), Text = "12:00:00" };
+        superView.Add (view);
+        superView.Layout (new Size (50, 10));
+
+        superView.NeedsLayout = false;
+        view.NeedsLayout = false;
+
+        // Wider text changes the Frame size
+        view.Text = "12:00:00 in the morning";
+
+        Assert.True (view.NeedsLayout);
+        Assert.True (superView.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_SameSize_PreservesPendingLayoutRequest ()
+    {
+        // The optimization only avoids *setting* NeedsLayout; it never clears it. A layout request that was already
+        // pending must survive an identical-size text change.
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = Auto (DimAutoStyle.Text), Text = "12:00:00" };
+        view.Layout ();
+
+        view.SetNeedsLayout ();
+        Assert.True (view.NeedsLayout);
+
+        view.Text = "12:00:01";
+
+        Assert.True (view.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_AutoStyle_BypassesOptimization ()
+    {
+        // DimAutoStyle.Auto (Content | Text) also depends on content/subviews, so the optimization must not apply
+        // even when the text size is unchanged.
+        View view = new () { Width = Auto (), Height = Auto (), Text = "12:00:00" };
+        view.Layout ();
+
+        view.NeedsLayout = false;
+
+        view.Text = "12:00:01";
+
+        Assert.True (view.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_FixedDimensions_BypassOptimization ()
+    {
+        // The optimization is conservatively scoped to views sized solely by Text. A fixed-size view still routes
+        // through SetNeedsLayout on a text change.
+        View view = new () { Width = 20, Height = 3, Text = "12:00:00" };
+        view.Layout ();
+
+        view.NeedsLayout = false;
+
+        view.Text = "12:00:01";
+
+        Assert.True (view.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_NotYetLaidOut_SetsNeedsLayout ()
+    {
+        // _frame is null until the first layout pass; the optimization must bypass so the first layout can establish
+        // the Frame.
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = Auto (DimAutoStyle.Text) };
+
+        view.Text = "12:00:00";
+
+        Assert.True (view.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_SameSize_WithMinimum_DoesNotSetNeedsLayout ()
+    {
+        // Both texts are narrower than the minimum, so the minimum anchor clamps the width to the same value. The
+        // predictor reuses DimAuto.Calculate, so the min anchor is honored.
+        View view = new ()
+        {
+            Width = Auto (DimAutoStyle.Text, minimumContentDim: 20),
+            Height = Auto (DimAutoStyle.Text),
+            Text = "ab"
+        };
+        view.Layout ();
+        Assert.Equal (20, view.Frame.Width);
+
+        view.NeedsLayout = false;
+
+        view.Text = "cd";
+
+        Assert.Equal (20, view.Frame.Width);
+        Assert.False (view.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_ExceedsMinimum_SetsNeedsLayout ()
+    {
+        // Growing past the minimum changes the resulting width, so layout must run.
+        View view = new ()
+        {
+            Width = Auto (DimAutoStyle.Text, minimumContentDim: 20),
+            Height = Auto (DimAutoStyle.Text),
+            Text = "ab"
+        };
+        view.Layout ();
+        Assert.Equal (20, view.Frame.Width);
+
+        view.NeedsLayout = false;
+
+        view.Text = new string ('x', 30);
+
+        Assert.True (view.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_SameSize_WithBorderAdornment_DoesNotSetNeedsLayout ()
+    {
+        // The adornment thickness is part of the Frame size. The predictor must account for it (it does, by reusing
+        // DimAuto.Calculate which adds adornment thickness).
+        View view = new ()
+        {
+            Width = Auto (DimAutoStyle.Text),
+            Height = Auto (DimAutoStyle.Text),
+            BorderStyle = LineStyle.Single, // 1-thick adornment on each side
+            Text = "12:00:00"
+        };
+        view.Layout ();
+        Assert.Equal (new Rectangle (0, 0, 10, 3), view.Frame); // 8 + 2 wide, 1 + 2 tall
+
+        view.NeedsLayout = false;
+
+        view.Text = "12:00:01";
+
+        Assert.Equal (new Rectangle (0, 0, 10, 3), view.Frame);
+        Assert.False (view.NeedsLayout);
+    }
+}

--- a/Tests/UnitTestsParallelizable/ViewBase/Layout/Dim.AutoTests.TextOptimization.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/Layout/Dim.AutoTests.TextOptimization.cs
@@ -109,11 +109,76 @@ public partial class DimAutoTests
     }
 
     [Fact]
-    public void Text_FixedDimensions_BypassOptimization ()
+    public void Text_FixedDimensions_DoesNotSetNeedsLayout_ButStillRedraws ()
     {
-        // The optimization is conservatively scoped to views sized solely by Text. A fixed-size view still routes
-        // through SetNeedsLayout on a text change.
+        // A fixed-size view's Frame never changes on a text change, so layout is skipped and only a redraw happens -
+        // even when the new text is a different length (it still fits the fixed Frame). See issue #5499 (Finding 3:
+        // fixed-size text redraws should not force layout).
         View view = new () { Width = 20, Height = 3, Text = "12:00:00" };
+        view.Layout ();
+
+        view.NeedsLayout = false;
+        view.ClearNeedsDraw ();
+
+        view.Text = "a much longer string that still fits the fixed width";
+
+        Assert.False (view.NeedsLayout);
+        Assert.True (view.NeedsDraw);
+    }
+
+    [Fact]
+    public void Text_OneAxisAuto_SameSize_DoesNotSetNeedsLayout ()
+    {
+        // One axis Text-auto, the other fixed - a common label shape. Same-size text change skips layout. See issue
+        // #5499 (Finding 3: one-axis auto scenarios).
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = 1, Text = "12:00:00" };
+        view.Layout ();
+        Assert.Equal (new Rectangle (0, 0, 8, 1), view.Frame);
+
+        view.NeedsLayout = false;
+
+        view.Text = "12:00:01";
+
+        Assert.False (view.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_OneAxisAuto_DifferentSize_SetsNeedsLayout ()
+    {
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = 1, Text = "12:00:00" };
+        view.Layout ();
+
+        view.NeedsLayout = false;
+
+        view.Text = "12:00:00 in the morning";
+
+        Assert.True (view.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_PositionDependsOnText_SameSize_SetsNeedsLayout ()
+    {
+        // Finding 1: comparing only size is wrong. A Pos can depend on Text, so a same-size text change can still move
+        // the view. The full-Frame prediction must detect the position change and run layout.
+        View view = new () { Width = Auto (DimAutoStyle.Text), Height = Auto (DimAutoStyle.Text), Text = "aa" };
+        view.X = Pos.Func (v => v!.Text.StartsWith ("b") ? 5 : 0, view);
+        view.Layout ();
+        Assert.Equal (new Rectangle (0, 0, 2, 1), view.Frame);
+
+        view.NeedsLayout = false;
+
+        // Same size (2x1) but X must move from 0 to 5
+        view.Text = "bb";
+
+        Assert.True (view.NeedsLayout);
+    }
+
+    [Fact]
+    public void Text_CompositeDim_BypassesOptimization ()
+    {
+        // Finding 2: the guard must be exact. Dim.Auto(Text) + 2 is a composite (DimCombine), not a bare Text-auto, so
+        // it must not enter the size-only fast path.
+        View view = new () { Width = Auto (DimAutoStyle.Text) + 2, Height = Auto (DimAutoStyle.Text), Text = "12:00:00" };
         view.Layout ();
 
         view.NeedsLayout = false;

--- a/Tests/UnitTestsParallelizable/ViewBase/Layout/TextFastPathRenderTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/Layout/TextFastPathRenderTests.cs
@@ -1,0 +1,117 @@
+using UnitTests;
+using static Terminal.Gui.ViewBase.Dim;
+
+namespace ViewBaseTests.Layout;
+
+// Claude - Opus 4.8
+// End-to-end guard for the #5499 Text fast path: the redraw-only path (no layout pass after a same-Frame text change)
+// must leave the view rendering exactly as a full layout pass would - including wrapped/clipped fixed-size text, whose
+// TextFormatter constraints would otherwise be lost. Compares the FAST path (laid out only if the setter requested it)
+// against a CONTROL that always runs a full layout.
+public class TextFastPathRenderTests : TestDriverBase
+{
+    private static string DriverContents (IDriver driver)
+    {
+        System.Text.StringBuilder sb = new ();
+
+        for (var r = 0; r < driver.Screen.Height; r++)
+        {
+            for (var c = 0; c < driver.Screen.Width; c++)
+            {
+                string g = driver.Contents! [r, c].Grapheme;
+                sb.Append (string.IsNullOrEmpty (g) ? " " : g);
+            }
+
+            sb.Append ('\n');
+        }
+
+        return sb.ToString ().TrimEnd ();
+    }
+
+    private string RenderFast (View v, IDriver driver, string newText)
+    {
+        v.NeedsLayout = false;
+        v.Text = newText;
+
+        // Mirror the app loop: lay out only if the setter requested it. This keeps the redraw-only fast path isolated.
+        if (v.NeedsLayout)
+        {
+            v.Layout ();
+        }
+
+        v.Draw ();
+
+        return DriverContents (driver);
+    }
+
+    private string RenderControl (View v, IDriver driver, string newText)
+    {
+        v.Text = newText;
+        v.SetNeedsLayout ();
+        v.Layout ();
+        v.Draw ();
+
+        return DriverContents (driver);
+    }
+
+    [Theory]
+    [InlineData (5, 2, true, "abcdefghi")] // fixed size + word wrap (the reported regression)
+    [InlineData (5, 2, false, "abcdefghi")] // fixed size, no wrap (clipping)
+    [InlineData (6, 1, true, "ab cd ef gh")] // fixed width, single fixed row
+    public void FixedSize_TextChange_RendersLikeFullLayout (int width, int height, bool wrap, string newText)
+    {
+        IDriver dFast = CreateTestDriver (24, 8);
+        IDriver dCtrl = CreateTestDriver (24, 8);
+
+        View fast = new () { Driver = dFast, Width = width, Height = height, Text = "abc" };
+        fast.TextFormatter.WordWrap = wrap;
+        View ctrl = new () { Driver = dCtrl, Width = width, Height = height, Text = "abc" };
+        ctrl.TextFormatter.WordWrap = wrap;
+
+        fast.Layout ();
+        fast.Draw ();
+        ctrl.Layout ();
+        ctrl.Draw ();
+
+        string fastRender = RenderFast (fast, dFast, newText);
+        string ctrlRender = RenderControl (ctrl, dCtrl, newText);
+
+        Assert.False (fast.NeedsLayout); // confirms the fast path was actually taken
+        Assert.Equal (ctrlRender, fastRender);
+
+        fast.Dispose ();
+        ctrl.Dispose ();
+        dFast.Dispose ();
+        dCtrl.Dispose ();
+    }
+
+    [Theory]
+    [InlineData (5)] // Auto(Text, max:5) + wrap: text wider than max wraps to multiple rows
+    [InlineData (4)]
+    public void MaxConstrainedAuto_WordWrap_RendersLikeFullLayout (int max)
+    {
+        IDriver dFast = CreateTestDriver (24, 8);
+        IDriver dCtrl = CreateTestDriver (24, 8);
+
+        View fast = new () { Driver = dFast, Width = Auto (DimAutoStyle.Text, maximumContentDim: max), Height = Auto (DimAutoStyle.Text), Text = "ab cd" };
+        fast.TextFormatter.WordWrap = true;
+        View ctrl = new () { Driver = dCtrl, Width = Auto (DimAutoStyle.Text, maximumContentDim: max), Height = Auto (DimAutoStyle.Text), Text = "ab cd" };
+        ctrl.TextFormatter.WordWrap = true;
+
+        fast.Layout ();
+        fast.Draw ();
+        ctrl.Layout ();
+        ctrl.Draw ();
+
+        // "ab cd ef" keeps the same max-constrained width while wrapping - exercises the width->height prediction.
+        string fastRender = RenderFast (fast, dFast, "ab cd ef");
+        string ctrlRender = RenderControl (ctrl, dCtrl, "ab cd ef");
+
+        Assert.Equal (ctrlRender, fastRender);
+
+        fast.Dispose ();
+        ctrl.Dispose ();
+        dFast.Dispose ();
+        dCtrl.Dispose ();
+    }
+}


### PR DESCRIPTION
Fixes #5499.

## Problem

The `View.Text` setter unconditionally called `SetNeedsLayout()`. That marks the view and its whole subtree as needing layout, sets `_needsDrawAfterLayout`, and **propagates up the entire ancestor chain** on every text change, even when the recomputed frame is identical to the current one (e.g. a once-per-second clock `Label`).

The layout machinery already no-ops the *frame mutation* when nothing changed (`SetRelativeLayout` only calls `SetFrame` when `Frame != newFrame`), but the layout pass, formatter setup, redraw scheduling, and ancestor invalidation were still being scheduled every tick.

## Change

### `Terminal.Gui/ViewBase/View.Layout.cs`

Extracted `SetRelativeLayout`'s `Pos`/`Dim` -> absolute-`Frame` resolution into a private `TryComputeRelativeFrame (Size, out Rectangle)`. `SetRelativeLayout` now calls it, and so does the `Text` setter's speculative check. This keeps frame prediction and real layout on the same computation path.

Also extracted `SetRelativeLayout`'s post-frame `TextFormatter` constraint cleanup into `FinalizeTextFormatterConstraints()`. This matters because `UpdateTextFormatterText()` clears `ConstrainToWidth`/`ConstrainToHeight`; if the text setter skips layout, the fast path must still restore the same formatter constraints a full layout pass would produce so wrapped/clipped text formats correctly.

### `Terminal.Gui/ViewBase/View.Text.cs`

The setter now calls `TryRedrawWithoutLayout()` after updating `TextFormatter.Text`.

When the view has already been laid out and **both** `Width` and `Height` are eligible, `TryRedrawWithoutLayout()` resolves the would-be `Frame` via `TryComputeRelativeFrame`. If the predicted frame equals the current `Frame`, it skips `SetNeedsLayout()` and ancestor propagation, then:

- finalizes `TextFormatter` constraints with `FinalizeTextFormatterConstraints()`;
- sets `TextFormatter.NeedsFormat = true`;
- calls `SetNeedsDraw()`;
- lets the setter raise `TextChanged` normally.

The comparison is the **full `Rectangle`** (position and size), not just dimensions. A `Pos` can depend on `Text` (e.g. `Pos.Func` reading `view.Text`), so a same-size text change can still move the view and must run layout.

Eligibility is exact by design:

```csharp
static bool IsEagerlyResolvable (Dim dim) => dim is DimAbsolute or DimAuto { Style: DimAutoStyle.Text };
```

- `DimAbsolute` is constant; a Text-only `DimAuto` depends on this view's `TextFormatter`.
- `DimAutoStyle.Content` / `DimAutoStyle.Auto` can lay out subviews while calculating, so those fall back to `SetNeedsLayout()`.
- Composite/nested dims such as `Dim.Auto(Text) + 2` are not bare `DimAbsolute`/`DimAuto`, so they also fall back.

This covers the intended safe cases: both-axis Text-auto, fixed-size text redraws, and one-axis-auto (`Width = Auto(Text), Height = 1`). The optimization only avoids *setting* `NeedsLayout`; it never clears a pre-existing pending layout request.

## Tests

Added focused layout and render coverage:

- `Tests/UnitTestsParallelizable/ViewBase/Layout/Dim.AutoTests.TextOptimization.cs`
  - ancestor diagnostic: same-size text change leaves `superView.NeedsLayout == false` while the view still redraws;
  - full-frame guard: `Pos.Func` depending on `Text` forces layout when same-size text moves the view;
  - exact guard: composite dims bypass the fast path;
  - fixed-size and one-axis-auto fast paths;
  - formatter constraint survival for fixed-size and one-axis-auto word-wrap cases;
  - clock-style repeated same-width updates with no frame drift or ancestor propagation;
  - reentrant `TextChanged` handling;
  - min/max, border adornment, uninitialized, `DimAutoStyle.Auto`, different-size, and pending-layout cases.

- `Tests/UnitTestsParallelizable/ViewBase/Layout/TextFastPathRenderTests.cs`
  - compares the isolated redraw-only fast path against a forced full-layout control;
  - verifies rendered driver contents match for fixed-size wrap, fixed-size clip, single-row clipping, and max-constrained Text-auto wrapping.

Additional exploratory probes were run and removed after conversion of the high-value cases into permanent tests. They compared fast-path vs full-layout behavior across repeated text updates, fixed/min/max/Text-auto dimensions, word-wrap on/off, explicit content-size constraints, `Button`, `CheckBox`, and reentrant handlers.

## Verification

Current local verification on `ae2047abec598989a10bea28d858e01e6b6b2f5f`:

- Build `Tests/UnitTestsParallelizable`: passed
- `DimAutoTests` text-focused tests: 67 passed
- `TextFastPathRenderTests`: 5 passed
- `SetRelativeLayoutTests`: 10 passed
- Full `UnitTestsParallelizable`: 17,484 total / 0 failed / 17 skipped
- Full `UnitTests.NonParallelizable`: 74 total / 0 failed / 2 skipped

## Pull Request checklist

- [x] My code follows the style guidelines of Terminal.Gui
- [x] My code follows the Terminal.Gui library design guidelines
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [ ] I conducted basic QA to assure all features are working

🤖 Generated with [Claude Code](https://claude.com/claude-code)