### PR TITLE
Fix platform table and ARM64 ioctl guard defects following #5600

### DIFF
--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -135,6 +135,10 @@ public class AnsiOutput : OutputBase, IOutput
                     return;
                 }
 
+                // The duplicate only proves the fd is usable; writes go through UnixIOHelper.TryWriteStdout, which
+                // resolves TerminalDevice.OutputFd itself. Close it so each AnsiOutput does not leak a descriptor.
+                UnixIOHelper.close (fdCopy);
+
                 _platform = AnsiPlatform.UnixRaw;
             }
 

--- a/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
+++ b/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
@@ -212,7 +212,10 @@ public class NetOutput : OutputBase, IOutput
 
             if (!SuspendHelper.Suspend ())
             {
-                return;
+                // Do NOT return here. The alternate buffer has already been left and the cursor shown, so returning
+                // would leave the terminal that way while the app keeps drawing into the scrollback buffer.
+                Logging.Warning ("NetOutput.Suspend: SuspendHelper.Suspend () returned false; the process was never "
+                                 + "stopped. Re-entering the alternate buffer anyway.");
             }
 
             //Enable alternative screen buffer.

--- a/Terminal.Gui/Drivers/PlatformDetection.cs
+++ b/Terminal.Gui/Drivers/PlatformDetection.cs
@@ -54,6 +54,66 @@ public static class PlatformDetection
     }
 
     /// <summary>
+    ///     Determines whether the current operating system is Linux.
+    /// </summary>
+    /// <remarks>
+    ///     This method returns <see langword="true"/> only when running on a Linux distribution. Other Unix-like
+    ///     platforms such as macOS and FreeBSD return <see langword="false"/>, as does Android.
+    /// </remarks>
+    /// <returns><see langword="true"/> if the operating system is Linux; otherwise, <see langword="false"/>.</returns>
+    [Obsolete ("Use OperatingSystem.IsLinux () instead. This shim exists for binary compatibility with v2.4.17 and earlier.")]
+    public static bool IsLinux () => OperatingSystem.IsLinux ();
+
+    /// <summary>
+    ///     Determines whether the current operating system is macOS.
+    /// </summary>
+    /// <returns><see langword="true"/> if the current operating system is macOS; otherwise, <see langword="false"/>.</returns>
+    [Obsolete ("Use OperatingSystem.IsMacOS () instead. This shim exists for binary compatibility with v2.4.17 and earlier.")]
+    public static bool IsMac () => OperatingSystem.IsMacOS ();
+
+    /// <summary>
+    ///     Determines if the current platform is Windows.
+    /// </summary>
+    /// <returns><see langword="true"/> if the operating system is Windows; otherwise, <see langword="false"/>.</returns>
+    [Obsolete ("Use OperatingSystem.IsWindows () instead. This shim exists for binary compatibility with v2.4.17 and earlier.")]
+    public static bool IsWindows () => OperatingSystem.IsWindows ();
+
+    /// <summary>
+    ///     Determines whether the current operating system is a Unix-like platform.
+    /// </summary>
+    /// <remarks>
+    ///     Returns <see langword="true"/> for Linux, macOS (Darwin), and FreeBSD only. Other Unix platforms .NET can
+    ///     report — NetBSD, OpenBSD, Solaris, illumos, Haiku — return <see langword="false"/>, which is why driver
+    ///     code should test <c>!OperatingSystem.IsWindows ()</c> rather than call this.
+    /// </remarks>
+    /// <returns>
+    ///     <see langword="true"/> if the operating system is Linux, macOS, or FreeBSD; otherwise,
+    ///     <see langword="false"/>.
+    /// </returns>
+    [Obsolete ("Test !OperatingSystem.IsWindows () instead; this method excludes NetBSD, OpenBSD, Solaris, illumos and Haiku. "
+               + "This shim exists for binary compatibility with v2.4.17 and earlier.")]
+    public static bool IsUnixLike () => OperatingSystem.IsLinux () || OperatingSystem.IsMacOS () || OperatingSystem.IsFreeBSD ();
+
+    /// <summary>Returns the <see cref="TuiPlatform"/> for the current operating system.</summary>
+    /// <remarks>Any platform that is neither Windows nor macOS reports <see cref="TuiPlatform.Linux"/>.</remarks>
+    [Obsolete ("Use OperatingSystem.IsWindows ()/IsMacOS ()/IsLinux () instead. This shim exists for binary compatibility "
+               + "with v2.4.17 and earlier.")]
+    public static TuiPlatform GetCurrentPlatform ()
+    {
+        if (OperatingSystem.IsWindows ())
+        {
+            return TuiPlatform.Windows;
+        }
+
+        if (OperatingSystem.IsMacOS ())
+        {
+            return TuiPlatform.Macos;
+        }
+
+        return TuiPlatform.Linux;
+    }
+
+    /// <summary>
     ///     Determines if the current platform is WSL (Windows Subsystem for Linux).
     /// </summary>
     /// <returns>True if running on WSL, false otherwise.</returns>

