### PR TITLE
Fixes #5604 - Fix and simplify platform detection

### DIFF
--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiComponentFactory.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiComponentFactory.cs
@@ -78,7 +78,7 @@ public class AnsiComponentFactory : ComponentFactoryImpl<char>
     /// </summary>
     internal static Func<Size?> CreateNativeSizeQuery ()
     {
-        if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (OperatingSystem.IsWindows ())
         {
             return () =>
                    {

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiInput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiInput.cs
@@ -94,7 +94,7 @@ public class AnsiInput : InputImpl<char>, ITestableInput<char>
             }
 
             // Initialize platform-specific input helpers
-            if (PlatformDetection.IsWindows ())
+            if (OperatingSystem.IsWindows ())
             {
                 _windowsVTInput = new WindowsVTInputHelper ();
 
@@ -111,7 +111,7 @@ public class AnsiInput : InputImpl<char>, ITestableInput<char>
                 }
                 _platform = AnsiPlatform.WindowsVT;
             }
-            else if (PlatformDetection.IsUnixLike ())
+            else
             {
                 try
                 {
@@ -138,10 +138,6 @@ public class AnsiInput : InputImpl<char>, ITestableInput<char>
                                      "Init",
                                      $"Failed to enable Unix raw input mode. libc not available: {ex.Message}. Running in degraded mode.");
                 }
-            }
-            else
-            {
-                Trace.Lifecycle (nameof (AnsiInput), "Init", "Unknown OS platform. Terminal input will not work. Running in degraded mode.");
             }
 
             // NOTE: Output operations (alternate buffer, cursor visibility, mouse events)

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -111,7 +111,7 @@ public class AnsiOutput : OutputBase, IOutput
                 }
                 _platform = AnsiPlatform.WindowsVT;
             }
-            else if (!OperatingSystem.IsWindows ())
+            else
             {
                 // duplicate the controlling terminal output fd so we don't mess with it.
                 // When stdout is redirected this is /dev/tty rather than STDOUT_FILENO,

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -94,7 +94,7 @@ public class AnsiOutput : OutputBase, IOutput
             }
 
             // Initialize platform-specific output helpers
-            if (PlatformDetection.IsWindows ())
+            if (OperatingSystem.IsWindows ())
             {
                 _windowsVTOutput = new WindowsVTOutputHelper ();
 
@@ -111,7 +111,7 @@ public class AnsiOutput : OutputBase, IOutput
                 }
                 _platform = AnsiPlatform.WindowsVT;
             }
