### PR TITLE
Fixes #5555. Preserve explicit Scheme role reassignment

### DIFF
--- a/Terminal.Gui/Drawing/Scheme.cs
+++ b/Terminal.Gui/Drawing/Scheme.cs
@@ -545,6 +545,12 @@ public record Scheme : IEqualityOperators<Scheme, Scheme, bool>
     // Helper method for property _set implementation
     private Attribute? SetAttributeForRoleProperty (Attribute value, VisualRole role)
     {
+        // Reassigning an explicit value must not change the role to implicit.
+        if (TryGetExplicitlySetAttributeForRole (role, out Attribute? explicitValue) && explicitValue == value)
+        {
+            return value;
+        }
+
         // If value is the same as the algorithm value, use null
         if (GetAttributeForRoleCore (role, [], null) == value)
         {

--- a/Tests/UnitTestsParallelizable/Drawing/SchemeTests.cs
+++ b/Tests/UnitTestsParallelizable/Drawing/SchemeTests.cs
@@ -232,6 +232,28 @@ public class SchemeTests
     [Fact]
     public void CopyConstructor_Null_Throws () => Assert.Throws<ArgumentNullException> (() => new Scheme (null));
 
+    // Codex - GPT-5
+    [Fact]
+    public void CopyConstructor_Reassigning_Explicit_Role_Same_Value_Preserves_Explicit_Value ()
+    {
+        Attribute editable = new (new Color ("#00FF6A"), new Color ("#292E42"));
+        Scheme baseScheme = new ()
+        {
+            Normal = new Attribute (new Color ("#C0CAF5"), new Color ("#1A1B26")),
+            Editable = editable
+        };
+
+        Scheme copiedScheme = new (baseScheme)
+        {
+            Normal = new Attribute (new Color ("#C0CAF5"), new Color ("#16161E")),
+            Editable = editable
+        };
+
+        Assert.Equal (editable, copiedScheme.Editable);
+        Assert.True (copiedScheme.TryGetExplicitlySetAttributeForRole (VisualRole.Editable, out Attribute? explicitEditable));
+        Assert.Equal (editable, explicitEditable);
+    }
+
     [Fact]
     public void Is_Thread_Safe_For_Concurrent_Reads ()
     {


### PR DESCRIPTION
- Fixes #5555

## Description

Preserves an explicitly assigned Scheme role when a copied scheme
reassigns that role to the same Attribute.

Previously, SetAttributeForRoleProperty compared the assignment with the
resolved role value and converted a matching value to null. For copied
schemes, this erased the copied explicit value and caused the role to be
derived from Normal.

## Tests

Added a regression test covering an identical Editable reassignment after
copying and changing Normal.

- Full parallelizable suite: 17,453 passed, 17 skipped
- Scheme tests: 46 passed
- git diff --check: passed

## To pull down this PR locally:

```bash
git remote add copilot https://github.com/YourRobotOverlord/Terminal.Gui.git
git fetch copilot codex/fix-scheme-explicit-role-reassignment
git checkout copilot/codex/fix-scheme-explicit-role-reassignment
```