--- a/Terminal.Gui/Drivers/PlatformDetection.cs
+++ b/Terminal.Gui/Drivers/PlatformDetection.cs
@@ -8,6 +8,52 @@ namespace Terminal.Gui.Drivers;
 public static class PlatformDetection
 {
     /// <summary>
+    ///     The .NET OS platform names Terminal.Gui carries platform-specific data for, in probe order.
+    /// </summary>
+    /// <remarks>
+    ///     These are the names <see cref="OperatingSystem.IsOSPlatform"/> matches against. .NET reports exactly one
+    ///     of them for any given runtime. Note that <c>ANDROID</c> is distinct from <c>LINUX</c>:
+    ///     <see cref="OperatingSystem.IsLinux"/> returns <see langword="false"/> on Android even though Android
+    ///     runs a Linux kernel.
+    /// </remarks>
+    internal static readonly string [] KnownPlatformNames =
+    [
+        "WINDOWS",
+        "LINUX",
+        "ANDROID",
+        "OSX",
+        "FREEBSD",
+        "NETBSD",
+        "OPENBSD",
+        "SOLARIS",
+        "ILLUMOS",
+        "HAIKU"
+    ];
+
+    /// <summary>
+    ///     Gets the .NET OS platform name for the current platform (for example <c>LINUX</c>, <c>OSX</c>, or
+    ///     <c>ANDROID</c>).
+    /// </summary>
+    /// <returns>
+    ///     The matching entry from <see cref="KnownPlatformNames"/>, or <see cref="string.Empty"/> when the current
+    ///     platform is not one Terminal.Gui has platform-specific data for (for example <c>BROWSER</c>).
+    /// </returns>
+    internal static string GetPlatformName ()
+    {
+        foreach (string name in KnownPlatformNames)
+        {
+            if (!RuntimeInformation.IsOSPlatform (OSPlatform.Create (name)))
+            {
+                continue;
+            }
+
+            return name;
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
     ///     Determines if the current platform is WSL (Windows Subsystem for Linux).
     /// </summary>
     /// <returns>True if running on WSL, false otherwise.</returns>

--- a/Terminal.Gui/Drivers/PlatformDetection.cs
+++ b/Terminal.Gui/Drivers/PlatformDetection.cs
@@ -22,6 +22,9 @@ public static class PlatformDetection
         "LINUX",
         "ANDROID",
         "OSX",
+        "MACCATALYST",
+        "IOS",
+        "TVOS",
         "FREEBSD",
         "NETBSD",
         "OPENBSD",
@@ -29,6 +32,18 @@ public static class PlatformDetection
         "ILLUMOS",
         "HAIKU"
     ];
+
+    /// <summary>
+    ///     Determines whether a platform name identifies an Apple (Darwin) platform.
+    /// </summary>
+    /// <param name="platformName">A platform name, as returned by <see cref="GetPlatformName"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="platformName"/> is an Apple platform.</returns>
+    /// <remarks>
+    ///     Apple platforms share Darwin's kernel interfaces and, on ARM64, Apple's variadic calling convention, so
+    ///     they must be treated as a group rather than testing for macOS alone. watchOS is absent because .NET has no
+    ///     <c>WATCHOS</c> platform name — it never reports one, so there is nothing to match.
+    /// </remarks>
+    internal static bool IsApplePlatformName (string platformName) => platformName is "OSX" or "MACCATALYST" or "IOS" or "TVOS";
 
     /// <summary>
     ///     Gets the .NET OS platform name for the current platform (for example <c>LINUX</c>, <c>OSX</c>, or

--- a/Terminal.Gui/Drivers/PlatformDetection.cs
+++ b/Terminal.Gui/Drivers/PlatformDetection.cs
@@ -11,10 +11,16 @@ public static class PlatformDetection
     ///     The .NET OS platform names Terminal.Gui carries platform-specific data for, in probe order.
     /// </summary>
     /// <remarks>
-    ///     These are the names <see cref="OperatingSystem.IsOSPlatform"/> matches against. .NET reports exactly one
-    ///     of them for any given runtime. Note that <c>ANDROID</c> is distinct from <c>LINUX</c>:
-    ///     <see cref="OperatingSystem.IsLinux"/> returns <see langword="false"/> on Android even though Android
-    ///     runs a Linux kernel.
+    ///     <para>
+    ///         These are the names <see cref="OperatingSystem.IsOSPlatform"/> matches against. Note that
+    ///         <c>ANDROID</c> is distinct from <c>LINUX</c>: <see cref="OperatingSystem.IsLinux"/> returns
+    ///         <see langword="false"/> on Android even though Android runs a Linux kernel.
+    ///     </para>
+    ///     <para>
+    ///         Order matters. A runtime normally reports exactly one of these names, but Mac Catalyst matches both
+    ///         <c>MACCATALYST</c> and <c>IOS</c> — .NET aliases <c>IOS</c> on that target. <c>MACCATALYST</c> is
+    ///         therefore listed first so the more specific name wins.
+    ///     </para>
     /// </remarks>
     internal static readonly string [] KnownPlatformNames =
     [

--- a/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 namespace Terminal.Gui.Drivers;
@@ -37,33 +36,44 @@ internal static class SuspendHelper
             return _suspendSignal;
         }
 
-        if (OperatingSystem.IsMacOS () ||
-            OperatingSystem.IsFreeBSD () ||
-            RuntimeInformation.IsOSPlatform (OSPlatform.Create ("NETBSD")) ||
-            RuntimeInformation.IsOSPlatform (OSPlatform.Create ("OPENBSD")))
-        {
-            _suspendSignal = 18;
-        }
-        else if (OperatingSystem.IsLinux ())
-        {
-            _suspendSignal = 20;
-        }
-        else if (RuntimeInformation.IsOSPlatform (OSPlatform.Create ("SOLARIS")) ||
-                 RuntimeInformation.IsOSPlatform (OSPlatform.Create ("ILLUMOS")))
-        {
-            _suspendSignal = 24;
-        }
-        else if (RuntimeInformation.IsOSPlatform (OSPlatform.Create ("HAIKU")))
-        {
-            _suspendSignal = 21;
-        }
-        else
-        {
-            _suspendSignal = -1;
-        }
+        _suspendSignal = MapSuspendSignal (PlatformDetection.GetPlatformName ());
 
         return _suspendSignal;
     }
+
+    /// <summary>
+    ///     Maps a .NET OS platform name to that platform's <c>SIGTSTP</c> signal number.
+    /// </summary>
+    /// <param name="platformName">
+    ///     A platform name from <see cref="PlatformDetection.KnownPlatformNames"/>, as returned by
+    ///     <see cref="PlatformDetection.GetPlatformName"/>.
+    /// </param>
+    /// <returns>The <c>SIGTSTP</c> number, or -1 when the platform has no known suspend signal.</returns>
+    /// <remarks>
+    ///     Values come from each platform's <c>signal.h</c>. Two entries are easy to get wrong:
+    ///     <list type="bullet">
+    ///         <item>
+    ///             Haiku's <c>SIGTSTP</c> is 13. 21 is <c>SIGKILLTHR</c> there, so sending 21 would kill threads
+    ///             instead of suspending.
+    ///         </item>
+    ///         <item>
+    ///             Android needs its own entry because <see cref="OperatingSystem.IsLinux"/> returns
+    ///             <see langword="false"/> on Android.
+    ///         </item>
+    ///     </list>
+    /// </remarks>
+    internal static int MapSuspendSignal (string platformName) =>
+        platformName switch
+        {
+            // Darwin and the BSDs share the historical BSD signal numbering.
+            "OSX" or "FREEBSD" or "NETBSD" or "OPENBSD" => 18,
+
+            // Linux, on every architecture .NET targets. (Linux/MIPS uses 24, but .NET has no MIPS target.)
+            "LINUX" or "ANDROID" => 20,
+            "SOLARIS" or "ILLUMOS" => 24,
+            "HAIKU" => 13,
+            _ => -1
+        };
 
     [DllImport ("libc", SetLastError = true)]
     private static extern int killpg (int pgrp, int sig);

--- a/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
@@ -65,8 +65,8 @@ internal static class SuspendHelper
     internal static int MapSuspendSignal (string platformName) =>
         platformName switch
         {
-            // Darwin and the BSDs share the historical BSD signal numbering.
-            "OSX" or "FREEBSD" or "NETBSD" or "OPENBSD" => 18,
+            // Darwin (all Apple platforms) and the BSDs share the historical BSD signal numbering.
+            "OSX" or "MACCATALYST" or "IOS" or "TVOS" or "FREEBSD" or "NETBSD" or "OPENBSD" => 18,
 
             // Linux, on every architecture .NET targets. (Linux/MIPS uses 24, but .NET has no MIPS target.)
             "LINUX" or "ANDROID" => 20,

--- a/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
@@ -6,12 +6,27 @@ internal static class SuspendHelper
 {
     private static int _suspendSignal;
 
-    /// <summary>Suspends the process by sending SIGTSTP to the process group.</summary>
-    /// <returns>True if the suspension was successful.</returns>
-    public static bool Suspend ()
-    {
-        int signal = GetSuspendSignal ();
+    /// <summary>Suspends the process by sending <c>SIGTSTP</c> to the process group.</summary>
+    /// <returns>
+    ///     <see langword="true"/> if the process group was stopped and has since resumed. <see langword="false"/> if
+    ///     the platform has no suspend signal, or if <c>killpg</c> failed.
+    /// </returns>
+    /// <remarks>
+    ///     A <see langword="false"/> return means the process was never stopped. Callers that tore down terminal state
+    ///     before calling this — leaving the alternate buffer, returning to cooked mode — must restore it either way,
+    ///     because there is nothing to resume from and the torn-down state would otherwise persist.
+    /// </remarks>
+    public static bool Suspend () => Suspend (GetSuspendSignal (), killpg);
 
+    /// <summary>Testable core of <see cref="Suspend()"/>, with the syscall supplied by the caller.</summary>
+    /// <param name="signal">The signal to send, or -1 when the platform has no suspend signal.</param>
+    /// <param name="killProcessGroup">
+    ///     The <c>killpg</c> implementation, taking the process group and signal and returning 0 on success. Blocks
+    ///     until the process group resumes when it really does stop the process.
+    /// </param>
+    /// <returns><see langword="true"/> only if <paramref name="killProcessGroup"/> reported success.</returns>
+    internal static bool Suspend (int signal, Func<int, int, int> killProcessGroup)
+    {
         Logging.Information ($"SuspendHelper.Suspend: signal={signal}");
 
         if (signal == -1)
@@ -22,9 +37,17 @@ internal static class SuspendHelper
         }
 
         Logging.Information ($"SuspendHelper.Suspend: Calling killpg(0, {signal}) [SIGTSTP]...");
-        int result = killpg (0, signal);
-        int errno = Marshal.GetLastWin32Error ();
-        Logging.Information ($"SuspendHelper.Suspend: killpg returned {result}, errno={errno}");
+        int result = killProcessGroup (0, signal);
+
+        if (result != 0)
+        {
+            // errno is only meaningful for the real P/Invoke, which sets SetLastError.
+            Logging.Warning ($"SuspendHelper.Suspend: killpg returned {result} (errno={Marshal.GetLastWin32Error ()}). Process was not stopped.");
+
+            return false;
+        }
+
+        Logging.Information ("SuspendHelper.Suspend: killpg succeeded; process group has resumed.");
 
         return true;
     }
@@ -68,7 +91,9 @@ internal static class SuspendHelper
             // Darwin (all Apple platforms) and the BSDs share the historical BSD signal numbering.
             "OSX" or "MACCATALYST" or "IOS" or "TVOS" or "FREEBSD" or "NETBSD" or "OPENBSD" => 18,
 
-            // Linux, on every architecture .NET targets. (Linux/MIPS uses 24, but .NET has no MIPS target.)
+            // Linux, on every architecture .NET targets — including ppc64le, which follows the generic Linux signal
+            // numbering even though its ioctl numbering differs. (MIPS uses 24, SPARC and Alpha 18; none is a .NET
+            // target, so unlike TIOCGWINSZ this needs no architecture.)
             "LINUX" or "ANDROID" => 20,
             "SOLARIS" or "ILLUMOS" => 24,
             "HAIKU" => 13,

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -178,10 +178,42 @@ internal static class UnixIOHelper
     }
 
     /// <summary>
-    ///     Get window/terminal size using ioctl.
-    ///     Platform-specific constant (different on Darwin/BSD vs Linux).
+    ///     Get window/terminal size using ioctl. Platform-specific constant; see <see cref="MapTiocgwinsz"/>.
     /// </summary>
-    public static readonly uint TIOCGWINSZ = OperatingSystem.IsLinux () ? 0x5413u : 0x40087468u;
+    public static readonly uint TIOCGWINSZ = MapTiocgwinsz (PlatformDetection.GetPlatformName ());
+
+    /// <summary>
+    ///     Maps a .NET OS platform name to that platform's <c>TIOCGWINSZ</c> ioctl request code.
+    /// </summary>
+    /// <param name="platformName">
+    ///     A platform name from <see cref="PlatformDetection.KnownPlatformNames"/>, as returned by
+    ///     <see cref="PlatformDetection.GetPlatformName"/>.
+    /// </param>
+    /// <returns>The <c>TIOCGWINSZ</c> request code for <paramref name="platformName"/>.</returns>
+    /// <remarks>
+    ///     <para>
+    ///         Android needs its own entry because <see cref="OperatingSystem.IsLinux"/> returns
+    ///         <see langword="false"/> on Android even though it uses the same asm-generic ioctl numbering as Linux.
+    ///     </para>
+    ///     <para>
+    ///         On Linux the value is architecture-dependent, not purely OS-dependent: ppc64le, MIPS, SPARC and Alpha
+    ///         use the BSD-style 0x40087468 rather than 0x5413. Only the asm-generic architectures (x86, x64, Arm,
+    ///         Arm64, RISC-V, s390x) are handled here, which covers every architecture Terminal.Gui is tested on.
+    ///     </para>
+    /// </remarks>
+    internal static uint MapTiocgwinsz (string platformName) =>
+        platformName switch
+        {
+            // asm-generic ioctl numbering.
+            "LINUX" or "ANDROID" => 0x5413u,
+
+            // Solaris/illumos: TIOC|104, where TIOC is ('T' << 8).
+            "SOLARIS" or "ILLUMOS" => 0x5468u,
+
+            // BSD _IOR ('t', 104, struct winsize): Darwin, FreeBSD, NetBSD, OpenBSD, and the best guess for any
+            // other Unix, since BSD-style ioctl encoding is the most common.
+            _ => 0x40087468u
+        };
 
     /// <summary>
     ///     I/O control operations on file descriptors.

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -118,6 +118,14 @@ internal static class UnixIOHelper
     public static extern int dup (int fd);
 
     /// <summary>
+    ///     Close a file descriptor.
+    /// </summary>
+    /// <param name="fd">File descriptor to close.</param>
+    /// <returns>0 on success, -1 on error.</returns>
+    [DllImport ("libc", SetLastError = true)]
+    public static extern int close (int fd);
+
+    /// <summary>
     ///     Wait until all output written to the file descriptor has been transmitted.
     /// </summary>
     /// <param name="fd">File descriptor (typically <see cref="STDOUT_FILENO"/>).</param>
@@ -213,10 +221,39 @@ internal static class UnixIOHelper
             // Haiku uses its own sequential numbering: TIOCGWINSZ is (TCGETA + 12), where TCGETA is 0x8000.
             "HAIKU" => 0x800Cu,
 
-            // BSD _IOR ('t', 104, struct winsize): Darwin, FreeBSD, NetBSD, OpenBSD, and the best guess for any
-            // other Unix, since BSD-style ioctl encoding is the most common.
+            // BSD _IOR ('t', 104, struct winsize): Darwin (all Apple platforms), FreeBSD, NetBSD, OpenBSD, and the
+            // best guess for any other Unix, since BSD-style ioctl encoding is the most common.
             _ => 0x40087468u
         };
+
+    /// <summary>
+    ///     Determines whether <see cref="ioctl_arm64"/> must be used in place of <see cref="ioctl"/>.
+    /// </summary>
+    /// <param name="processArchitecture">
+    ///     The architecture of the running process — <see cref="RuntimeInformation.ProcessArchitecture"/>, never
+    ///     <see cref="RuntimeInformation.OSArchitecture"/>. See the remarks.
+    /// </param>
+    /// <param name="platformName">A platform name, as returned by <see cref="PlatformDetection.GetPlatformName"/>.</param>
+    /// <returns><see langword="true"/> when the Apple ARM64 variadic calling convention applies.</returns>
+    /// <remarks>
+    ///     <para>
+    ///         Apple's ARM64 ABI passes every variadic argument on the stack, unlike standard AAPCS64 where they go in
+    ///         registers. <c>ioctl</c> is variadic, so on Apple ARM64 the <c>winsize*</c> must be pushed past the eight
+    ///         register slots — which is what <see cref="ioctl_arm64"/>'s placeholder parameters accomplish. Every other
+    ///         ARM64 platform (Linux, Android, FreeBSD) follows standard AAPCS64 and must use the plain
+    ///         <see cref="ioctl"/>. See https://github.com/dotnet/runtime/issues/48796#issuecomment-3695794860.
+    ///     </para>
+    ///     <para>
+    ///         This must key off the <em>process</em> architecture, not the OS architecture. .NET deliberately reports
+    ///         <see cref="RuntimeInformation.OSArchitecture"/> as <see cref="Architecture.Arm64"/> for an x64 process
+    ///         translated by Rosetta (it checks <c>sysctl.proc_translated</c>), but such a process executes x64 code and
+    ///         follows the x64 ABI, where variadic arguments go in registers. Keying off
+    ///         <see cref="RuntimeInformation.OSArchitecture"/> therefore selects the stack-passing path for a process
+    ///         that needs the register path, and terminal sizing fails.
+    ///     </para>
+    /// </remarks>
+    internal static bool UseArm64VariadicIoctl (Architecture processArchitecture, string platformName) =>
+        processArchitecture == Architecture.Arm64 && PlatformDetection.IsApplePlatformName (platformName);
 
     /// <summary>
     ///     I/O control operations on file descriptors.
@@ -467,8 +504,7 @@ internal static class UnixIOHelper
             var ioctlResult = 0;
             WinSize ws;
 
-            if (RuntimeInformation.OSArchitecture == Architecture.Arm64
-                && OperatingSystem.IsMacOS ())
+            if (UseArm64VariadicIoctl (RuntimeInformation.ProcessArchitecture, PlatformDetection.GetPlatformName ()))
             {
                 ioctlResult = ioctl_arm64 (fd,
                                            TIOCGWINSZ,

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -210,6 +210,9 @@ internal static class UnixIOHelper
             // Solaris/illumos: TIOC|104, where TIOC is ('T' << 8).
             "SOLARIS" or "ILLUMOS" => 0x5468u,
 
+            // Haiku uses its own sequential numbering: TIOCGWINSZ is (TCGETA + 12), where TCGETA is 0x8000.
+            "HAIKU" => 0x800Cu,
+
             // BSD _IOR ('t', 104, struct winsize): Darwin, FreeBSD, NetBSD, OpenBSD, and the best guess for any
             // other Unix, since BSD-style ioctl encoding is the most common.
             _ => 0x40087468u

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -188,11 +188,15 @@ internal static class UnixIOHelper
     /// <summary>
     ///     Get window/terminal size using ioctl. Platform-specific constant; see <see cref="MapTiocgwinsz"/>.
     /// </summary>
-    public static readonly uint TIOCGWINSZ = MapTiocgwinsz (PlatformDetection.GetPlatformName ());
+    public static readonly uint TIOCGWINSZ = MapTiocgwinsz (RuntimeInformation.ProcessArchitecture, PlatformDetection.GetPlatformName ());
 
     /// <summary>
     ///     Maps a .NET OS platform name to that platform's <c>TIOCGWINSZ</c> ioctl request code.
     /// </summary>
+    /// <param name="processArchitecture">
+    ///     The architecture of the running process — <see cref="RuntimeInformation.ProcessArchitecture"/>. Only
+    ///     consulted for Linux, whose ioctl numbering varies by architecture.
+    /// </param>
     /// <param name="platformName">
     ///     A platform name from <see cref="PlatformDetection.KnownPlatformNames"/>, as returned by
     ///     <see cref="PlatformDetection.GetPlatformName"/>.
@@ -204,16 +208,17 @@ internal static class UnixIOHelper
     ///         <see langword="false"/> on Android even though it uses the same asm-generic ioctl numbering as Linux.
     ///     </para>
     ///     <para>
-    ///         On Linux the value is architecture-dependent, not purely OS-dependent: ppc64le, MIPS, SPARC and Alpha
-    ///         use the BSD-style 0x40087468 rather than 0x5413. Only the asm-generic architectures (x86, x64, Arm,
-    ///         Arm64, RISC-V, s390x) are handled here, which covers every architecture Terminal.Gui is tested on.
+    ///         On Linux the value is architecture-dependent, not purely OS-dependent, which is why this takes an
+    ///         architecture. Every architecture .NET targets uses asm-generic numbering (0x5413) except ppc64le, whose
+    ///         UAPI defines <c>TIOCGWINSZ</c> as <c>_IOR ('t', 104, struct winsize)</c> — the BSD encoding, 0x40087468.
+    ///         Linux on MIPS, SPARC and Alpha does the same, but .NET has no targets for those.
     ///     </para>
     /// </remarks>
-    internal static uint MapTiocgwinsz (string platformName) =>
+    internal static uint MapTiocgwinsz (Architecture processArchitecture, string platformName) =>
         platformName switch
         {
-            // asm-generic ioctl numbering.
-            "LINUX" or "ANDROID" => 0x5413u,
+            // asm-generic ioctl numbering, except on ppc64le which uses the BSD encoding.
+            "LINUX" or "ANDROID" => processArchitecture == Architecture.Ppc64le ? 0x40087468u : 0x5413u,
 
             // Solaris/illumos: TIOC|104, where TIOC is ('T' << 8).
             "SOLARIS" or "ILLUMOS" => 0x5468u,

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixRawModeHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixRawModeHelper.cs
@@ -57,7 +57,8 @@ internal sealed class UnixRawModeHelper : IDisposable
             return true;
         }
 
-        // Only attempt on Unix-like platforms
+        // Attempt on every non-Windows platform. Testing for a known Unix would exclude NetBSD, OpenBSD, Solaris,
+        // illumos and Haiku; platforms without libc fail below and fall back to degraded mode.
         if (OperatingSystem.IsWindows ())
         {
             return false;

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixTerminalHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixTerminalHelper.cs
@@ -134,14 +134,18 @@ internal static class UnixTerminalHelper
 
             Logging.Information ("UnixTerminalHelper.Suspend: Terminal restored to cooked mode, calling SuspendHelper.Suspend...");
 
-            if (!SuspendHelper.Suspend ())
+            if (SuspendHelper.Suspend ())
             {
-                Logging.Warning ("UnixTerminalHelper.Suspend: SuspendHelper.Suspend() returned false");
-
-                return;
+                Logging.Information ("UnixTerminalHelper.Suspend: Resumed from suspend! Restoring raw mode...");
             }
-
-            Logging.Information ("UnixTerminalHelper.Suspend: Resumed from suspend! Restoring raw mode...");
+            else
+            {
+                // Do NOT return here. The terminal is already in cooked mode, out of the alternate buffer, with the
+                // cursor shown. Returning would leave it that way while the app keeps running, so input would be
+                // line-buffered and echoed and drawing would land in the scrollback buffer.
+                Logging.Warning ("UnixTerminalHelper.Suspend: SuspendHelper.Suspend () returned false; the process was "
+                                 + "never stopped. Restoring terminal state anyway.");
+            }
 
             // Restore the saved raw mode terminal state.
             RestoreTerminalState ();

--- a/Tests/UnitTestsParallelizable/Drivers/PlatformDetectionObsoleteShimTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/PlatformDetectionObsoleteShimTests.cs
@@ -1,0 +1,76 @@
+namespace DriverTests;
+
+/// <summary>
+///     Pins the <see cref="PlatformDetection"/> members that shipped public in v2.4.17 and were removed in #5600.
+///     They are restored as <see cref="ObsoleteAttribute"/> shims so upgrading consumers do not hit
+///     <see cref="MissingMethodException"/>. Each assertion below encodes the v2.4.17 behaviour, not an improved one.
+/// </summary>
+public class PlatformDetectionObsoleteShimTests
+{
+    // Claude - Opus 5
+    // These members are deliberately obsolete; calling them here is the point of the test.
+#pragma warning disable CS0618
+
+    [Fact]
+    public void IsWindows_MatchesOperatingSystem () => Assert.Equal (OperatingSystem.IsWindows (), PlatformDetection.IsWindows ());
+
+    // Claude - Opus 5
+    [Fact]
+    public void IsLinux_MatchesOperatingSystem () => Assert.Equal (OperatingSystem.IsLinux (), PlatformDetection.IsLinux ());
+
+    // Claude - Opus 5
+    [Fact]
+    public void IsMac_MatchesOperatingSystem () => Assert.Equal (OperatingSystem.IsMacOS (), PlatformDetection.IsMac ());
+
+    // Claude - Opus 5
+    [Fact]
+    public void IsUnixLike_CoversLinuxMacAndFreeBsdOnly ()
+    {
+        // v2.4.17 semantics: Linux || OSX || FreeBSD. Deliberately excludes NetBSD/OpenBSD/Solaris/illumos/Haiku.
+        bool expected = OperatingSystem.IsLinux () || OperatingSystem.IsMacOS () || OperatingSystem.IsFreeBSD ();
+
+        Assert.Equal (expected, PlatformDetection.IsUnixLike ());
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void IsUnixLike_IsFalseOnWindows ()
+    {
+        if (!OperatingSystem.IsWindows ())
+        {
+            return;
+        }
+
+        Assert.False (PlatformDetection.IsUnixLike ());
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void GetCurrentPlatform_ReturnsPlatformForCurrentOS ()
+    {
+        TuiPlatform expected = OperatingSystem.IsWindows () ? TuiPlatform.Windows
+                               : OperatingSystem.IsMacOS () ? TuiPlatform.Macos
+                               : TuiPlatform.Linux;
+
+        Assert.Equal (expected, PlatformDetection.GetCurrentPlatform ());
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void GetCurrentPlatform_ReturnsDefinedvalue () => Assert.True (Enum.IsDefined (PlatformDetection.GetCurrentPlatform ()));
+
+    // Claude - Opus 5
+    [Fact]
+    public void ExactlyOneOfWindowsLinuxMac_IsTrue_OnSupportedPlatforms ()
+    {
+        if (!OperatingSystem.IsWindows () && !OperatingSystem.IsLinux () && !OperatingSystem.IsMacOS ())
+        {
+            return; // Some other Unix; none of the three is expected to be true.
+        }
+
+        bool [] flags = [PlatformDetection.IsWindows (), PlatformDetection.IsLinux (), PlatformDetection.IsMac ()];
+
+        Assert.Single (flags, f => f);
+    }
+#pragma warning restore CS0618
+}

--- a/Tests/UnitTestsParallelizable/Drivers/PlatformDetectionObsoleteShimTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/PlatformDetectionObsoleteShimTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace DriverTests;
 
 /// <summary>
@@ -58,6 +60,42 @@ public class PlatformDetectionObsoleteShimTests
     // Claude - Opus 5
     [Fact]
     public void GetCurrentPlatform_ReturnsDefinedvalue () => Assert.True (Enum.IsDefined (PlatformDetection.GetCurrentPlatform ()));
+
+    // Claude - Opus 5
+    // Pins the public surface that #5600 removed. A full PublicAPI baseline for the library would catch this
+    // class of break everywhere, but this guards the specific type that regressed without gating every future PR.
+    [Fact]
+    public void PublicSurface_MatchesV2_4_17 ()
+    {
+        string [] expected =
+        [
+            "GetCurrentPlatform",
+            "IsLinux",
+            "IsMac",
+            "IsUnixLike",
+            "IsWSL",
+            "IsWindows"
+        ];
+
+        string [] actual =
+        [
+            .. typeof (PlatformDetection).GetMethods (BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                                        .Select (m => m.Name)
+                                        .OrderBy (n => n, StringComparer.Ordinal)
+        ];
+
+        Assert.Equal (expected, actual);
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void PublicSurface_IsParameterlessAndReturnsExpectedTypes ()
+    {
+        MethodInfo [] methods = typeof (PlatformDetection).GetMethods (BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+
+        Assert.All (methods, m => Assert.Empty (m.GetParameters ()));
+        Assert.Equal (typeof (TuiPlatform), typeof (PlatformDetection).GetMethod (nameof (PlatformDetection.GetCurrentPlatform))!.ReturnType);
+    }
 
     // Claude - Opus 5
     [Fact]

--- a/Tests/UnitTestsParallelizable/Drivers/PlatformDetectionTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/PlatformDetectionTests.cs
@@ -29,4 +29,45 @@ public class PlatformDetectionTests (ITestOutputHelper output)
             output.WriteLine ($"Unknown OS Description: {RuntimeInformation.OSDescription}");
         }
     }
+
+    // Claude - Opus 5
+    [Fact]
+    public void GetPlatformName_ReturnsNameMatchingCurrentPlatform ()
+    {
+        string name = PlatformDetection.GetPlatformName ();
+
+        string expected = OperatingSystem.IsWindows () ? "WINDOWS"
+                          : OperatingSystem.IsAndroid () ? "ANDROID"
+                          : OperatingSystem.IsLinux () ? "LINUX"
+                          : OperatingSystem.IsMacOS () ? "OSX"
+                          : OperatingSystem.IsFreeBSD () ? "FREEBSD"
+                          : name; // Platform not covered by OperatingSystem.Is* helpers; asserted below instead.
+
+        Assert.Equal (expected, name);
+        Assert.True (name.Length == 0 || PlatformDetection.KnownPlatformNames.Contains (name));
+    }
+
+    // Claude - Opus 5
+    // ANDROID must be listed separately from LINUX: OperatingSystem.IsLinux () is false on Android, so any
+    // platform table keyed off "is it Linux?" silently misses it.
+    [Theory]
+    [InlineData ("WINDOWS")]
+    [InlineData ("LINUX")]
+    [InlineData ("ANDROID")]
+    [InlineData ("OSX")]
+    [InlineData ("FREEBSD")]
+    [InlineData ("NETBSD")]
+    [InlineData ("OPENBSD")]
+    [InlineData ("SOLARIS")]
+    [InlineData ("ILLUMOS")]
+    [InlineData ("HAIKU")]
+    public void KnownPlatformNames_Contains (string platformName) => Assert.Contains (platformName, PlatformDetection.KnownPlatformNames);
+
+    // Claude - Opus 5
+    [Fact]
+    public void KnownPlatformNames_AreUpperCaseAndUnique ()
+    {
+        Assert.Equal (PlatformDetection.KnownPlatformNames.Length, PlatformDetection.KnownPlatformNames.Distinct ().Count ());
+        Assert.All (PlatformDetection.KnownPlatformNames, n => Assert.Equal (n.ToUpperInvariant (), n));
+    }
 }

--- a/Tests/UnitTestsParallelizable/Drivers/SuspendHelperTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/SuspendHelperTests.cs
@@ -1,0 +1,56 @@
+namespace DriverTests;
+
+/// <summary>
+///     Pins <see cref="SuspendHelper.MapSuspendSignal"/> against each platform's <c>signal.h</c>. These values are
+///     unverifiable on CI (which only runs Windows, Linux, and macOS), so the table itself is the contract.
+/// </summary>
+public class SuspendHelperTests
+{
+    // Claude - Opus 5
+    [Theory]
+
+    // Darwin and the BSDs.
+    [InlineData ("OSX", 18)]
+    [InlineData ("FREEBSD", 18)]
+    [InlineData ("NETBSD", 18)]
+    [InlineData ("OPENBSD", 18)]
+
+    // Linux, and Android — which needs its own entry because OperatingSystem.IsLinux () is false there.
+    [InlineData ("LINUX", 20)]
+    [InlineData ("ANDROID", 20)]
+
+    // Solaris/illumos.
+    [InlineData ("SOLARIS", 24)]
+    [InlineData ("ILLUMOS", 24)]
+
+    // Haiku: SIGTSTP is 13. 21 is SIGKILLTHR there, which would kill threads instead of suspending.
+    [InlineData ("HAIKU", 13)]
+
+    // Platforms with no suspend concept, and unknown names.
+    [InlineData ("WINDOWS", -1)]
+    [InlineData ("BROWSER", -1)]
+    [InlineData ("", -1)]
+    public void MapSuspendSignal_ReturnsSigtstpForPlatform (string platformName, int expected) =>
+        Assert.Equal (expected, SuspendHelper.MapSuspendSignal (platformName));
+
+    // Claude - Opus 5
+    [Fact]
+    public void MapSuspendSignal_NeverReturnsHaikuSigkillthr ()
+    {
+        // Regression guard: 21 is SIGKILLTHR on Haiku and SIGURG/SIGTTOU elsewhere — never a suspend signal.
+        Assert.All (PlatformDetection.KnownPlatformNames, n => Assert.NotEqual (21, SuspendHelper.MapSuspendSignal (n)));
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void MapSuspendSignal_EveryUnixPlatformHasASignal ()
+    {
+        string [] unixPlatforms = [.. PlatformDetection.KnownPlatformNames.Where (n => n != "WINDOWS")];
+
+        Assert.All (unixPlatforms, n => Assert.NotEqual (-1, SuspendHelper.MapSuspendSignal (n)));
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void MapSuspendSignal_UnknownPlatform_ReturnsMinusOne () => Assert.Equal (-1, SuspendHelper.MapSuspendSignal ("NOT_A_PLATFORM"));
+}

--- a/Tests/UnitTestsParallelizable/Drivers/SuspendHelperTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/SuspendHelperTests.cs
@@ -53,4 +53,54 @@ public class SuspendHelperTests
     // Claude - Opus 5
     [Fact]
     public void MapSuspendSignal_UnknownPlatform_ReturnsMinusOne () => Assert.Equal (-1, SuspendHelper.MapSuspendSignal ("NOT_A_PLATFORM"));
+
+    // Claude - Opus 5
+    [Fact]
+    public void Suspend_KillpgSucceeds_ReturnsTrue () => Assert.True (SuspendHelper.Suspend (20, (_, _) => 0));
+
+    // Claude - Opus 5
+    // killpg failing means the process was never stopped, so Suspend () must not claim success — callers use this to
+    // decide whether they resumed, and previously it always returned true.
+    [Theory]
+    [InlineData (-1)]
+    [InlineData (1)]
+    public void Suspend_KillpgFails_ReturnsFalse (int killpgResult) => Assert.False (SuspendHelper.Suspend (20, (_, _) => killpgResult));
+
+    // Claude - Opus 5
+    [Fact]
+    public void Suspend_NoSuspendSignal_ReturnsFalse_AndDoesNotSignal ()
+    {
+        var invoked = false;
+
+        bool result = SuspendHelper.Suspend (-1,
+                                             (_, _) =>
+                                             {
+                                                 invoked = true;
+
+                                                 return 0;
+                                             });
+
+        Assert.False (result);
+        Assert.False (invoked);
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void Suspend_SignalsOwnProcessGroup_WithMappedSignal ()
+    {
+        int observedGroup = int.MinValue;
+        int observedSignal = int.MinValue;
+
+        SuspendHelper.Suspend (20,
+                               (pgrp, sig) =>
+                               {
+                                   observedGroup = pgrp;
+                                   observedSignal = sig;
+
+                                   return 0;
+                               });
+
+        Assert.Equal (0, observedGroup); // 0 == caller's own process group
+        Assert.Equal (20, observedSignal);
+    }
 }

--- a/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTiocgwinszTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTiocgwinszTests.cs
@@ -24,8 +24,10 @@ public class UnixIOHelperTiocgwinszTests
     [InlineData ("SOLARIS", 0x5468u)]
     [InlineData ("ILLUMOS", 0x5468u)]
 
+    // Haiku: (TCGETA + 12) where TCGETA == 0x8000. Notably NOT the BSD value.
+    [InlineData ("HAIKU", 0x800Cu)]
+
     // Unknown platforms fall back to BSD-style encoding, the most common convention.
-    [InlineData ("HAIKU", 0x40087468u)]
     [InlineData ("", 0x40087468u)]
     public void MapTiocgwinsz_ReturnsRequestCodeForPlatform (string platformName, uint expected) =>
         Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz (platformName));
@@ -50,6 +52,19 @@ public class UnixIOHelperTiocgwinszTests
         uint expected = ((uint)'T' << 8) | 104u;
 
         Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz ("SOLARIS"));
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void MapTiocgwinsz_HaikuConstant_MatchesTcgetaOffset ()
+    {
+        // Haiku: TIOCGWINSZ == (TCGETA + 12), TCGETA == 0x8000. Haiku does not use BSD _IOR encoding, so the
+        // BSD fallback is wrong for it.
+        const uint TCGETA = 0x8000u;
+        uint expected = TCGETA + 12u;
+
+        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz ("HAIKU"));
+        Assert.NotEqual (0x40087468u, UnixIOHelper.MapTiocgwinsz ("HAIKU"));
     }
 
     // Claude - Opus 5

--- a/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTiocgwinszTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTiocgwinszTests.cs
@@ -32,7 +32,37 @@ public class UnixIOHelperTiocgwinszTests
     // Unknown platforms fall back to BSD-style encoding, the most common convention.
     [InlineData ("", 0x40087468u)]
     public void MapTiocgwinsz_ReturnsRequestCodeForPlatform (string platformName, uint expected) =>
-        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz (platformName));
+        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz (Architecture.X64, platformName));
+
+    // Claude - Opus 5
+    // Linux ioctl numbering is architecture-dependent: ppc64le uses _IOR ('t', 104, struct winsize) per its UAPI,
+    // every other architecture .NET targets uses asm-generic 0x5413.
+    [Theory]
+    [InlineData (Architecture.Ppc64le, 0x40087468u)]
+    [InlineData (Architecture.X64, 0x5413u)]
+    [InlineData (Architecture.X86, 0x5413u)]
+    [InlineData (Architecture.Arm, 0x5413u)]
+    [InlineData (Architecture.Arm64, 0x5413u)]
+    [InlineData (Architecture.RiscV64, 0x5413u)]
+    [InlineData (Architecture.S390x, 0x5413u)]
+    [InlineData (Architecture.LoongArch64, 0x5413u)]
+    public void MapTiocgwinsz_Linux_IsArchitectureDependent (Architecture arch, uint expected) =>
+        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz (arch, "LINUX"));
+
+    // Claude - Opus 5
+    [Fact]
+    public void MapTiocgwinsz_NonLinux_IsArchitectureIndependent ()
+    {
+        string [] nonLinux = ["OSX", "FREEBSD", "NETBSD", "OPENBSD", "SOLARIS", "ILLUMOS", "HAIKU", ""];
+        Architecture [] arches = [Architecture.X64, Architecture.Arm64, Architecture.Ppc64le, Architecture.S390x];
+
+        foreach (string platform in nonLinux)
+        {
+            uint baseline = UnixIOHelper.MapTiocgwinsz (Architecture.X64, platform);
+
+            Assert.All (arches, a => Assert.Equal (baseline, UnixIOHelper.MapTiocgwinsz (a, platform)));
+        }
+    }
 
     // Claude - Opus 5
     [Fact]
@@ -43,7 +73,7 @@ public class UnixIOHelperTiocgwinszTests
         const uint WINSIZE_SIZE = 8u; // four ushorts
         uint expected = IOC_OUT | (WINSIZE_SIZE << 16) | ((uint)'t' << 8) | 104u;
 
-        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz ("OSX"));
+        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz (Architecture.X64, "OSX"));
     }
 
     // Claude - Opus 5
