### PR TITLE
Fixes #5544 #issuecomment-4836836706. FileDialog/OpenDialog: one unre…

### DIFF
--- a/Terminal.Gui/FileServices/FileSystemTreeBuilder.cs
+++ b/Terminal.Gui/FileServices/FileSystemTreeBuilder.cs
@@ -72,5 +72,15 @@ public class FileSystemTreeBuilder : ITreeBuilder<IFileSystemInfo>, IComparer<IF
         }
     }
 
-    internal static bool IsReparsePoint (IFileSystemInfo entry) => (entry.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+    internal static bool IsReparsePoint (IFileSystemInfo entry)
+    {
+        try
+        {
+            return (entry.Attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+        catch (Exception)
+        {
+            return false; // treat an unreadable entry as not a reparse point / not expandable
+        }
+    }
 }

--- a/Terminal.Gui/Views/FileDialogs/FileDialogState.cs
+++ b/Terminal.Gui/Views/FileDialogs/FileDialogState.cs
@@ -4,6 +4,8 @@ namespace Terminal.Gui.Views;
 
 internal class FileDialogState
 {
+    private static readonly EnumerationOptions _ignoreInaccessibleEnumerationOptions = new () { IgnoreInaccessible = true };
+
     public FileDialogState (IDirectoryInfo dir, FileDialog parent)
     {
         Parent = parent;
@@ -60,19 +62,7 @@ internal class FileDialogState
     {
         try
         {
-            IEnumerable<IFileSystemInfo> entries;
-
-            // if directories only
-            if (Parent.OpenMode == OpenMode.Directory)
-            {
-                entries = dir.GetDirectories ();
-            }
-            else
-            {
-                entries = dir.GetFileSystemInfos ();
-            }
-
-            foreach (IFileSystemInfo entry in entries)
+            foreach (IFileSystemInfo entry in EnumerateReadableEntries (dir))
             {
                 AddReadableChild (children, entry);
             }
@@ -81,6 +71,17 @@ internal class FileDialogState
         {
             // Access permission exceptions, missing directories, etc.
         }
+    }
+
+    private IEnumerable<IFileSystemInfo> EnumerateReadableEntries (IDirectoryInfo dir)
+    {
+        // if directories only
+        if (Parent.OpenMode == OpenMode.Directory)
+        {
+            return dir.EnumerateDirectories ("*", _ignoreInaccessibleEnumerationOptions);
+        }
+
+        return dir.EnumerateFileSystemInfos ("*", _ignoreInaccessibleEnumerationOptions);
     }
 
     private void AddReadableChild (List<FileSystemInfoStats> children, IFileSystemInfo entry)

--- a/Tests/UnitTestsParallelizable/FileServices/FileSystemTreeBuilderTests.cs
+++ b/Tests/UnitTestsParallelizable/FileServices/FileSystemTreeBuilderTests.cs
@@ -1,0 +1,37 @@
+using System.IO.Abstractions;
+using Moq;
+
+namespace FileServicesTests;
+
+public class FileSystemTreeBuilderTests
+{
+    [Fact]
+    public void CanExpand_DirectoryWithUnreadableAttributes_DoesNotThrowAndReturnsFalse ()
+    {
+        Mock<IDirectoryInfo> directory = new ();
+        directory.SetupGet (d => d.Attributes).Throws (new UnauthorizedAccessException ("Access denied"));
+        directory.SetupGet (d => d.Exists).Returns (true);
+        directory.Setup (d => d.GetFileSystemInfos ()).Returns ([]);
+
+        FileSystemTreeBuilder builder = new ();
+
+        bool canExpand = builder.CanExpand (directory.Object);
+
+        Assert.False (canExpand);
+    }
+
+    [Fact]
+    public void GetChildren_DirectoryWithUnreadableAttributes_DoesNotThrowAndReturnsEmpty ()
+    {
+        Mock<IDirectoryInfo> directory = new ();
+        directory.SetupGet (d => d.Attributes).Throws (new UnauthorizedAccessException ("Access denied"));
+        directory.SetupGet (d => d.Exists).Returns (true);
+        directory.Setup (d => d.GetFileSystemInfos ()).Returns ([]);
+
+        FileSystemTreeBuilder builder = new ();
+
+        IEnumerable<IFileSystemInfo> children = builder.GetChildren (directory.Object);
+
+        Assert.Empty (children);
+    }
+}

--- a/Tests/UnitTestsParallelizable/Views/FileDialogResultTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/FileDialogResultTests.cs
@@ -265,6 +265,10 @@ public class FileDialogResultTests
             .Setup (d => d.GetFileSystemInfos ())
             .Returns ([goodFile, badFile, goodDirectory]);
 
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateFileSystemInfos ("*", It.IsAny<EnumerationOptions> ()))
+            .Returns ([goodFile, badFile, goodDirectory]);
+
         using FileDialog fd = new TestableFileDialog (fileSystem);
         fd.OpenMode = OpenMode.Mixed;
 
@@ -288,6 +292,10 @@ public class FileDialogResultTests
             .Setup (d => d.GetDirectories ())
             .Returns ([goodDirectory, badDirectory]);
 
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateDirectories ("*", It.IsAny<EnumerationOptions> ()))
+            .Returns ([goodDirectory, badDirectory]);
+
         using FileDialog fd = new TestableFileDialog (fileSystem);
         fd.OpenMode = OpenMode.Directory;
 
@@ -297,6 +305,64 @@ public class FileDialogResultTests
         Assert.Contains (fd.State!.Children, c => c.Name == "good-dir");
         Assert.Contains (fd.State.Children, c => c.IsParent && c.Name == "..");
         Assert.DoesNotContain (fd.State.Children, c => c.Name == "bad-dir");
+    }
+
+    [Fact]
+    public void FileDialog_MixedMode_WhenEagerListingThrows_StillKeepsReadableEntries ()
+    {
+        IFileSystem fileSystem = CreateFileSystemWithDirectory (out IDirectoryInfo directory);
+        IFileInfo goodFile = CreateFile ("/testdir/good.txt", "good.txt");
+        IDirectoryInfo goodDirectory = CreateDirectory ("/testdir/good-dir", "good-dir", directory);
+
+        Mock.Get (directory)
+            .Setup (d => d.GetFileSystemInfos ())
+            .Throws (new UnauthorizedAccessException ());
+
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateFileSystemInfos ())
+            .Returns ([goodFile, goodDirectory]);
+
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateFileSystemInfos ("*", It.IsAny<EnumerationOptions> ()))
+            .Returns ([goodFile, goodDirectory]);
+
+        using FileDialog fd = new TestableFileDialog (fileSystem);
+        fd.OpenMode = OpenMode.Mixed;
+
+        fd.Path = "/testdir";
+
+        Assert.NotNull (fd.State);
+        Assert.Contains (fd.State!.Children, c => c.Name == "good.txt");
+        Assert.Contains (fd.State.Children, c => c.Name == "good-dir");
+        Assert.Contains (fd.State.Children, c => c.IsParent && c.Name == "..");
+    }
+
+    [Fact]
+    public void FileDialog_DirectoryMode_WhenEagerListingThrows_StillKeepsReadableDirectories ()
+    {
+        IFileSystem fileSystem = CreateFileSystemWithDirectory (out IDirectoryInfo directory);
+        IDirectoryInfo goodDirectory = CreateDirectory ("/testdir/good-dir", "good-dir", directory);
+
+        Mock.Get (directory)
+            .Setup (d => d.GetDirectories ())
+            .Throws (new UnauthorizedAccessException ());
+
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateDirectories ())
+            .Returns ([goodDirectory]);
+
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateDirectories ("*", It.IsAny<EnumerationOptions> ()))
+            .Returns ([goodDirectory]);
+
+        using FileDialog fd = new TestableFileDialog (fileSystem);
+        fd.OpenMode = OpenMode.Directory;
+
+        fd.Path = "/testdir";
+
+        Assert.NotNull (fd.State);
+        Assert.Contains (fd.State!.Children, c => c.Name == "good-dir");
+        Assert.Contains (fd.State.Children, c => c.IsParent && c.Name == "..");
     }
 
     [Fact]
