### PR TITLE
Fixes IsReparsePoint fail-open and PopoverMenu.DefaultKey binding collision (release v2.4.17 blockers)

### DIFF
--- a/Terminal.Gui/FileServices/FileSystemTreeBuilder.cs
+++ b/Terminal.Gui/FileServices/FileSystemTreeBuilder.cs
@@ -80,7 +80,10 @@ public class FileSystemTreeBuilder : ITreeBuilder<IFileSystemInfo>, IComparer<IF
         }
         catch (Exception)
         {
-            return false; // treat an unreadable entry as not a reparse point / not expandable
+            // Fail closed: if the reparse status cannot be read, treat the entry as a reparse point so
+            // callers do not traverse it — an unreadable symlink/junction could otherwise recreate the
+            // directory-cycle risk this guard exists to prevent.
+            return true;
         }
     }
 }

--- a/Terminal.Gui/Views/CharMap/CharMap.cs
+++ b/Terminal.Gui/Views/CharMap/CharMap.cs
@@ -103,7 +103,9 @@ public class CharMap : View, IDesignable, IValue<Rune>
         KeyBindings.Add (Key.PageDown, Command.PageDown);
         KeyBindings.Add (Key.Home, Command.Start);
         KeyBindings.Add (Key.End, Command.End);
-        KeyBindings.Add (PopoverMenu.DefaultKey, Command.Context);
+        // ReplaceCommands, not Add: PopoverMenu.DefaultKey is configurable and may collide with a key
+        // that is already bound (e.g. Ctrl+P); the user's context-menu key wins.
+        KeyBindings.ReplaceCommands (PopoverMenu.DefaultKey, Command.Context);
 
         MouseBindings.ReplaceCommands (MouseFlags.LeftButtonClicked, Command.Activate);
         MouseBindings.Add (MouseFlags.LeftButtonDoubleClicked, Command.Accept);

--- a/Terminal.Gui/Views/FileDialogs/FileDialog.cs
+++ b/Terminal.Gui/Views/FileDialogs/FileDialog.cs
@@ -231,7 +231,10 @@ public partial class FileDialog : Dialog<IReadOnlyList<string>?>, IDesignable
         // by default, Runnable doesn't bind to Command.Context, so
         // we can take advantage of the CommandNotBound event to handle it
         _tableView.CommandNotBound += TableViewHandleCommandNotBound;
-        _tableView.KeyBindings.Add (PopoverMenu.DefaultKey, Command.Context);
+
+        // ReplaceCommands, not Add: PopoverMenu.DefaultKey is configurable and may collide with a key
+        // TableView already binds (e.g. Ctrl+P -> Command.Up); the user's context-menu key wins.
+        _tableView.KeyBindings.ReplaceCommands (PopoverMenu.DefaultKey, Command.Context);
         _tableView.MouseBindings.Add (MouseFlags.RightButtonClicked, Command.Context);
 
         _tbPath.TextChanged += (_, _) => PathChanged ();

--- a/Tests/UnitTestsParallelizable/Configuration/PopoverMenuDefaultKeyCollisionTests.cs
+++ b/Tests/UnitTestsParallelizable/Configuration/PopoverMenuDefaultKeyCollisionTests.cs
@@ -1,0 +1,58 @@
+// Claude - Opus 4.8
+
+using System.IO.Abstractions.TestingHelpers;
+using Terminal.Gui.Configuration;
+
+namespace ConfigurationTests;
+
+/// <summary>
+///     Verifies that views binding <see cref="PopoverMenu.DefaultKey"/> to <see cref="Command.Context"/>
+///     do not throw when the configured key collides with a key the view already binds
+///     (e.g. Ctrl+P, which <see cref="TableView"/> binds to <see cref="Command.Up"/> by default).
+/// </summary>
+[Collection ("StaticSettingsTests")]
+public class PopoverMenuDefaultKeyCollisionTests
+{
+    [Fact]
+    public void FileDialog_Ctor_DoesNotThrow_WhenDefaultKeyCollidesWithTableViewBinding ()
+    {
+        PopoverMenuSettings original = PopoverMenuSettings.Defaults;
+
+        try
+        {
+            // TableView binds Ctrl+P -> Command.Up by default; the context-menu key must win without throwing.
+            PopoverMenuSettings.Defaults = new () { DefaultKey = Key.P.WithCtrl };
+
+            MockFileSystem fs = new ();
+            fs.AddDirectory ("/testdir");
+
+            using FileDialog fd = new (fs);
+
+            Assert.NotNull (fd);
+        }
+        finally
+        {
+            PopoverMenuSettings.Defaults = original;
+        }
+    }
+
+    [Fact]
+    public void CharMap_Ctor_DoesNotThrow_WhenDefaultKeyCollidesWithExistingBinding ()
+    {
+        PopoverMenuSettings original = PopoverMenuSettings.Defaults;
+
+        try
+        {
+            // CharMap binds Key.End -> Command.End before binding the context-menu key.
+            PopoverMenuSettings.Defaults = new () { DefaultKey = Key.End };
+
+            using CharMap charMap = new ();
+
+            Assert.NotNull (charMap);
+        }
+        finally
+        {
+            PopoverMenuSettings.Defaults = original;
+        }
+    }
+}