@@ -53,7 +83,7 @@ public class UnixIOHelperTiocgwinszTests
         // Solaris: TIOCGWINSZ == (TIOC|104) where TIOC == ('T' << 8)
         uint expected = ((uint)'T' << 8) | 104u;
 
-        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz ("SOLARIS"));
+        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz (Architecture.X64, "SOLARIS"));
     }
 
     // Claude - Opus 5
@@ -65,14 +95,15 @@ public class UnixIOHelperTiocgwinszTests
         const uint TCGETA = 0x8000u;
         uint expected = TCGETA + 12u;
 
-        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz ("HAIKU"));
-        Assert.NotEqual (0x40087468u, UnixIOHelper.MapTiocgwinsz ("HAIKU"));
+        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz (Architecture.X64, "HAIKU"));
+        Assert.NotEqual (0x40087468u, UnixIOHelper.MapTiocgwinsz (Architecture.X64, "HAIKU"));
     }
 
     // Claude - Opus 5
     [Fact]
     public void TIOCGWINSZ_MatchesMappingForCurrentPlatform () =>
-        Assert.Equal (UnixIOHelper.MapTiocgwinsz (PlatformDetection.GetPlatformName ()), UnixIOHelper.TIOCGWINSZ);
+        Assert.Equal (UnixIOHelper.MapTiocgwinsz (RuntimeInformation.ProcessArchitecture, PlatformDetection.GetPlatformName ()),
+                      UnixIOHelper.TIOCGWINSZ);
 
     // Claude - Opus 5
     // The Apple ARM64 variadic ABI applies to every Apple platform on ARM64, and to nothing else.

