### PR TITLE
ci: read the release branch name from env instead of interpolating it

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Extract release info from branch name
         id: release
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
+          BRANCH="$HEAD_REF"
           # Branch name is release/vX.Y.Z or release/vX.Y.Z-beta
           TAG="${BRANCH#release/}"
           SEMVER="${TAG#v}"
@@ -82,8 +84,10 @@ jobs:
             $PRERELEASE_FLAG
 
       - name: Delete release branch
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
+          BRANCH="$HEAD_REF"
           git push origin --delete "$BRANCH" || true
           echo "Deleted branch: $BRANCH"
 

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -39,6 +39,12 @@ jobs:
           BRANCH="$HEAD_REF"
           # Branch name is release/vX.Y.Z or release/vX.Y.Z-beta
           TAG="${BRANCH#release/}"
+
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::Unexpected release branch format: $BRANCH"
+            exit 1
+          fi
+
           SEMVER="${TAG#v}"
 
           # Determine if this is a pre-release


### PR DESCRIPTION
Hi, and thanks for Terminal.Gui.

`.github/workflows/finalize-release.yml` reads the merged PR's branch name into a shell variable in two steps:

```yaml
BRANCH="${{ github.event.pull_request.head.ref }}"
```

once in "Extract release info from branch name" and again in "Delete release branch".

Actions substitutes `${{ ... }}` into the script text before bash runs, so the branch name becomes part of the script instead of a value assigned to `BRANCH`. Git allows `$`, `(`, `)` and backticks in branch names, and `$(...)` still runs inside double quotes.

The guard rails already here matter, and I would rather note them than overstate this:

- the job only runs on `github.event.pull_request.merged == true`, so a maintainer has to merge the PR first;
- and on `startsWith(github.event.pull_request.head.ref, 'release/')`, so the name has to begin with `release/` — but everything after that prefix is unconstrained;
- on a fork PR the `GITHUB_TOKEN` stays read-only regardless of the `contents: write` request.

So the realistic shape is a branch like `release/v1.0.0$(...)` executing on the runner once someone merges it, in a job that goes on to create tags and releases. Hardening rather than a live exploit.

The change binds the value to `env:` in both steps and leaves the rest untouched:

```yaml
env:
  HEAD_REF: ${{ github.event.pull_request.head.ref }}
run: |
  BRANCH="$HEAD_REF"
```

The `${BRANCH#release/}` and `${TAG#v}` stripping downstream is unchanged, so tag and semver extraction behave exactly as before.

Disclosure: I used AI assistance to help spot this and prepare the change, and I checked the workflow, its trigger and its conditions myself.