--- a/Tests/UnitTestsParallelizable/Configuration/StaticSettingsTestCollection.cs
+++ b/Tests/UnitTestsParallelizable/Configuration/StaticSettingsTestCollection.cs
@@ -1,0 +1,11 @@
+namespace ConfigurationTests;
+
+[CollectionDefinition ("StaticSettingsTests", DisableParallelization = true)]
+public class StaticSettingsTestCollection
+{
+    // Marker collection for tests that mutate process-wide static settings facades
+    // (e.g. DriverSettings.Defaults, PopoverMenuSettings.Defaults). Without
+    // DisableParallelization, these tests race views constructed in parallel tests —
+    // e.g. temporarily making PopoverMenu.DefaultKey read Ctrl+P while a FileDialog
+    // is being constructed elsewhere.
+}

--- a/Tests/UnitTestsParallelizable/FileServices/FileSystemTreeBuilderTests.cs
+++ b/Tests/UnitTestsParallelizable/FileServices/FileSystemTreeBuilderTests.cs
@@ -34,4 +34,16 @@ public class FileSystemTreeBuilderTests
 
         Assert.Empty (children);
     }
+
+    // Claude - Opus 4.8
+    [Fact]
+    public void IsReparsePoint_WhenAttributesUnreadable_FailsClosed ()
+    {
+        Mock<IDirectoryInfo> directory = new ();
+        directory.SetupGet (d => d.Attributes).Throws (new UnauthorizedAccessException ("Access denied"));
+
+        // Fail closed: an entry whose reparse status cannot be read must be treated as a reparse
+        // point so callers (CanExpand, GetChildren, FileDialog search) do not traverse it.
+        Assert.True (FileSystemTreeBuilder.IsReparsePoint (directory.Object));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the two blockers on release PR #5582:

### 1. Codex CR feedback — `IsReparsePoint` must fail closed

When reading `Attributes` throws, `FileSystemTreeBuilder.IsReparsePoint` returned `false`, so an unreadable symlink/junction was treated as safe to traverse — recreating the directory-cycle risk the guard exists to prevent. It now fails closed: unreadable reparse status → treated as a reparse point → `CanExpand`/`GetChildren` and `FileDialog.SearchState` do not traverse it. The existing unreadable-attributes tests (`CanExpand` → false, `GetChildren` → empty) still hold.

### 2. CI failure — `FileDialog` ctor crash: "A binding for Ctrl+P exists"

`Parallel Unit Tests (windows-latest)` failed in `AllViews_HasFocus_Changed_Event(SaveDialog)` because `FileDialog`'s ctor did `_tableView.KeyBindings.Add (PopoverMenu.DefaultKey, Command.Context)` while `PopoverMenu.DefaultKey` read **Ctrl+P** — a key `TableView` already binds to `Command.Up` (emacs-style nav).

**Root cause:** `MecDottedKeyTests.ApplyToStaticFacades_BindsFlatDottedKeyTypedProperty` temporarily swaps the process-wide `PopoverMenuSettings.Defaults` (to assert `"PopoverMenu.DefaultKey": "Ctrl+P"` binds), and its `[Collection ("StaticSettingsTests")]` had **no `CollectionDefinition`** — so it serialized only against its sibling Mec* classes and still raced every other test in the suite.

The crash is also reachable by real users: configuring `PopoverMenu.DefaultKey` to any already-bound key made every `FileDialog` (and `CharMap`) throw at construction.

Fixes:
- `FileDialog`/`CharMap` bind the context-menu key with `KeyBindings.ReplaceCommands` instead of `Add` — the user's configured key wins instead of crashing.
- Added `[CollectionDefinition ("StaticSettingsTests", DisableParallelization = true)]` so the five Mec* test classes that swap static settings facades no longer run in parallel with the rest of the suite (same pattern as the existing `Logging Tests` / `Environment Variable Tests` collections).

## Tests

- `IsReparsePoint_WhenAttributesUnreadable_FailsClosed`
- `FileDialog_Ctor_DoesNotThrow_WhenDefaultKeyCollidesWithTableViewBinding`
- `CharMap_Ctor_DoesNotThrow_WhenDefaultKeyCollidesWithExistingBinding`

Full `UnitTestsParallelizable` suite (17,547) and integration `FileDialogTests` (42) pass locally.

After this merges to `develop`, #5582 should be closed and Prepare Release (stable) re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)