--- a/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTiocgwinszTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTiocgwinszTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace DriverTests;
 
 /// <summary>
@@ -71,4 +73,47 @@ public class UnixIOHelperTiocgwinszTests
     [Fact]
     public void TIOCGWINSZ_MatchesMappingForCurrentPlatform () =>
         Assert.Equal (UnixIOHelper.MapTiocgwinsz (PlatformDetection.GetPlatformName ()), UnixIOHelper.TIOCGWINSZ);
+
+    // Claude - Opus 5
+    // The Apple ARM64 variadic ABI applies to every Apple platform on ARM64, and to nothing else.
+    [Theory]
+    [InlineData (Architecture.Arm64, "OSX", true)]
+    [InlineData (Architecture.Arm64, "MACCATALYST", true)]
+    [InlineData (Architecture.Arm64, "IOS", true)]
+    [InlineData (Architecture.Arm64, "TVOS", true)]
+
+    // Non-Apple ARM64 uses standard AAPCS64, where variadic args go in registers.
+    [InlineData (Architecture.Arm64, "LINUX", false)]
+    [InlineData (Architecture.Arm64, "ANDROID", false)]
+    [InlineData (Architecture.Arm64, "FREEBSD", false)]
+    [InlineData (Architecture.Arm64, "NETBSD", false)]
+
+    // Non-ARM64 never uses the placeholder signature, Apple or not.
+    [InlineData (Architecture.X64, "OSX", false)]
+    [InlineData (Architecture.X64, "LINUX", false)]
+    [InlineData (Architecture.Arm, "OSX", false)]
+    [InlineData (Architecture.X86, "OSX", false)]
+    public void UseArm64VariadicIoctl_OnlyForAppleArm64 (Architecture arch, string platformName, bool expected) =>
+        Assert.Equal (expected, UnixIOHelper.UseArm64VariadicIoctl (arch, platformName));
+
+    // Claude - Opus 5
+    [Fact]
+    public void UseArm64VariadicIoctl_RosettaX64Process_UsesPlainIoctl ()
+    {
+        // .NET reports OSArchitecture == Arm64 for an x64 process translated by Rosetta (it checks
+        // sysctl.proc_translated). That process executes x64 code and passes variadic args in registers, so keying
+        // off OSArchitecture would wrongly select the stack-passing path. ProcessArchitecture is X64 there.
+        Assert.False (UnixIOHelper.UseArm64VariadicIoctl (Architecture.X64, "OSX"));
+        Assert.True (UnixIOHelper.UseArm64VariadicIoctl (Architecture.Arm64, "OSX"));
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void UseArm64VariadicIoctl_MatchesProcessArchitectureForCurrentPlatform ()
+    {
+        bool expected = RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                        && PlatformDetection.IsApplePlatformName (PlatformDetection.GetPlatformName ());
+
+        Assert.Equal (expected, UnixIOHelper.UseArm64VariadicIoctl (RuntimeInformation.ProcessArchitecture, PlatformDetection.GetPlatformName ()));
+    }
 }

