### PR TITLE
Back-merge v2.4.14-beta.1 from main into develop

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -34,7 +34,7 @@ branches:
     # Matches the main branch
     regex: ^main$
     # Uses an empty label for stable releases
-    label: ''
+    label: beta
     # Increments patch version (x.y.z+1) on commits
     increment: Patch
     # Specifies develop as the source branch


### PR DESCRIPTION
Automatic back-merge after release v2.4.14-beta.1. Merge this to keep `develop` in sync with `main`.