@@ -418,6 +484,10 @@ public class FileDialogResultTests
         directory.SetupGet (d => d.LastWriteTime).Returns (new DateTime (2026, 1, 1));
         directory.Setup (d => d.GetFileSystemInfos ()).Returns ([]);
         directory.Setup (d => d.GetDirectories ()).Returns ([]);
+        directory.Setup (d => d.EnumerateFileSystemInfos ()).Returns ([]);
+        directory.Setup (d => d.EnumerateDirectories ()).Returns ([]);
+        directory.Setup (d => d.EnumerateFileSystemInfos ("*", It.IsAny<EnumerationOptions> ())).Returns ([]);
+        directory.Setup (d => d.EnumerateDirectories ("*", It.IsAny<EnumerationOptions> ())).Returns ([]);
 
         return directory;
     }


### PR DESCRIPTION
## Fixes

- Fixes #5544

## Proposed Changes/Todos

- [x] Add fix and regression unit tests.

## Summary:

- Both tests fail as expected. The failure collection contains only the `..` parent row, proving the current fix preserves parent navigation but still loses the readable entries when the listing call itself throws.
- Changed `FileDialogState` to stop using the eager Get* methods altogether for normal listing. It will enumerate with `EnumerationOptions.IgnoreInaccessible = true`, then still wrap each returned entry defensively as before.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/tui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/tui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [ ] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
