### PR TITLE
Fixes FileDialog hiding hidden/system entries (dotfiles) after IgnoreInaccessible change

### DIFF
--- a/Terminal.Gui/Views/FileDialogs/FileDialogState.cs
+++ b/Terminal.Gui/Views/FileDialogs/FileDialogState.cs
@@ -4,7 +4,9 @@ namespace Terminal.Gui.Views;
 
 internal class FileDialogState
 {
-    private static readonly EnumerationOptions _ignoreInaccessibleEnumerationOptions = new () { IgnoreInaccessible = true };
+    // AttributesToSkip defaults to Hidden | System; clear it so hidden/system entries (e.g. dotfiles on Unix)
+    // remain visible, matching the behavior of the GetDirectories ()/GetFileSystemInfos () calls this replaced.
+    private static readonly EnumerationOptions _ignoreInaccessibleEnumerationOptions = new () { IgnoreInaccessible = true, AttributesToSkip = FileAttributes.None };
 
     public FileDialogState (IDirectoryInfo dir, FileDialog parent)
     {
@@ -63,6 +65,32 @@ internal class FileDialogState
         try
         {
             foreach (IFileSystemInfo entry in EnumerateReadableEntries (dir))
+            {
+                AddReadableChild (children, entry);
+            }
+        }
+        catch (NotSupportedException)
+        {
+            // Some IFileSystem implementations (e.g. System.IO.Abstractions.TestingHelpers MockFileSystem)
+            // do not support clearing EnumerationOptions.AttributesToSkip; fall back to the eager listing
+            // methods, which never skip hidden/system entries.
+            AddReadableChildrenEagerly (children, dir);
+        }
+        catch (Exception)
+        {
+            // Access permission exceptions, missing directories, etc.
+        }
+    }
+
+    private void AddReadableChildrenEagerly (List<FileSystemInfoStats> children, IDirectoryInfo dir)
+    {
+        try
+        {
+            IEnumerable<IFileSystemInfo> entries = Parent.OpenMode == OpenMode.Directory
+                                                       ? dir.GetDirectories ()
+                                                       : dir.GetFileSystemInfos ();
+
+            foreach (IFileSystemInfo entry in entries)
             {
                 AddReadableChild (children, entry);
             }

--- a/Tests/UnitTestsParallelizable/Views/FileDialogResultTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/FileDialogResultTests.cs
@@ -365,6 +365,127 @@ public class FileDialogResultTests
         Assert.Contains (fd.State.Children, c => c.IsParent && c.Name == "..");
     }
 
+    // Claude - Opus 4.8
+    [Fact]
+    public void FileDialog_MixedMode_EnumerationDoesNotSkipHiddenOrSystemEntries ()
+    {
+        IFileSystem fileSystem = CreateFileSystemWithDirectory (out IDirectoryInfo directory);
+        IFileInfo hiddenFile = CreateFile ("/testdir/.hidden", ".hidden");
+
+        EnumerationOptions? capturedOptions = null;
+
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateFileSystemInfos ("*", It.IsAny<EnumerationOptions> ()))
+            .Callback<string, EnumerationOptions> ((_, options) => capturedOptions = options)
+            .Returns ([hiddenFile]);
+
+        using FileDialog fd = new TestableFileDialog (fileSystem);
+        fd.OpenMode = OpenMode.Mixed;
+
+        fd.Path = "/testdir";
+
+        Assert.NotNull (capturedOptions);
+        Assert.True (capturedOptions!.IgnoreInaccessible);
+        Assert.Equal (FileAttributes.None, capturedOptions.AttributesToSkip);
+        Assert.Contains (fd.State!.Children, c => c.Name == ".hidden");
+    }
+
+    // Claude - Opus 4.8
+    [Fact]
+    public void FileDialog_DirectoryMode_EnumerationDoesNotSkipHiddenOrSystemEntries ()
+    {
+        IFileSystem fileSystem = CreateFileSystemWithDirectory (out IDirectoryInfo directory);
+        IDirectoryInfo hiddenDirectory = CreateDirectory ("/testdir/.git", ".git", directory);
+
+        EnumerationOptions? capturedOptions = null;
+
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateDirectories ("*", It.IsAny<EnumerationOptions> ()))
+            .Callback<string, EnumerationOptions> ((_, options) => capturedOptions = options)
+            .Returns ([hiddenDirectory]);
+
+        using FileDialog fd = new TestableFileDialog (fileSystem);
+        fd.OpenMode = OpenMode.Directory;
+
+        fd.Path = "/testdir";
+
+        Assert.NotNull (capturedOptions);
+        Assert.True (capturedOptions!.IgnoreInaccessible);
+        Assert.Equal (FileAttributes.None, capturedOptions.AttributesToSkip);
+        Assert.Contains (fd.State!.Children, c => c.Name == ".git");
+    }
+
+    // Claude - Opus 4.8
+    [Fact]
+    public void FileDialog_MixedMode_WhenEnumerationOptionsUnsupported_FallsBackToEagerListing ()
+    {
+        IFileSystem fileSystem = CreateFileSystemWithDirectory (out IDirectoryInfo directory);
+        IFileInfo goodFile = CreateFile ("/testdir/good.txt", "good.txt");
+
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateFileSystemInfos ("*", It.IsAny<EnumerationOptions> ()))
+            .Throws (new NotSupportedException ("The property AttributesToSkip is not yet implemented"));
+
+        Mock.Get (directory)
+            .Setup (d => d.GetFileSystemInfos ())
+            .Returns ([goodFile]);
+
+        using FileDialog fd = new TestableFileDialog (fileSystem);
+        fd.OpenMode = OpenMode.Mixed;
+
+        fd.Path = "/testdir";
+
+        Assert.NotNull (fd.State);
+        Assert.Contains (fd.State!.Children, c => c.Name == "good.txt");
+        Assert.Contains (fd.State.Children, c => c.IsParent && c.Name == "..");
+    }
+
+    // Claude - Opus 4.8
+    [Fact]
+    public void FileDialog_DirectoryMode_WhenEnumerationOptionsUnsupported_FallsBackToEagerListing ()
+    {
+        IFileSystem fileSystem = CreateFileSystemWithDirectory (out IDirectoryInfo directory);
+        IDirectoryInfo goodDirectory = CreateDirectory ("/testdir/good-dir", "good-dir", directory);
+
+        Mock.Get (directory)
+            .Setup (d => d.EnumerateDirectories ("*", It.IsAny<EnumerationOptions> ()))
+            .Throws (new NotSupportedException ("The property AttributesToSkip is not yet implemented"));
+
+        Mock.Get (directory)
+            .Setup (d => d.GetDirectories ())
+            .Returns ([goodDirectory]);
+
+        using FileDialog fd = new TestableFileDialog (fileSystem);
+        fd.OpenMode = OpenMode.Directory;
+
+        fd.Path = "/testdir";
+
+        Assert.NotNull (fd.State);
+        Assert.Contains (fd.State!.Children, c => c.Name == "good-dir");
+        Assert.Contains (fd.State.Children, c => c.IsParent && c.Name == "..");
+    }
+
+    // Claude - Opus 4.8
+    [Fact]
+    public void FileDialog_MixedMode_ListsHiddenAndSystemFiles ()
+    {
+        MockFileSystem fs = new ();
+        fs.AddDirectory ("/testdir");
+        fs.AddFile ("/testdir/visible.txt", new MockFileData ("visible"));
+        fs.AddFile ("/testdir/.hidden", new MockFileData ("hidden") { Attributes = FileAttributes.Hidden });
+        fs.AddFile ("/testdir/system.dat", new MockFileData ("system") { Attributes = FileAttributes.System });
+
+        using FileDialog fd = new TestableFileDialog (fs);
+        fd.OpenMode = OpenMode.Mixed;
+
+        fd.Path = "/testdir";
+
+        Assert.NotNull (fd.State);
+        Assert.Contains (fd.State!.Children, c => c.Name == "visible.txt");
+        Assert.Contains (fd.State.Children, c => c.Name == ".hidden");
+        Assert.Contains (fd.State.Children, c => c.Name == "system.dat");
+    }
+
     [Fact]
     public void FileDialog_Accepting_Directory_From_Table_Keeps_Path_On_Opened_Directory ()
     {


### PR DESCRIPTION
## Summary

Fixes the regression flagged by Codex review on #5580 ([review comment](https://github.com/tui-cs/Terminal.Gui/pull/5580#pullrequestreview-comments)): the `FileDialog` change that adopted `EnumerationOptions { IgnoreInaccessible = true }` (follow-up to #5544) kept the framework default `AttributesToSkip = Hidden | System`, so the dialog silently stopped listing hidden/system entries — including dotfiles on Unix, which .NET marks as `Hidden`. The `GetDirectories ()`/`GetFileSystemInfos ()` calls it replaced never skipped them.

## Changes

- **`FileDialogState`**: Clear `AttributesToSkip` (`FileAttributes.None`) on the shared `EnumerationOptions` so hidden/system entries remain visible while inaccessible ones are still ignored.
- **Fallback for `IFileSystem` implementations that reject non-default `AttributesToSkip`**: `System.IO.Abstractions.TestingHelpers` `MockFileSystem` throws `NotSupportedException` for any `AttributesToSkip` other than `Hidden | System` (its default; [not yet implemented upstream](https://github.com/TestableIO/System.IO.Abstractions)). Without the fallback that exception was swallowed and the dialog listed *nothing* for such file systems. `AddReadableChildren` now catches `NotSupportedException` and falls back to the eager `GetDirectories ()`/`GetFileSystemInfos ()` listing, which never skips hidden/system entries.

## Tests

- `FileDialog_MixedMode_EnumerationDoesNotSkipHiddenOrSystemEntries` / `FileDialog_DirectoryMode_EnumerationDoesNotSkipHiddenOrSystemEntries` — capture the `EnumerationOptions` passed to the enumeration calls and assert `IgnoreInaccessible == true` and `AttributesToSkip == FileAttributes.None`.
- `FileDialog_MixedMode_WhenEnumerationOptionsUnsupported_FallsBackToEagerListing` / `FileDialog_DirectoryMode_WhenEnumerationOptionsUnsupported_FallsBackToEagerListing` — assert the `NotSupportedException` fallback path lists entries.
- `FileDialog_MixedMode_ListsHiddenAndSystemFiles` — end-to-end via `MockFileSystem` with `Hidden` and `System` attributed files.

All 17,544 UnitTestsParallelizable tests and 42 IntegrationTests FileDialog tests pass.

Note for the v2.4.17 release (#5580): this should be merged to `develop` and flowed into the release branch before shipping, since the regression is part of the pending release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)