--- a/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTiocgwinszTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTiocgwinszTests.cs
@@ -1,0 +1,59 @@
+namespace DriverTests;
+
+/// <summary>
+///     Pins <see cref="UnixIOHelper.MapTiocgwinsz"/> against each platform's ioctl numbering. These values are
+///     unverifiable on CI (which only runs Windows, Linux, and macOS), so the table itself is the contract.
+/// </summary>
+public class UnixIOHelperTiocgwinszTests
+{
+    // Claude - Opus 5
+    [Theory]
+
+    // asm-generic ioctl numbering. Android needs its own entry because OperatingSystem.IsLinux () is false there,
+    // even though Android uses the same numbering as Linux.
+    [InlineData ("LINUX", 0x5413u)]
+    [InlineData ("ANDROID", 0x5413u)]
+
+    // BSD _IOR ('t', 104, struct winsize) == 0x40000000 | (8 << 16) | ('t' << 8) | 104.
+    [InlineData ("OSX", 0x40087468u)]
+    [InlineData ("FREEBSD", 0x40087468u)]
+    [InlineData ("NETBSD", 0x40087468u)]
+    [InlineData ("OPENBSD", 0x40087468u)]
+
+    // Solaris/illumos: TIOC|104 where TIOC == ('T' << 8).
+    [InlineData ("SOLARIS", 0x5468u)]
+    [InlineData ("ILLUMOS", 0x5468u)]
+
+    // Unknown platforms fall back to BSD-style encoding, the most common convention.
+    [InlineData ("HAIKU", 0x40087468u)]
+    [InlineData ("", 0x40087468u)]
+    public void MapTiocgwinsz_ReturnsRequestCodeForPlatform (string platformName, uint expected) =>
+        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz (platformName));
+
+    // Claude - Opus 5
+    [Fact]
+    public void MapTiocgwinsz_BsdConstant_MatchesIorEncoding ()
+    {
+        // _IOR ('t', 104, struct winsize): IOC_OUT | ((sizeof (winsize) & IOCPARM_MASK) << 16) | ('t' << 8) | 104
+        const uint IOC_OUT = 0x40000000u;
+        const uint WINSIZE_SIZE = 8u; // four ushorts
+        uint expected = IOC_OUT | (WINSIZE_SIZE << 16) | ((uint)'t' << 8) | 104u;
+
+        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz ("OSX"));
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void MapTiocgwinsz_SolarisConstant_MatchesTiocEncoding ()
+    {
+        // Solaris: TIOCGWINSZ == (TIOC|104) where TIOC == ('T' << 8)
+        uint expected = ((uint)'T' << 8) | 104u;
+
+        Assert.Equal (expected, UnixIOHelper.MapTiocgwinsz ("SOLARIS"));
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void TIOCGWINSZ_MatchesMappingForCurrentPlatform () =>
+        Assert.Equal (UnixIOHelper.MapTiocgwinsz (PlatformDetection.GetPlatformName ()), UnixIOHelper.TIOCGWINSZ);
+}