-            else if (PlatformDetection.IsUnixLike ())
+            else if (!OperatingSystem.IsWindows ())
             {
                 // duplicate the controlling terminal output fd so we don't mess with it.
                 // When stdout is redirected this is /dev/tty rather than STDOUT_FILENO,

--- a/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
+++ b/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
@@ -181,7 +181,7 @@ public class NetOutput : OutputBase, IOutput
     /// <inheritdoc/>
     public void Suspend ()
     {
-        if (PlatformDetection.IsWindows () && !IsAttachedToTerminal)
+        if (OperatingSystem.IsWindows () && !IsAttachedToTerminal)
         {
             return;
         }

--- a/Terminal.Gui/Drivers/DriverImpl.cs
+++ b/Terminal.Gui/Drivers/DriverImpl.cs
@@ -205,9 +205,9 @@ internal class DriverImpl : IDriver
         PlatformID p = Environment.OSVersion.Platform;
 
         return CreateClipboard (() => p is PlatformID.Win32NT or PlatformID.Win32S or PlatformID.Win32Windows,
-                                () => RuntimeInformation.IsOSPlatform (OSPlatform.OSX),
+                                OperatingSystem.IsMacOS,
                                 PlatformDetection.IsWSL,
-                                PlatformDetection.IsLinux,
+                                OperatingSystem.IsLinux,
                                 () => new WindowsClipboard (),
                                 () => new MacOSXClipboard (),
                                 () => new WSLClipboard (),

--- a/Terminal.Gui/Drivers/PlatformDetection.cs
+++ b/Terminal.Gui/Drivers/PlatformDetection.cs
@@ -8,66 +8,6 @@ namespace Terminal.Gui.Drivers;
 public static class PlatformDetection
 {
     /// <summary>
-    ///     Determines whether the current operating system is Linux.
-    /// </summary>
-    /// <remarks>
-    ///     This method returns <see langword="true"/> only when running on a Linux
-    ///     distribution. Other Unix-like platforms such as macOS and FreeBSD
-    ///     return <see langword="false"/>.
-    /// </remarks>
-    /// <returns>
-    ///     <see langword="true"/> if the operating system is Linux;
-    ///     otherwise, <see langword="false"/>.
-    /// </returns>
-    public static bool IsLinux () => RuntimeInformation.IsOSPlatform (OSPlatform.Linux);
-
-    /// <summary>
-    ///     Determines whether the current operating system is macOS.
-    /// </summary>
-    /// <returns>true if the current operating system is macOS; otherwise, false.</returns>
-    public static bool IsMac () => RuntimeInformation.IsOSPlatform (OSPlatform.OSX);
-
-    /// <summary>
-    ///     Determines whether the current operating system is a Unix-like platform.
-    /// </summary>
-    /// <remarks>
-    ///     Unix-like platforms include operating systems that derive from or
-    ///     closely follow traditional UNIX and POSIX design principles.
-    ///     On .NET, this currently includes Linux, macOS (Darwin), and FreeBSD.
-    /// </remarks>
-    /// <returns>
-    ///     <see langword="true"/> if the operating system is Linux, macOS, or FreeBSD;
-    ///     otherwise, <see langword="false"/>.
-    /// </returns>
-    public static bool IsUnixLike () =>
-        RuntimeInformation.IsOSPlatform (OSPlatform.Linux)
-        || RuntimeInformation.IsOSPlatform (OSPlatform.OSX)
-        || RuntimeInformation.IsOSPlatform (OSPlatform.FreeBSD);
-
-
-    /// <summary>Returns the <see cref="TuiPlatform"/> for the current operating system.</summary>
-    public static TuiPlatform GetCurrentPlatform ()
-    {
-        if (IsWindows ())
-        {
-            return TuiPlatform.Windows;
-        }
-
-        if (IsMac ())
-        {
-            return TuiPlatform.Macos;
-        }
-
-        return TuiPlatform.Linux;
-    }
-
-    /// <summary>
-    ///     Determines if the current platform is Windows.
-    /// </summary>
-    /// <returns></returns>
-    public static bool IsWindows () => RuntimeInformation.IsOSPlatform (OSPlatform.Windows);
-
-    /// <summary>
     ///     Determines if the current platform is WSL (Windows Subsystem for Linux).
     /// </summary>
     /// <returns>True if running on WSL, false otherwise.</returns>

--- a/Terminal.Gui/Drivers/TerminalDevice.cs
+++ b/Terminal.Gui/Drivers/TerminalDevice.cs
@@ -186,7 +186,7 @@ internal static class TerminalDevice
 
             try
             {
-                if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+                if (OperatingSystem.IsWindows ())
                 {
                     InitializeWindows ();
                 }

--- a/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 
 namespace Terminal.Gui.Drivers;
@@ -36,58 +37,30 @@ internal static class SuspendHelper
             return _suspendSignal;
         }
 
-        nint buf = Marshal.AllocHGlobal (8192);
-
-        if (uname (buf) != 0)
+        if (OperatingSystem.IsMacOS () ||
+            OperatingSystem.IsFreeBSD () ||
+            RuntimeInformation.IsOSPlatform (OSPlatform.Create ("NETBSD")) ||
+            RuntimeInformation.IsOSPlatform (OSPlatform.Create ("OPENBSD")))
         {
-            Marshal.FreeHGlobal (buf);
+            _suspendSignal = 18;
+        }
+        else if (OperatingSystem.IsLinux ())
+        {
+                _suspendSignal = 20;
+        }
+        else if (RuntimeInformation.IsOSPlatform (OSPlatform.Create ("SOLARIS")) ||
+                 RuntimeInformation.IsOSPlatform (OSPlatform.Create ("ILLUMOS")))
+        {
+            _suspendSignal = 24;
+        }
+        else
+        {
             _suspendSignal = -1;
-
-            return _suspendSignal;
         }
 
-        try
-        {
-            switch (Marshal.PtrToStringAnsi (buf))
-            {
-                case "Darwin":
-                case "DragonFly":
-                case "FreeBSD":
-                case "NetBSD":
-                case "OpenBSD":
-                    _suspendSignal = 18;
-
-                    break;
-
-                case "Linux":
-                    // TODO: should fetch the machine name and
-                    // if it is MIPS return 24
-                    _suspendSignal = 20;
-
-                    break;
-
-                case "Solaris":
-                    _suspendSignal = 24;
-
-                    break;
-
-                default:
-                    _suspendSignal = -1;
-
-                    break;
-            }
-
-            return _suspendSignal;
-        }
-        finally
-        {
-            Marshal.FreeHGlobal (buf);
-        }
+        return _suspendSignal;
     }
 
     [DllImport ("libc", SetLastError = true)]
     private static extern int killpg (int pgrp, int sig);
-
-    [DllImport ("libc")]
-    private static extern int uname (nint buf);
 }

--- a/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
@@ -53,6 +53,10 @@ internal static class SuspendHelper
         {
             _suspendSignal = 24;
         }
+        else if (RuntimeInformation.IsOSPlatform (OSPlatform.Create ("HAIKU")))
+        {
+            _suspendSignal = 21;
+        }
         else
         {
             _suspendSignal = -1;

--- a/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
@@ -46,7 +46,7 @@ internal static class SuspendHelper
         }
         else if (OperatingSystem.IsLinux ())
         {
-                _suspendSignal = 20;
+            _suspendSignal = 20;
         }
         else if (RuntimeInformation.IsOSPlatform (OSPlatform.Create ("SOLARIS")) ||
                  RuntimeInformation.IsOSPlatform (OSPlatform.Create ("ILLUMOS")))

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -181,9 +181,7 @@ internal static class UnixIOHelper
     ///     Get window/terminal size using ioctl.
     ///     Platform-specific constant (different on Darwin/BSD vs Linux).
     /// </summary>
-    public static readonly uint TIOCGWINSZ = RuntimeInformation.IsOSPlatform (OSPlatform.OSX) || RuntimeInformation.IsOSPlatform (OSPlatform.FreeBSD)
-                                                 ? 0x40087468u // Darwin/BSD
-                                                 : 0x5413u; // Linux
+    public static readonly uint TIOCGWINSZ = OperatingSystem.IsLinux () ? 0x5413u : 0x40087468u;
 
     /// <summary>
     ///     I/O control operations on file descriptors.
@@ -196,7 +194,7 @@ internal static class UnixIOHelper
     public static extern int ioctl (int fd, uint request, out WinSize ws);
 
     /// <summary>
-    ///     ioctl definition for Darwin/FreeBSD on ARM64.
+    ///     ioctl definition for Darwin on ARM64.
     ///     See https://github.com/dotnet/runtime/issues/48796#issuecomment-3695794860.
     /// </summary>
     /// <param name="fd">File descriptor</param>
@@ -435,7 +433,7 @@ internal static class UnixIOHelper
             WinSize ws;
 
             if (RuntimeInformation.OSArchitecture == Architecture.Arm64
-                && (RuntimeInformation.IsOSPlatform (OSPlatform.OSX) || RuntimeInformation.IsOSPlatform (OSPlatform.FreeBSD)))
+                && OperatingSystem.IsMacOS ())
             {
                 ioctlResult = ioctl_arm64 (fd,
                                            TIOCGWINSZ,

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixRawModeHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixRawModeHelper.cs
@@ -58,7 +58,7 @@ internal sealed class UnixRawModeHelper : IDisposable
         }
 
         // Only attempt on Unix-like platforms
-        if (!PlatformDetection.IsUnixLike ())
+        if (OperatingSystem.IsWindows ())
         {
             return false;
         }

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixTerminalHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixTerminalHelper.cs
@@ -100,7 +100,7 @@ internal static class UnixTerminalHelper
 
     public static void Suspend (IOutput output)
     {
-        if (PlatformDetection.IsWindows ())
+        if (OperatingSystem.IsWindows ())
         {
             return;
         }

--- a/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
@@ -101,7 +101,7 @@ internal partial class WindowsOutput : OutputBase, IOutput
             return;
         }
 
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -261,7 +261,7 @@ internal partial class WindowsOutput : OutputBase, IOutput
             return;
         }
 
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -290,7 +290,7 @@ internal partial class WindowsOutput : OutputBase, IOutput
 
     internal Size SetConsoleWindow (short cols, short rows)
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows) || !IsAttachedToTerminal)
+        if (!OperatingSystem.IsWindows () || !IsAttachedToTerminal)
         {
             return new Size (cols, rows);
         }
