### PR TITLE
Fixes #5616. Preserve repeated legacy input after kitty detection

### DIFF
--- a/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
@@ -222,11 +222,6 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
                                           {
                                               if (!result.IsSupported)
                                               {
-                                                  if (_inputProcessor is AnsiInputProcessor unsupportedAnsiInputProcessor)
-                                                  {
-                                                      unsupportedAnsiInputProcessor.SetKittyKeyboardEnabled (false);
-                                                  }
-
                                                   Trace.Lifecycle (app?.MainThreadId?.ToString (), "KittyKeyboard", "Kitty keyboard mode not enabled");
 
                                                   return;
@@ -234,12 +229,6 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
 
                                               // Kitty is supported. Store the capabilities and set the flags we care about.
                                               _driver?.SetKittyKeyboardCapabilities (result);
-
-                                              if (_inputProcessor is AnsiInputProcessor supportedAnsiInputProcessor)
-                                              {
-                                                  supportedAnsiInputProcessor.SetKittyKeyboardEnabled (true);
-                                              }
-
                                               kittyKeyboardDetector.Enable (EscSeqUtils.KittyKeyboardRequestedFlags);
 
                                               Trace.Lifecycle (app?.MainThreadId?.ToString (),

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
@@ -39,8 +39,9 @@ namespace Terminal.Gui.Drivers;
 /// </summary>
 public class AnsiInputProcessor : InputProcessorImpl<char>
 {
-    private bool _isKittyKeyboardEnabled;
-    private string _pendingPrintableSuppression = string.Empty;
+    private static readonly TimeSpan PrintableSuppressionTimeout = TimeSpan.FromMilliseconds (50);
+    private string _pendingParsedPrintableSuppression = string.Empty;
+    private DateTime _pendingParsedPrintableSuppressionExpiresAt;
 
     /// <inheritdoc/>
     /// <param name="inputBuffer">The input buffer to process.</param>
@@ -62,9 +63,12 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     /// <inheritdoc/>
     protected override Key OnKeyboardEventParsed (Key keyEvent)
     {
-        _pendingPrintableSuppression = string.Empty;
+        _pendingParsedPrintableSuppression = string.Empty;
 
-        if (keyEvent.EventType != KeyEventType.Press || keyEvent.IsAlt || keyEvent.IsCtrl || keyEvent.IsModifierOnly)
+        if (keyEvent.EventType != KeyEventType.Press
+            || keyEvent.IsAlt
+            || keyEvent.IsCtrl
+            || keyEvent.IsModifierOnly)
         {
             return keyEvent;
         }
@@ -73,7 +77,8 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
 
         if (!string.IsNullOrEmpty (printableText))
         {
-            _pendingPrintableSuppression = printableText;
+            _pendingParsedPrintableSuppression = printableText;
+            _pendingParsedPrintableSuppressionExpiresAt = CurrentTime + PrintableSuppressionTimeout;
         }
 
         return keyEvent;
@@ -82,29 +87,18 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     /// <inheritdoc/>
     protected override bool ShouldSuppressFallbackKeyDown (Key key)
     {
-        if (string.IsNullOrEmpty (_pendingPrintableSuppression))
+        string parsedPrintableText = _pendingParsedPrintableSuppression;
+        _pendingParsedPrintableSuppression = string.Empty;
+
+        if (string.IsNullOrEmpty (parsedPrintableText)
+            || CurrentTime > _pendingParsedPrintableSuppressionExpiresAt)
         {
-            if (_isKittyKeyboardEnabled)
-            {
-                string fallbackPrintableText = key.GetPrintableText ();
-
-                if (!string.IsNullOrEmpty (fallbackPrintableText))
-                {
-                    _pendingPrintableSuppression = fallbackPrintableText;
-                }
-            }
-
             return false;
         }
 
         string printableText = key.GetPrintableText ();
-        bool suppress = string.Equals (printableText, _pendingPrintableSuppression, StringComparison.Ordinal);
-        _pendingPrintableSuppression = string.Empty;
-
-        return suppress;
+        return string.Equals (printableText, parsedPrintableText, StringComparison.Ordinal);
     }
-
-    internal void SetKittyKeyboardEnabled (bool enabled) => _isKittyKeyboardEnabled = enabled;
 
     /// <inheritdoc/>
     public override void InjectKeyDownEvent (Key key)

--- a/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
+++ b/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
@@ -33,6 +33,9 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
     private readonly ITimeProvider _timeProvider;
     private readonly MouseInterpreter _mouseInterpreter;
 
+    /// <summary>Gets the current pipeline time.</summary>
+    protected DateTime CurrentTime => _timeProvider.Now;
+
     /// <summary>
     ///     Thread-safe input queue populated by <see cref="IInput{TInputRecord}"/> on the input thread.
     ///     Dequeued by <see cref="ProcessQueue"/> on the main loop thread.

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -15,15 +15,15 @@ public class KittyKeyboardPipelineTests
     /// </summary>
     private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequence (params string [] sequences)
     {
-        return InjectRawSequenceCore (false, sequences);
+        return InjectRawSequenceCore (TimeSpan.Zero, sequences);
     }
 
-    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceWithKittyEnabled (params string [] sequences)
+    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceWithDelay (TimeSpan delay, params string [] sequences)
     {
-        return InjectRawSequenceCore (true, sequences);
+        return InjectRawSequenceCore (delay, sequences);
     }
 
-    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceCore (bool kittyKeyboardEnabled, params string [] sequences)
+    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceCore (TimeSpan delay, params string [] sequences)
     {
         VirtualTimeProvider timeProvider = new ();
         timeProvider.SetTime (new DateTime (2025, 1, 1, 12, 0, 0));
@@ -37,17 +37,23 @@ public class KittyKeyboardPipelineTests
         app.Keyboard.KeyUp += (_, key) => keyUpEvents.Add (key);
 
         IInputProcessor processor = app.Driver?.GetInputProcessor ()!;
-        ((AnsiInputProcessor)processor).SetKittyKeyboardEnabled (kittyKeyboardEnabled);
         ConcurrentQueue<char> queue = ((AnsiInputProcessor)processor).InputQueue;
 
-        foreach (string seq in sequences)
+        for (var sequenceIndex = 0; sequenceIndex < sequences.Length; sequenceIndex++)
         {
+            string seq = sequences [sequenceIndex];
+
             foreach (char ch in seq)
             {
                 queue.Enqueue (ch);
             }
 
             processor.ProcessQueue ();
+
+            if (sequenceIndex < sequences.Length - 1)
+            {
+                timeProvider.Advance (delay);
+            }
         }
 
         return (keyDownEvents, keyUpEvents);
@@ -215,9 +221,9 @@ public class KittyKeyboardPipelineTests
 
     #endregion
 
-    #region Mixed Kitty + Legacy Duplicate Input
+    #region Kitty + Legacy Input
 
-    // Copilot
+    // Codex - GPT-5 Codex
     [Fact]
     public void Pipeline_MixedKittyAndLegacyPrintable_DoesNotRaiseDuplicateKeyDown ()
     {
@@ -230,27 +236,29 @@ public class KittyKeyboardPipelineTests
         Assert.Empty (up);
     }
 
-    // Copilot
-    [Theory]
-    [InlineData ("«")]
-    [InlineData ("»")]
-    [InlineData ("ç")]
-    [InlineData ("Ç")]
-    [InlineData ("º")]
-    [InlineData ("ª")]
-    public void Pipeline_LegacyPrintable_PortugueseKeys_WhenKittyEnabled_DoesNotRaiseDuplicateKeyDown (string printable)
+    // Codex - GPT-5 Codex
+    [Fact]
+    public void Pipeline_MixedKittyAndLegacyPrintable_AfterSuppressionTimeout_RaisesBothKeyDowns ()
     {
-        // Issue #4918 (PT keyboard): some glyphs may still arrive as duplicated legacy printable input
-        // even when kitty is enabled. A single keypress should still produce one KeyDown.
-        string duplicatedInput = printable + printable;
-        (List<Key> down, List<Key> up) = InjectRawSequenceWithKittyEnabled (duplicatedInput);
+        (List<Key> down, List<Key> up) = InjectRawSequenceWithDelay (TimeSpan.FromMilliseconds (51), "\x1b[97u", "a");
 
-        Assert.Single (down);
-        Assert.Equal (printable, down [0].GetPrintableText ());
+        Assert.Equal (2, down.Count);
+        Assert.All (down, key => Assert.Equal (Key.A, key));
         Assert.Empty (up);
     }
 
-    // Copilot
+    // Codex - GPT-5 Codex
+    [Fact]
+    public void Pipeline_RepeatedLegacyPrintableInput_DoesNotSelfArmSuppression ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("jjjj");
+
+        Assert.Equal (4, down.Count);
+        Assert.Equal ("jjjj", string.Concat (down.Select (key => key.GetPrintableText ())));
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5 Codex
     [Fact]
     public void Pipeline_MixedKittyAssociatedTextAndLegacyPrintable_DoesNotRaiseDuplicateKeyDown ()
     {


### PR DESCRIPTION
Closes #5616