### PR DESCRIPTION
Follow-up to #5600. That PR fixed a FreeBSD/ARM64 bug (#5604) and the move to `OperatingSystem.Is*` is right; this corrects defects in the platform tables and predicates it touched. None are reachable from CI, which runs Windows/Linux/macOS only.

## Defects

| Defect | Was | Correct | Regression from #5600 |
|---|---|---|---|
| Haiku suspend signal | `21` (`SIGKILLTHR`) | `13` (`SIGTSTP`) | **Yes** — worse than the pre-#5600 no-op |
| Android `TIOCGWINSZ` | `0x40087468` | `0x5413` | **Yes** |
| Android suspend signal | `-1` | `20` | **Yes** |
| `PlatformDetection` public members | removed | restored | **Yes** — binary break |
| ARM64 ioctl guard architecture axis | `OSArchitecture` | `ProcessArchitecture` | No |
| ARM64 ioctl guard platform axis | `IsMacOS ()` | all Apple platforms | No |
| Haiku `TIOCGWINSZ` | `0x40087468` | `0x800C` | No |
| Solaris/illumos `TIOCGWINSZ` | `0x40087468` | `0x5468` | No |
| `AnsiOutput` descriptor leak | leaked per instance | closed | No |
| Linux `TIOCGWINSZ` on ppc64le | `0x5413` | `0x40087468` | No |
| `Suspend ()` return value | always `true` | `killpg` result | No |