@@ -392,7 +392,7 @@ internal partial class WindowsOutput : OutputBase, IOutput
         {
             Logging.Error ($"Error: {e.Message} in {nameof (WindowsOutput)}");
 
-            if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+            if (OperatingSystem.IsWindows ())
             {
                 throw;
             }
@@ -455,7 +455,7 @@ internal partial class WindowsOutput : OutputBase, IOutput
             {
                 Logging.Error ($"Error: {e.Message} in {nameof (WindowsOutput)}");
 
-                if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+                if (OperatingSystem.IsWindows ())
                 {
                     throw;
                 }

--- a/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
+++ b/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTInputHelper.cs
@@ -124,7 +124,7 @@ internal sealed class WindowsVTInputHelper : IDisposable
         }
 
         // Only attempt on Windows
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return false;
         }
@@ -290,7 +290,7 @@ internal sealed class WindowsVTInputHelper : IDisposable
     /// </summary>
     public static void WakePendingRead ()
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }

--- a/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTOutputHelper.cs
+++ b/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTOutputHelper.cs
@@ -70,7 +70,7 @@ internal sealed class WindowsVTOutputHelper : IDisposable
         }
 
         // Only attempt on Windows
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return false;
         }

--- a/Terminal.Gui/Input/Keyboard/PlatformKeyBinding.cs
+++ b/Terminal.Gui/Input/Keyboard/PlatformKeyBinding.cs
@@ -66,7 +66,7 @@ public record PlatformKeyBinding
             }
         }
 
-        Key []? platKeys = OperatingSystem.IsWindows() ? Windows :
+        Key []? platKeys = OperatingSystem.IsWindows () ? Windows :
             OperatingSystem.IsMacOS () ? Macos : Linux;
 
         if (platKeys is null)

