### PR TITLE
Fix TIOCGWINSZ on other platforms

### DIFF
--- a/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
@@ -38,13 +38,18 @@ internal static class SuspendHelper
         }
 
         if (OperatingSystem.IsMacOS () ||
+            OperatingSystem.IsMacCatalyst () ||
+            OperatingSystem.IsIOS () ||
+            OperatingSystem.IsTvOS () ||
+            OperatingSystem.IsWatchOS () ||
             OperatingSystem.IsFreeBSD () ||
             RuntimeInformation.IsOSPlatform (OSPlatform.Create ("NETBSD")) ||
             RuntimeInformation.IsOSPlatform (OSPlatform.Create ("OPENBSD")))
         {
             _suspendSignal = 18;
         }
-        else if (OperatingSystem.IsLinux ())
+        else if (OperatingSystem.IsLinux () ||
+                 OperatingSystem.IsAndroid ())
         {
             _suspendSignal = 20;
         }
@@ -55,7 +60,7 @@ internal static class SuspendHelper
         }
         else if (RuntimeInformation.IsOSPlatform (OSPlatform.Create ("HAIKU")))
         {
-            _suspendSignal = 21;
+            _suspendSignal = 13;
         }
         else
         {

--- a/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/SuspendHelper.cs
@@ -11,6 +11,7 @@ internal static class SuspendHelper
     /// <returns>True if the suspension was successful.</returns>
     public static bool Suspend ()
     {
+        // TODO: Use (int)PosixSignal.SIGTSTP once baseline moves to .NET 11.0
         int signal = GetSuspendSignal ();
 
         Logging.Information ($"SuspendHelper.Suspend: signal={signal}");

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -181,7 +181,10 @@ internal static class UnixIOHelper
     ///     Get window/terminal size using ioctl.
     ///     Platform-specific constant (different on Darwin/BSD vs Linux).
     /// </summary>
-    public static readonly uint TIOCGWINSZ = OperatingSystem.IsLinux () ? 0x5413u : 0x40087468u;
+    public static readonly uint TIOCGWINSZ = 
+        (OperatingSystem.IsLinux () || OperatingSystem.IsAndroid ()) && RuntimeInformation.ProcessArchitecture != Architecture.Ppc64le ? 0x5413u :
+        RuntimeInformation.IsOSPlatform(OSPlatform.Create ("SOLARIS")) || RuntimeInformation.IsOSPlatform(OSPlatform.Create ("ILLUMOS")) ? 0x5468u :
+        RuntimeInformation.IsOSPlatform(OSPlatform.Create ("HAIKU")) ? 0x800Cu : 0x40087468u;
 
     /// <summary>
     ///     I/O control operations on file descriptors.

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -179,12 +179,12 @@ internal static class UnixIOHelper
 
     /// <summary>
     ///     Get window/terminal size using ioctl.
-    ///     Platform-specific constant (different on Darwin/BSD vs Linux).
+    ///     Platform-specific constant.
     /// </summary>
     public static readonly uint TIOCGWINSZ = 
         (OperatingSystem.IsLinux () || OperatingSystem.IsAndroid ()) && RuntimeInformation.ProcessArchitecture != Architecture.Ppc64le ? 0x5413u :
-        RuntimeInformation.IsOSPlatform(OSPlatform.Create ("SOLARIS")) || RuntimeInformation.IsOSPlatform(OSPlatform.Create ("ILLUMOS")) ? 0x5468u :
-        RuntimeInformation.IsOSPlatform(OSPlatform.Create ("HAIKU")) ? 0x800Cu : 0x40087468u;
+        RuntimeInformation.IsOSPlatform (OSPlatform.Create ("SOLARIS")) || RuntimeInformation.IsOSPlatform (OSPlatform.Create ("ILLUMOS")) ? 0x5468u :
+        RuntimeInformation.IsOSPlatform (OSPlatform.Create ("HAIKU")) ? 0x800Cu : 0x40087468u;
 
     /// <summary>
     ///     I/O control operations on file descriptors.


### PR DESCRIPTION
Two values were incorrect in https://github.com/tui-cs/Terminal.Gui/pull/5600. Let's fix them instead of bringing back unnecessary ceremony in https://github.com/tui-cs/Terminal.Gui/pull/5606. All this manual signal mapping will go away once the Terminal.Gui framework moves past .NET 11 (`(int)PosixSignal.SIGTSTP`), so it's temporary.