Sources: [Haiku `signal.h`](https://github.com/haiku/haiku/blob/master/headers/posix/signal.h) (`SIGTSTP` 13, `SIGKILLTHR` 21) · [Haiku `termios.h`](https://github.com/haiku/haiku/blob/master/headers/posix/termios.h) (`TCGETA` `0x8000`, `TIOCGWINSZ` `TCGETA + 12`) · [`OperatingSystem.cs`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs) (`IsLinux()` is `#if TARGET_LINUX && !TARGET_ANDROID`) · [`pal_runtimeinformation.c`](https://github.com/dotnet/runtime/blob/main/src/native/libs/System.Native/pal_runtimeinformation.c) (`OSArchitecture` returns `ARCH_ARM64` when `sysctl.proc_translated`) · [dotnet/runtime#48796](https://github.com/dotnet/runtime/issues/48796#issuecomment-3695794860) (Apple ARM64 variadic ABI)

### Notes on the two non-obvious ones

**Android.** `OperatingSystem.IsLinux ()` returns `false` on Android. #5600 inverted the `TIOCGWINSZ` ternary to key off it, which changed the *default* for every platform name that is not `LINUX`/`OSX`/`FREEBSD`. Android uses asm-generic ioctl numbering, so it needs `0x5413`. Affects `net*-android` targets; not Termux, which runs a stock `linux-arm64` runtime.

**Rosetta.** .NET reports `OSArchitecture == Arm64` for an x64 process translated by Rosetta, but that process executes x64 code and passes variadic arguments in registers. The old guard therefore selected `ioctl_arm64`'s stack-passing signature for a process needing the register one: `winsize*` arrived as `NULL` in `rdx`, `ioctl` returned `EFAULT`, sizing fell back to 80×25 on any x64 process on Apple silicon. `ProcessArchitecture` is the correct axis and is a compile-time constant rather than a cached `uname` call. Separately, the stack-passing convention is an Apple ABI deviation, not a macOS one, so Mac Catalyst/iOS/tvOS need it too. watchOS is deliberately absent — .NET has no `WATCHOS` platform name.

## Restored public API

`IsLinux`, `IsMac`, `IsUnixLike`, `IsWindows` and `GetCurrentPlatform` shipped `public static` in v2.4.17 and were deleted by #5600, so consumers compiled against 2.4.17 hit `MissingMethodException` on upgrade. Restored as `[Obsolete]` shims with **v2.4.17 behaviour preserved exactly, not improved** — `IsUnixLike ()` still covers Linux/macOS/FreeBSD only, with the reason not to use it documented on the member rather than silently changing what it returns. Verified signature-identical to the tag. Also un-orphans `TuiPlatform`, which had no producer after #5600.

Two maintainer calls, both one-line edits: whether the shims should warn now or defer the warning to the next minor, and whether `TuiPlatform`/`GetCurrentPlatform` live on or are scheduled for v3.

## Design

Each lookup is now a pure function over the .NET OS platform name, so the tables are directly testable. All are once-per-process cached (`_suspendSignal`; `TIOCGWINSZ` and the guard are `static readonly`/const-folded), so this costs nothing measurable — the ~25 call sites where #5600's const-folding matters are untouched.

Every value carries its derivation in a comment, and encoding tests re-derive the BSD (`_IOR('t',104,winsize)`), Solaris (`TIOC|104`) and Haiku (`TCGETA+12`) constants from first principles rather than restating a magic number.

## Verification

- Full build clean, no new warnings; `CS0618` suppressed only inside the shim tests
- `UnitTestsParallelizable` 17,638 passed / 0 failed / 17 skipped (was 17,559)
- `UnitTests.NonParallelizable` 72 passed; Legacy, IntegrationTests, UICatalog build clean
- Mutation-checked: reintroducing the Haiku 21 and Android gaps fails 5 tests; removing the Haiku ioctl entry fails 2; narrowing the Apple set to macOS fails 3

Two honest limits: the ARM64 call-site swap to `ProcessArchitecture` is verified by inspection, not test, since the two values coincide on all non-Rosetta hardware. And every fix here is on a platform or configuration neither CI nor I can execute — they are verified against vendor headers and the .NET runtime source, not by running.

Unrelated finding while running the suite: `CollectionNavigatorTests.Delay` is timing-dependent (`Thread.Sleep (TypingDelay + 10)`) and fails roughly 1 run in 4 under parallel load. Untouched by this PR; worth its own issue.

## Deliberately excluded

- **PublicAPI baseline** (`Microsoft.CodeAnalysis.PublicApiAnalyzers`) — the systemic fix for how #5600's removal passed CI, but it generates a baseline for the entire public surface and gates every future PR, so it needs its own PR and your buy-in. A targeted reflection test pins `PlatformDetection`'s surface here in the meantime.
- **Linux `TIOCGWINSZ` on MIPS/SPARC/Alpha** — these use `0x40087468` like ppc64le, but .NET has no targets for them, so they stay documented in a code comment rather than handled.
- **Unused `using System.Runtime.InteropServices;`** left by #5600 in ~9 files — pure churn that would bury the substantive diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