--- a/Terminal.Gui/Input/Keyboard/PlatformKeyBinding.cs
+++ b/Terminal.Gui/Input/Keyboard/PlatformKeyBinding.cs
@@ -66,13 +66,8 @@ public record PlatformKeyBinding
             }
         }
 
-        Key []? platKeys = PlatformDetection.GetCurrentPlatform () switch
-        {
-            TuiPlatform.Windows => Windows,
-            TuiPlatform.Linux => Linux,
-            TuiPlatform.Macos => Macos,
-            _ => null
-        };
+        Key []? platKeys = OperatingSystem.IsWindows() ? Windows :
+            OperatingSystem.IsMacOS () ? Macos : Linux;
 
         if (platKeys is null)
         {

--- a/Terminal.Gui/Input/Mouse/PlatformMouseBinding.cs
+++ b/Terminal.Gui/Input/Mouse/PlatformMouseBinding.cs
@@ -66,13 +66,8 @@ public record PlatformMouseBinding
             }
         }
 
-        MouseFlags []? platformFlags = PlatformDetection.GetCurrentPlatform () switch
-        {
-            TuiPlatform.Windows => Windows,
-            TuiPlatform.Linux => Linux,
-            TuiPlatform.Macos => Macos,
-            _ => null
-        };
+        MouseFlags []? platformFlags = OperatingSystem.IsWindows () ? Windows :
+            OperatingSystem.IsMacOS () ? Macos : Linux;
 
         if (platformFlags is null)
         {

--- a/Terminal.Gui/Views/Autocomplete/AutocompleteFilepathContext.cs
+++ b/Terminal.Gui/Views/Autocomplete/AutocompleteFilepathContext.cs
@@ -42,7 +42,7 @@ internal class FilepathSuggestionGenerator : ISuggestionGenerator
             return [];
         }
 
-        bool isWindows = RuntimeInformation.IsOSPlatform (OSPlatform.Windows);
+        bool isWindows = OperatingSystem.IsWindows ();
 
         string? [] suggestions = _state?.Children.Where (d => !d.IsParent)
                                        .Select (e => e.FileSystemInfo is IDirectoryInfo d ? d.Name + Path.DirectorySeparatorChar : e.FileSystemInfo?.Name)

