### PR TITLE
Fixes #5579. SynchronizationContext is not correctly implemented in v2

### DIFF
--- a/Terminal.Gui/App/ApplicationImpl.Lifecycle.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Lifecycle.cs
@@ -14,10 +14,10 @@ internal partial class ApplicationImpl
     /// <inheritdoc/>
     public bool Initialized { get; set; }
 
+    internal SynchronizationContext? SynchronizationContext { get; private set; }
+
     /// <inheritdoc/>
     public event EventHandler<EventArgs<bool>>? InitializedChanged;
-
-    internal SynchronizationContext SynchronizationContext;
 
     /// <inheritdoc/>
     public IApplication Init (string? driverName = null)

--- a/Terminal.Gui/App/ApplicationImpl.Lifecycle.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Lifecycle.cs
@@ -17,6 +17,8 @@ internal partial class ApplicationImpl
     /// <inheritdoc/>
     public event EventHandler<EventArgs<bool>>? InitializedChanged;
 
+    internal SynchronizationContext SynchronizationContext;
+
     /// <inheritdoc/>
     public IApplication Init (string? driverName = null)
     {
@@ -79,7 +81,8 @@ internal partial class ApplicationImpl
         RaiseInitializedChanged (this, new EventArgs<bool> (true));
         SubscribeDriverEvents ();
 
-        SynchronizationContext.SetSynchronizationContext (new SynchronizationContext ());
+        SynchronizationContext = new MainLoopSyncContext (this);
+        SynchronizationContext.SetSynchronizationContext (SynchronizationContext);
 
         _result = null;
 

--- a/Terminal.Gui/App/ApplicationImpl.Run.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Run.cs
@@ -136,6 +136,9 @@ internal partial class ApplicationImpl
         // Set the application reference in the runnable
         runnable.SetApp (this);
 
+        // Set the synchronization context to MainLoopSyncContext for this application
+        SynchronizationContext.SetSynchronizationContext (SynchronizationContext);
+
         // Ensure the mouse is ungrabbed
         Mouse.UngrabMouse ();
 

--- a/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
@@ -71,8 +71,7 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
         Task waitForSemaphore = _startupSemaphore.WaitAsync ();
 
         // Wait for either the semaphore to be released or the input task to crash.
-        // ReSharper disable once UseConfigureAwaitFalse
-        Task completedTask = await Task.WhenAny (waitForSemaphore, _inputTask);
+        Task completedTask = await Task.WhenAny (waitForSemaphore, _inputTask).ConfigureAwait (false);
 
         // Check if the task was the input task and if it has failed.
         if (completedTask == _inputTask)

--- a/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
@@ -1,43 +1,78 @@
-#nullable disable
 namespace Terminal.Gui.App;
 
-///// <summary>
-/////     provides the sync context set while executing code in Terminal.Gui, to let
-/////     users use async/await on their code
-///// </summary>
-//internal sealed class MainLoopSyncContext : SynchronizationContext
-//{
-//    public override SynchronizationContext CreateCopy () { return new MainLoopSyncContext (); }
+/// <summary>
+///     Provides the sync context set while executing code in Terminal.Gui, to let
+///     users use async/await on their code
+/// </summary>
+internal sealed class MainLoopSyncContext : SynchronizationContext
+{
+    private readonly IApplication _app;
 
-//    public override void Post (SendOrPostCallback d, object state)
-//    {
-//        // Queue the task using the modern architecture
-//        ApplicationImpl.Instance.Invoke (() => { d (state); });
-//    }
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="MainLoopSyncContext"/> class.
+    /// </summary>
+    /// <param name="app">The application instance that owns the main loop.</param>
+    public MainLoopSyncContext (IApplication app) => _app = app;
 
-//    //_mainLoop.Driver.Wakeup ();
-//    public override void Send (SendOrPostCallback d, object state)
-//    {
-//        if (Thread.CurrentThread.ManagedThreadId == Application.MainThreadId)
-//        {
-//            d (state);
-//        }
-//        else
-//        {
-//            var wasExecuted = false;
+    /// <inheritdoc/>
+    public override SynchronizationContext CreateCopy () => new MainLoopSyncContext (_app);
 
-//            ApplicationImpl.Instance.Invoke (
-//                                             () =>
-//                                             {
-//                                                 d (state);
-//                                                 wasExecuted = true;
-//                                             }
-//                                            );
+    /// <inheritdoc/>
+    public override void Post (SendOrPostCallback d, object? state)
+    {
+        ArgumentNullException.ThrowIfNull (d);
 
-//            while (!wasExecuted)
-//            {
-//                Thread.Sleep (15);
-//            }
-//        }
-//    }
-//}
+        // Queue the task using the modern architecture
+        _app.Invoke (() => d (state));
+    }
+
+    /// <inheritdoc/>
+    public override void Send (SendOrPostCallback d, object? state)
+    {
+        ArgumentNullException.ThrowIfNull (d);
+
+        if (_app.MainThreadId == Thread.CurrentThread.ManagedThreadId)
+        {
+            d (state);
+
+            return;
+        }
+
+        object gate = new ();
+        bool wasExecuted = false;
+        Exception? error = null;
+
+        _app.Invoke (() =>
+        {
+            try
+            {
+                d (state);
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
+            finally
+            {
+                lock (gate)
+                {
+                    wasExecuted = true;
+                    Monitor.Pulse (gate);
+                }
+            }
+        });
+
+        lock (gate)
+        {
+            while (!wasExecuted)
+            {
+                Monitor.Wait (gate);
+            }
+        }
+
+        if (error is { })
+        {
+            throw error;
+        }
+    }
+}

--- a/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
@@ -72,7 +72,7 @@ internal sealed class MainLoopSyncContext : SynchronizationContext
 
         if (error is { })
         {
-            throw error;
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture (error).Throw ();
         }
     }
 }

