### PR TITLE
Fixes #5561 - Make TuiConfigurationBuilder flat-key binding trim/AOT-safe

### DIFF
--- a/Terminal.Gui/Configuration/Settings/TuiConfigurationBuilder.cs
+++ b/Terminal.Gui/Configuration/Settings/TuiConfigurationBuilder.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
@@ -168,7 +167,7 @@ public class TuiConfigurationBuilder
 
     [UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Settings POCOs are simple types preserved by DynamicDependency in ConfigPropertyHostTypes.")]
     [UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "Settings POCOs are simple types; no generic instantiation needed at runtime.")]
-    private static void BindSection<T> (IConfiguration config, string sectionName, Action<T> apply) where T : new ()
+    private static void BindSection<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> (IConfiguration config, string sectionName, Action<T> apply) where T : new ()
     {
         T settings = new ();
         IConfigurationSection section = config.GetSection (sectionName);
@@ -206,10 +205,10 @@ public class TuiConfigurationBuilder
 
     /// <summary>
     ///     Binds flat dotted keys (e.g. <c>Driver.Force16Colors</c>) from the configuration root to the
-    ///     corresponding properties on the settings POCO.
+    ///     corresponding properties on the settings POCO. <typeparamref name="T"/>'s public properties are
+    ///     preserved for trimming via the <see cref="DynamicallyAccessedMembersAttribute"/> on the type parameter.
     /// </summary>
-    [UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "Settings POCOs are simple types preserved by DynamicDependency in ConfigPropertyHostTypes.")]
-    private static void BindFlatDottedKeys<T> (IConfiguration config, string sectionName, T settings)
+    private static void BindFlatDottedKeys<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicProperties)] T> (IConfiguration config, string sectionName, T settings)
     {
         string prefix = sectionName + ".";
 
@@ -244,8 +243,12 @@ public class TuiConfigurationBuilder
     }
 
     /// <summary>
-    ///     Converts a configuration string value to the target property type, using a fast path for the
-    ///     common scalar types and falling back to a <see cref="TypeConverter"/>.
+    ///     Converts a configuration string value to the target property type. Only the scalar types used by the
+    ///     settings POCOs are supported, so this path is trim/AOT-safe — it deliberately avoids
+    ///     <c>TypeDescriptor.GetConverter</c> (which is <see cref="RequiresUnreferencedCodeAttribute"/> /
+    ///     <see cref="RequiresDynamicCodeAttribute"/> and breaks NativeAOT/trimmed consumers). New non-scalar
+    ///     settings property types must be added here explicitly. Unsupported types return <see langword="null"/>
+    ///     and are skipped by <see cref="BindFlatDottedKeys{T}"/>.
     /// </summary>
     private static object? ConvertValue (string value, Type targetType)
     {
@@ -269,16 +272,14 @@ public class TuiConfigurationBuilder
             return value.Length > 0 ? new Rune (value [0]) : new Rune ('+');
         }
 
+        if (targetType == typeof (Key))
+        {
+            return Key.TryParse (value, out Key key) ? key : null;
+        }
+
         if (targetType.IsEnum)
         {
             return Enum.Parse (targetType, value);
-        }
-
-        TypeConverter converter = TypeDescriptor.GetConverter (targetType);
-
-        if (converter.CanConvertFrom (typeof (string)))
-        {
-            return converter.ConvertFromInvariantString (value);
         }
 
         return null;

--- a/Tests/UnitTestsParallelizable/Configuration/MecDottedKeyTests.cs
+++ b/Tests/UnitTestsParallelizable/Configuration/MecDottedKeyTests.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Terminal.Gui.Configuration;
+using Terminal.Gui.Input;
 
 namespace ConfigurationTests;
 
@@ -152,6 +153,30 @@ public class MecDottedKeyTests
         finally
         {
             DriverSettings.Defaults = original;
+        }
+    }
+
+    /// <summary>
+    ///     Verifies issue #5561 fix: a flat dotted <see cref="Key"/> key (<c>PopoverMenu.DefaultKey</c>) binds via
+    ///     the AOT-safe <see cref="Key"/> fast path — i.e. without the trim-unsafe <c>TypeDescriptor.GetConverter</c>
+    ///     fallback that was removed.
+    /// </summary>
+    [Fact]
+    public void ApplyToStaticFacades_BindsFlatDottedKeyTypedProperty ()
+    {
+        PopoverMenuSettings original = PopoverMenuSettings.Defaults;
+
+        try
+        {
+            TuiConfigurationBuilder builder = new ();
+            builder.RuntimeConfig = """{ "PopoverMenu.DefaultKey": "Ctrl+P" }""";
+            builder.ApplyToStaticFacades ();
+
+            Assert.Equal (Key.P.WithCtrl, PopoverMenuSettings.Defaults.DefaultKey);
+        }
+        finally
+        {
+            PopoverMenuSettings.Defaults = original;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #5561 — `TuiConfigurationBuilder`'s flat-dotted-key binding broke NativeAOT/trimmed consumers (regression from #5411). `ConvertValue` fell back to `TypeDescriptor.GetConverter` (annotated `[RequiresUnreferencedCode]`/`[RequiresDynamicCode]`) with no annotation, producing `IL2026`/`IL3050`; downstream AOT publishes (e.g. `tui-cs/Editor`'s `ted`) failed on all RIDs.

## Changes

- **`ConvertValue`** — replace the `TypeDescriptor.GetConverter` fallback with an explicit `Key` fast path (`Key.TryParse`). `Key` was the **only** non-scalar/non-enum type reachable via flat dotted keys (`MenuBar.DefaultKey`, `PopoverMenu.DefaultKey`); everything else is `string`/`bool`/`int`/`Rune`/`enum` and already had fast paths. The public binding path now has **no** `RequiresUnreferencedCode`/`RequiresDynamicCode` dependency.
- **`BindSection<T>` / `BindFlatDottedKeys<T>`** — annotate `T` with `[DynamicallyAccessedMembers(PublicProperties)]` so `typeof(T).GetProperties()` is trim-safe (fixes `IL2090`, which the issue's `TrimmerSingleWarn` default had collapsed behind the `IL2026`). All callers pass concrete settings types, so the annotation is satisfiable and preserves exactly the properties the trimmer would otherwise drop.
- Drop the now-unused `using System.ComponentModel;` and the no-longer-needed `IL2026` suppression on `BindFlatDottedKeys`.

## Verification

Reproduced the issue with a trimmed publish of a small consumer app that calls `new TuiConfigurationBuilder().ApplyToStaticFacades()`:

- **Before:** `IL2026` (ConvertValue → `GetConverter`) and `IL2090` (`BindFlatDottedKeys` → `GetProperties`).
- **After:** **zero** IL trim/AOT warnings from `TuiConfigurationBuilder`.

Added a regression test (`MecDottedKeyTests.ApplyToStaticFacades_BindsFlatDottedKeyTypedProperty`) confirming `PopoverMenu.DefaultKey` (a `Key`-typed flat dotted key) still binds via the new fast path. Full MEC test suite passes.

## Design note

The fallback is removed deliberately (issue option 2 — the stronger guarantee for a public, AOT-advertised API). Any future **non-scalar** settings property type must be added to `ConvertValue` explicitly; unsupported types return `null` and are skipped, the same as before for unconvertible values.

Fixes #5561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