--- a/Terminal.Gui/Views/Link.cs
+++ b/Terminal.Gui/Views/Link.cs
@@ -185,15 +185,15 @@ public class Link : View, IDesignable
 
         try
         {
-            if (PlatformDetection.IsWindows ())
+            if (OperatingSystem.IsWindows ())
             {
                 Process.Start (new ProcessStartInfo (url) { UseShellExecute = true });
             }
-            else if (PlatformDetection.IsMac ())
+            else if (OperatingSystem.IsMacOS ())
             {
                 Process.Start ("open", url);
             }
-            else if (PlatformDetection.IsLinux ())
+            else if (OperatingSystem.IsLinux ())
             {
                 using Process process = new ();
 

--- a/Tests/IntegrationTests/FluentTests/FileDialogTests.cs
+++ b/Tests/IntegrationTests/FluentTests/FileDialogTests.cs
@@ -144,7 +144,7 @@ public class FileDialogTests : TestsAllDrivers
                                     .AssertEqual (GetFileSystemRoot (fs!), sd!.FileName);
     }
 
-    private string GetFileSystemRoot (IFileSystem fs) => RuntimeInformation.IsOSPlatform (OSPlatform.Windows) ? $@"C:{fs.Path.DirectorySeparatorChar}" : "/";
+    private string GetFileSystemRoot (IFileSystem fs) => OperatingSystem.IsWindows () ? $@"C:{fs.Path.DirectorySeparatorChar}" : "/";
 
     [Theory]
     [MemberData (nameof (GetAllDriverNames))]

--- a/Tests/UnitTestsParallelizable/Application/Keyboard/KeyboardTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Keyboard/KeyboardTests.cs
@@ -394,7 +394,7 @@ public class KeyboardTests
         bool? result = keyboard.InvokeCommandsBoundToKey (key);
 
         // Assert — Suspend is NonWindows only, so on Windows this key is unbound
-        if (RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (OperatingSystem.IsWindows ())
         {
             Assert.Null (result);
         }

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiDriver/UnixRawModeHelperTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiDriver/UnixRawModeHelperTests.cs
@@ -63,9 +63,7 @@ public class UnixRawModeHelperTests
     [Fact]
     public void TryEnable_OnNonUnix_ReturnsFalse_AndLeavesNoSavedTermios ()
     {
-        if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux)
-            || RuntimeInformation.IsOSPlatform (OSPlatform.OSX)
-            || RuntimeInformation.IsOSPlatform (OSPlatform.FreeBSD))
+        if (!OperatingSystem.IsWindows ())
         {
             // Behaviour on Unix depends on whether stdin is a tty; covered by
             // integration tests, not this unit test.

--- a/Tests/UnitTestsParallelizable/Drivers/PlatformDetectionTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/PlatformDetectionTests.cs
@@ -13,35 +13,19 @@ public class PlatformDetectionTests (ITestOutputHelper output)
         if (OperatingSystem.IsWindows ())
         {
             Assert.False (isWSLExpected);
-            Assert.True (PlatformDetection.IsWindows ());
-            Assert.False (PlatformDetection.IsUnixLike ());
-            Assert.False (PlatformDetection.IsLinux ());
-            Assert.False (PlatformDetection.IsMac ());
         }
         else if (OperatingSystem.IsLinux ())
         {
             Assert.Equal (isWSLExpected, PlatformDetection.IsWSL ());
-            Assert.False (PlatformDetection.IsWindows ());
-            Assert.True (PlatformDetection.IsUnixLike ());
-            Assert.True (PlatformDetection.IsLinux ());
-            Assert.False (PlatformDetection.IsMac ());
         }
         else if (OperatingSystem.IsMacOS ())
         {
             Assert.False (isWSLExpected);
-            Assert.False (PlatformDetection.IsWindows ());
-            Assert.True (PlatformDetection.IsUnixLike ());
-            Assert.False (PlatformDetection.IsLinux ());
-            Assert.True (PlatformDetection.IsMac ());
         }
         else
         {
             // Fallback for other Unix-like or unknown systems
             Assert.False (isWSLExpected);
-            Assert.False (PlatformDetection.IsWindows ());
-            Assert.True (PlatformDetection.IsUnixLike ());
-            Assert.False (PlatformDetection.IsLinux ());
-            Assert.True (PlatformDetection.IsMac ());
             output.WriteLine ($"Unknown OS Description: {RuntimeInformation.OSDescription}");
         }
     }

--- a/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTests.cs
@@ -60,7 +60,7 @@ public class UnixIOHelperTests
     // Copilot
     public void IsInputAvailable_ReturnsTrue_WhenPollReportsReadableData ()
     {
-        if (!OperatingSystem.IsLinux () && !OperatingSystem.IsMacOS () && !OperatingSystem.IsFreeBSD ())
+        if (OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -95,7 +95,7 @@ public class UnixIOHelperTests
     // Copilot
     public void IsInputAvailable_ReturnsFalse_WhenPollReportsNonReadableEvent ()
     {
-        if (!OperatingSystem.IsLinux () && !OperatingSystem.IsMacOS () && !OperatingSystem.IsFreeBSD ())
+        if (OperatingSystem.IsWindows ())
         {
             return;
         }

--- a/Tests/UnitTestsParallelizable/Drivers/WindowsDriver/WindowsKeyConverterTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/WindowsDriver/WindowsKeyConverterTests.cs
@@ -25,7 +25,7 @@ public class WindowsKeyConverterTests
         KeyCode expectedKeyCode
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -53,7 +53,7 @@ public class WindowsKeyConverterTests
         KeyCode expectedKeyCode
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -87,7 +87,7 @@ public class WindowsKeyConverterTests
         KeyCode expectedKeyCode
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -123,7 +123,7 @@ public class WindowsKeyConverterTests
     [InlineData (ConsoleKey.RightArrow, KeyCode.CursorRight)]
     public void ToKey_SpecialKeys_ReturnsExpectedKeyCode (ConsoleKey consoleKey, KeyCode expectedKeyCode)
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -161,7 +161,7 @@ public class WindowsKeyConverterTests
     [InlineData (ConsoleKey.F12, KeyCode.F12)]
     public void ToKey_FunctionKeys_ReturnsExpectedKeyCode (ConsoleKey consoleKey, KeyCode expectedKeyCode)
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -189,7 +189,7 @@ public class WindowsKeyConverterTests
     [InlineData ('Ω')] // Greek character
     public void ToKey_VKPacket_Unicode_ReturnsExpectedCharacter (char unicodeChar)
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -207,7 +207,7 @@ public class WindowsKeyConverterTests
     [Fact]
     public void ToKey_VKPacket_ZeroChar_ReturnsNull ()
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -225,7 +225,7 @@ public class WindowsKeyConverterTests
     [Fact]
     public void ToKey_VKPacket_SurrogatePair_DocumentsCurrentLimitation ()
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -289,7 +289,7 @@ public class WindowsKeyConverterTests
         KeyCode expectedKeyCode
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -319,7 +319,7 @@ public class WindowsKeyConverterTests
         KeyCode expectedKeyCode
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -346,7 +346,7 @@ public class WindowsKeyConverterTests
         KeyCode expectedKeyCode
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -368,7 +368,7 @@ public class WindowsKeyConverterTests
     [Fact]
     public void ToKey_NullKey_ReturnsEmpty ()
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -398,7 +398,7 @@ public class WindowsKeyConverterTests
         char expectedChar
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -427,7 +427,7 @@ public class WindowsKeyConverterTests
         char expectedChar
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -459,7 +459,7 @@ public class WindowsKeyConverterTests
         char expectedChar
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -488,7 +488,7 @@ public class WindowsKeyConverterTests
     [InlineData (KeyCode.CursorRight, ConsoleKey.RightArrow)]
     public void ToKeyInfo_NavigationKeys_ReturnsExpectedInputRecord (KeyCode keyCode, ConsoleKey expectedConsoleKey)
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -510,7 +510,7 @@ public class WindowsKeyConverterTests
     [InlineData (KeyCode.F12, ConsoleKey.F12)]
     public void ToKeyInfo_FunctionKeys_ReturnsExpectedInputRecord (KeyCode keyCode, ConsoleKey expectedConsoleKey)
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -546,7 +546,7 @@ public class WindowsKeyConverterTests
         WindowsConsole.ControlKeyState expectedState
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -576,7 +576,7 @@ public class WindowsKeyConverterTests
     [InlineData (KeyCode.Home, 71)]
     public void ToKeyInfo_ScanCodes_ReturnsExpectedScanCode (KeyCode keyCode, ushort expectedScanCode)
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -607,7 +607,7 @@ public class WindowsKeyConverterTests
     [InlineData (KeyCode.Space)]
     public void RoundTrip_ToKeyInfo_ToKey_PreservesKeyCode (KeyCode originalKeyCode)
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -636,7 +636,7 @@ public class WindowsKeyConverterTests
         bool ctrl
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }
@@ -686,7 +686,7 @@ public class WindowsKeyConverterTests
         bool capsLock
     )
     {
-        if (!RuntimeInformation.IsOSPlatform (OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows ())
         {
             return;
         }

--- a/Tests/UnitTestsParallelizable/FileServices/FileSystemIconProviderTests.cs
+++ b/Tests/UnitTestsParallelizable/FileServices/FileSystemIconProviderTests.cs
@@ -39,7 +39,7 @@ public class FileSystemIconProviderTests
         var p = new FileSystemIconProvider ();
         IFileSystem fs = GetMockFileSystem ();
 
-        Assert.Equal (IsWindows () ? new Rune ('\\') : new Rune ('/'), p.GetIcon (fs.DirectoryInfo.New (@"c:\")));
+        Assert.Equal (OperatingSystem.IsWindows () ? new Rune ('\\') : new Rune ('/'), p.GetIcon (fs.DirectoryInfo.New (@"c:\")));
 
         Assert.Equal (
                       new Rune (' '),
@@ -49,7 +49,7 @@ public class FileSystemIconProviderTests
                      );
     }
 
-    private string GetFileSystemRoot () { return IsWindows () ? @"c:\" : "/"; }
+    private string GetFileSystemRoot () { return OperatingSystem.IsWindows () ? @"c:\" : "/"; }
 
     private IFileSystem GetMockFileSystem ()
     {
@@ -67,6 +67,4 @@ public class FileSystemIconProviderTests
 
         return fileSystem;
     }
-
-    private bool IsWindows () { return RuntimeInformation.IsOSPlatform (OSPlatform.Windows); }
 }

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/BindTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/BindTests.cs
@@ -98,12 +98,4 @@ public class BindTests
         Assert.Null (result.Linux);
         Assert.Null (result.Macos);
     }
-
-    [Fact]
-    public void GetCurrentPlatform_ReturnsValidPlatform ()
-    {
-        TuiPlatform platform = PlatformDetection.GetCurrentPlatform ();
-
-        Assert.True (Enum.IsDefined (platform));
-    }
 }

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/PlatformKeyBindingTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/PlatformKeyBindingTests.cs
@@ -102,9 +102,9 @@ public class PlatformKeyBindingTests
     [Fact]
     public void GetCurrentPlatformKeys_OtherPlatformOnly_ReturnsEmpty ()
     {
-        PlatformKeyBinding pkb = OperatingSystem.IsWindows() ? new () { Windows = [Key.F1] } :
-            OperatingSystem.IsMacOS () ? new () { Macos = [Key.F1] } :
-            new () { Linux = [Key.F1] };
+        PlatformKeyBinding pkb = OperatingSystem.IsWindows() ? new () { Linux = [Key.F1] } :
+            OperatingSystem.IsMacOS () ? new () { Windows = [Key.F1] } :
+            new () { Windows = [Key.F1] };
 
         List<Key> keys = pkb.GetCurrentPlatformKeys ().ToList ();
 

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/PlatformKeyBindingTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/PlatformKeyBindingTests.cs
@@ -77,7 +77,7 @@ public class PlatformKeyBindingTests
     {
         PlatformKeyBinding pkb = OperatingSystem.IsWindows() ? new () { Windows = [Key.F1] } :
             OperatingSystem.IsMacOS () ? new () { Macos = [Key.F1] } :
-            new () { Macos = [Key.F1] };
+            new () { Linux = [Key.F1] };
 
         List<Key> keys = pkb.GetCurrentPlatformKeys ().ToList ();
 

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/PlatformKeyBindingTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/PlatformKeyBindingTests.cs
@@ -75,16 +75,9 @@ public class PlatformKeyBindingTests
     [Fact]
     public void GetCurrentPlatformKeys_PlatformOnly_ReturnsCurrentPlatformKeys ()
     {
-        // Set the current platform's property (test runs on Windows for this CI)
-        TuiPlatform current = PlatformDetection.GetCurrentPlatform ();
-
-        PlatformKeyBinding pkb = current switch
-        {
-            TuiPlatform.Windows => new () { Windows = [Key.F1] },
-            TuiPlatform.Linux => new () { Linux = [Key.F1] },
-            TuiPlatform.Macos => new () { Macos = [Key.F1] },
-            _ => new () { Linux = [Key.F1] }
-        };
+        PlatformKeyBinding pkb = OperatingSystem.IsWindows() ? new () { Windows = [Key.F1] } :
+            OperatingSystem.IsMacOS () ? new () { Macos = [Key.F1] } :
+            new () { Macos = [Key.F1] };
 
         List<Key> keys = pkb.GetCurrentPlatformKeys ().ToList ();
 
@@ -95,15 +88,9 @@ public class PlatformKeyBindingTests
     [Fact]
     public void GetCurrentPlatformKeys_AllPlusPlatform_Additive ()
     {
-        TuiPlatform current = PlatformDetection.GetCurrentPlatform ();
-
-        PlatformKeyBinding pkb = current switch
-        {
-            TuiPlatform.Windows => new () { All = [Key.Esc], Windows = [Key.Q.WithCtrl] },
-            TuiPlatform.Linux => new () { All = [Key.Esc], Linux = [Key.Q.WithCtrl] },
-            TuiPlatform.Macos => new () { All = [Key.Esc], Macos = [Key.Q.WithCtrl] },
-            _ => new () { All = [Key.Esc], Linux = [Key.Q.WithCtrl] }
-        };
+        PlatformKeyBinding pkb = OperatingSystem.IsWindows() ? new () { All = [Key.Esc], Windows = [Key.Q.WithCtrl] } :
+            OperatingSystem.IsMacOS () ? new () { All = [Key.Esc], Macos = [Key.Q.WithCtrl] } :
+            new () { All = [Key.Esc], Linux = [Key.Q.WithCtrl] };
 
         List<Key> keys = pkb.GetCurrentPlatformKeys ().ToList ();
 
@@ -115,16 +102,9 @@ public class PlatformKeyBindingTests
     [Fact]
     public void GetCurrentPlatformKeys_OtherPlatformOnly_ReturnsEmpty ()
     {
-        TuiPlatform current = PlatformDetection.GetCurrentPlatform ();
-
-        // Set a platform that's NOT the current one
-        PlatformKeyBinding pkb = current switch
-        {
-            TuiPlatform.Windows => new () { Linux = [Key.F1] },
-            TuiPlatform.Linux => new () { Windows = [Key.F1] },
-            TuiPlatform.Macos => new () { Windows = [Key.F1] },
-            _ => new () { Windows = [Key.F1] }
-        };
+        PlatformKeyBinding pkb = OperatingSystem.IsWindows() ? new () { Windows = [Key.F1] } :
+            OperatingSystem.IsMacOS () ? new () { Macos = [Key.F1] } :
+            new () { Linux = [Key.F1] };
 
         List<Key> keys = pkb.GetCurrentPlatformKeys ().ToList ();
 

--- a/Tests/UnitTestsParallelizable/Input/Keyboard/PlatformKeyBindingTests.cs
+++ b/Tests/UnitTestsParallelizable/Input/Keyboard/PlatformKeyBindingTests.cs
@@ -75,7 +75,7 @@ public class PlatformKeyBindingTests
     [Fact]
     public void GetCurrentPlatformKeys_PlatformOnly_ReturnsCurrentPlatformKeys ()
     {
-        PlatformKeyBinding pkb = OperatingSystem.IsWindows() ? new () { Windows = [Key.F1] } :
+        PlatformKeyBinding pkb = OperatingSystem.IsWindows () ? new () { Windows = [Key.F1] } :
             OperatingSystem.IsMacOS () ? new () { Macos = [Key.F1] } :
             new () { Linux = [Key.F1] };
 
@@ -88,7 +88,7 @@ public class PlatformKeyBindingTests
     [Fact]
     public void GetCurrentPlatformKeys_AllPlusPlatform_Additive ()
     {
-        PlatformKeyBinding pkb = OperatingSystem.IsWindows() ? new () { All = [Key.Esc], Windows = [Key.Q.WithCtrl] } :
+        PlatformKeyBinding pkb = OperatingSystem.IsWindows () ? new () { All = [Key.Esc], Windows = [Key.Q.WithCtrl] } :
             OperatingSystem.IsMacOS () ? new () { All = [Key.Esc], Macos = [Key.Q.WithCtrl] } :
             new () { All = [Key.Esc], Linux = [Key.Q.WithCtrl] };
 
@@ -102,7 +102,7 @@ public class PlatformKeyBindingTests
     [Fact]
     public void GetCurrentPlatformKeys_OtherPlatformOnly_ReturnsEmpty ()
     {
-        PlatformKeyBinding pkb = OperatingSystem.IsWindows() ? new () { Linux = [Key.F1] } :
+        PlatformKeyBinding pkb = OperatingSystem.IsWindows () ? new () { Linux = [Key.F1] } :
             OperatingSystem.IsMacOS () ? new () { Windows = [Key.F1] } :
             new () { Windows = [Key.F1] };
 

--- a/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldTests.cs
@@ -1740,7 +1740,7 @@ public class TextFieldTests (ITestOutputHelper output) : TestDriverBase
     [Fact]
     public void UnifiedKeyBindings_NonWindows_Undo_Redo ()
     {
-        if (PlatformDetection.IsWindows ())
+        if (OperatingSystem.IsWindows ())
         {
             return; // non-Windows-only bindings are not added on Windows
         }

--- a/Tests/UnitTestsParallelizable/Views/TextViewMouseSelectionBindingsTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextViewMouseSelectionBindingsTests.cs
@@ -9,11 +9,11 @@ public class TextViewMouseSelectionBindingsTests
     {
         TextView textView = new ();
 
-        MouseFlags expectedStartSelection = OperatingSystem.IsWindows()
+        MouseFlags expectedStartSelection = OperatingSystem.IsWindows ()
                                                 ? MouseFlags.LeftButtonPressed | MouseFlags.Alt
                                                 : MouseFlags.LeftButtonPressed | MouseFlags.Shift;
 
-        MouseFlags expectedStartRectangleSelection = OperatingSystem.IsWindows. ()
+        MouseFlags expectedStartRectangleSelection = OperatingSystem.IsWindows ()
                                                          ? MouseFlags.LeftButtonPressed | MouseFlags.Alt | MouseFlags.Ctrl
                                                          : MouseFlags.LeftButtonPressed | MouseFlags.Shift | MouseFlags.Ctrl;
 

--- a/Tests/UnitTestsParallelizable/Views/TextViewMouseSelectionBindingsTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextViewMouseSelectionBindingsTests.cs
@@ -9,11 +9,11 @@ public class TextViewMouseSelectionBindingsTests
     {
         TextView textView = new ();
 
-        MouseFlags expectedStartSelection = PlatformDetection.GetCurrentPlatform () == TuiPlatform.Windows
+        MouseFlags expectedStartSelection = OperatingSystem.IsWindows()
                                                 ? MouseFlags.LeftButtonPressed | MouseFlags.Alt
                                                 : MouseFlags.LeftButtonPressed | MouseFlags.Shift;
 
-        MouseFlags expectedStartRectangleSelection = PlatformDetection.GetCurrentPlatform () == TuiPlatform.Windows
+        MouseFlags expectedStartRectangleSelection = OperatingSystem.IsWindows()
                                                          ? MouseFlags.LeftButtonPressed | MouseFlags.Alt | MouseFlags.Ctrl
                                                          : MouseFlags.LeftButtonPressed | MouseFlags.Shift | MouseFlags.Ctrl;
 

--- a/Tests/UnitTestsParallelizable/Views/TextViewMouseSelectionBindingsTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextViewMouseSelectionBindingsTests.cs
@@ -13,7 +13,7 @@ public class TextViewMouseSelectionBindingsTests
                                                 ? MouseFlags.LeftButtonPressed | MouseFlags.Alt
                                                 : MouseFlags.LeftButtonPressed | MouseFlags.Shift;
 
-        MouseFlags expectedStartRectangleSelection = OperatingSystem.IsWindows()
+        MouseFlags expectedStartRectangleSelection = OperatingSystem.IsWindows. ()
                                                          ? MouseFlags.LeftButtonPressed | MouseFlags.Alt | MouseFlags.Ctrl
                                                          : MouseFlags.LeftButtonPressed | MouseFlags.Shift | MouseFlags.Ctrl;
 

--- a/Tests/UnitTestsParallelizable/Views/TextViewTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextViewTests.cs
@@ -3846,7 +3846,7 @@ public class TextViewTests (ITestOutputHelper output)
     [Fact]
     public void UnifiedKeyBindings_NonWindows_Undo_Redo ()
     {
-        if (PlatformDetection.IsWindows ())
+        if (OperatingSystem.IsWindows ())
         {
             return; // non-Windows-only bindings are not added on Windows
         }


### PR DESCRIPTION
Other than Linux, all Unix OS use `0x40087468u`.

Other than macOS, all arm64 Unix OS use regular ioctl.

Use `OperatingSystem.IsLinux/Windows/MacOS()` and remove wrappers.

Fixes #5604