--- a/Tests/UnitTestsParallelizable/Application/ApplicationImplTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/ApplicationImplTests.cs
@@ -54,6 +54,122 @@ public class ApplicationImplTests
     }
 
     [Fact]
+    public void Init_Posts_To_The_App_Main_Thread ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        int mainThreadId = app.MainThreadId ?? Thread.CurrentThread.ManagedThreadId;
+        int? callbackThreadId = null;
+        ManualResetEventSlim callbackCalled = new (false);
+
+        SynchronizationContext.Current!.Post (_ =>
+                                              {
+                                                  callbackThreadId = Thread.CurrentThread.ManagedThreadId;
+                                                  callbackCalled.Set ();
+                                              },
+                                              null);
+
+        app.AddTimeout (TimeSpan.FromMilliseconds (100),
+                        () =>
+                        {
+                            app.RequestStop ();
+
+                            return false;
+                        });
+
+        app.Run (new Window ());
+
+        Assert.True (callbackCalled.Wait (TimeSpan.FromMilliseconds (200), TestContext.Current.CancellationToken));
+        Assert.Equal (mainThreadId, callbackThreadId);
+
+        app.Dispose ();
+    }
+
+    [Fact]
+    public void Init_Posts_To_The_App_Instance_Main_Thread ()
+    {
+        IApplication app1 = Application.Create ();
+        app1.Init (DriverRegistry.Names.ANSI);
+
+        int mainThreadId1 = app1.MainThreadId ?? Thread.CurrentThread.ManagedThreadId;
+        int? callbackThreadId1 = null;
+        SynchronizationContext? synchronizationContext1 = null;
+
+        ManualResetEventSlim callbackCalled = new (false);
+
+        app1.AddTimeout (TimeSpan.FromMilliseconds (100),
+                        () =>
+                        {
+                            if (synchronizationContext1 is null)
+                            {
+                                synchronizationContext1 = SynchronizationContext.Current;
+                                synchronizationContext1?.Post (_ =>
+                                                                      {
+                                                                          callbackThreadId1 = Thread.CurrentThread.ManagedThreadId;
+                                                                          callbackCalled.Set ();
+                                                                      },
+                                                                      null);
+
+                                return true;
+                            }
+                            else
+                            {
+                                app1.RequestStop ();
+
+                                return false;
+                            }
+                        });
+
+        app1.Run (new Window ());
+
+        Assert.True (callbackCalled.Wait (TimeSpan.FromMilliseconds (200), TestContext.Current.CancellationToken));
+        Assert.Equal (mainThreadId1, callbackThreadId1);
+        Assert.Equal (synchronizationContext1, SynchronizationContext.Current);
+
+        IApplication app2 = Application.Create ();
+        app2.Init (DriverRegistry.Names.ANSI);
+
+        int mainThreadId2 = app2.MainThreadId ?? Thread.CurrentThread.ManagedThreadId;
+        int? callbackThreadId2 = null;
+        SynchronizationContext? synchronizationContext2 = null;
+
+        app2.AddTimeout (TimeSpan.FromMilliseconds (100),
+                         () =>
+                         {
+                             if (synchronizationContext2 is null)
+                             {
+                                 synchronizationContext2 = SynchronizationContext.Current;
+                                 synchronizationContext2?.Post (_ =>
+                                                                      {
+                                                                          callbackThreadId2 = Thread.CurrentThread.ManagedThreadId;
+                                                                          callbackCalled.Set ();
+                                                                      },
+                                                                      null);
+
+                                 return true;
+                             }
+                             else
+                             {
+                                 app2.RequestStop ();
+
+                                 return false;
+                             }
+                         });
+
+        app2.Run (new Window ());
+
+        Assert.True (callbackCalled.Wait (TimeSpan.FromMilliseconds (200), TestContext.Current.CancellationToken));
+        Assert.Equal (mainThreadId2, callbackThreadId2);
+        Assert.NotEqual (synchronizationContext1, SynchronizationContext.Current);
+        Assert.Equal (synchronizationContext2, SynchronizationContext.Current);
+        Assert.NotEqual (synchronizationContext1, synchronizationContext2);
+
+        app1.Dispose ();
+        app2.Dispose ();
+    }
+
+    [Fact]
     public void Dispose_Alone_Does_Nothing ()
     {
         IApplication app = Application.Create ();

--- a/Tests/UnitTestsParallelizable/Application/ApplicationImplTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/ApplicationImplTests.cs
@@ -92,6 +92,9 @@ public class ApplicationImplTests
         IApplication app1 = Application.Create ();
         app1.Init (DriverRegistry.Names.ANSI);
 
+        IApplication app2 = Application.Create ();
+        app2.Init (DriverRegistry.Names.ANSI);
+
         int mainThreadId1 = app1.MainThreadId ?? Thread.CurrentThread.ManagedThreadId;
         int? callbackThreadId1 = null;
         SynchronizationContext? synchronizationContext1 = null;
@@ -126,9 +129,6 @@ public class ApplicationImplTests
         Assert.True (callbackCalled.Wait (TimeSpan.FromMilliseconds (200), TestContext.Current.CancellationToken));
         Assert.Equal (mainThreadId1, callbackThreadId1);
         Assert.Equal (synchronizationContext1, SynchronizationContext.Current);
-
-        IApplication app2 = Application.Create ();
-        app2.Init (DriverRegistry.Names.ANSI);
 
         int mainThreadId2 = app2.MainThreadId ?? Thread.CurrentThread.ManagedThreadId;
         int? callbackThreadId2 = null;

--- a/Tests/UnitTestsParallelizable/Application/ApplicationImplTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/ApplicationImplTests.cs
@@ -130,6 +130,8 @@ public class ApplicationImplTests
         Assert.Equal (mainThreadId1, callbackThreadId1);
         Assert.Equal (synchronizationContext1, SynchronizationContext.Current);
 
+        callbackCalled.Reset ();
+
         int mainThreadId2 = app2.MainThreadId ?? Thread.CurrentThread.ManagedThreadId;
         int? callbackThreadId2 = null;
         SynchronizationContext? synchronizationContext2 = null;


### PR DESCRIPTION
## Fixes

- Fixes #5579

## Proposed Changes/Todos

- [x] The SynchronizationContext is set on the Init method and also on the Begin method. Without the fix the unit tests will be fail.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/tui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/tui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working
