### PR TITLE
Fixes #5468. Fix TextValidateField cursor rendering

### DIFF
--- a/Terminal.Gui/Views/TextInput/TextValidateField.cs
+++ b/Terminal.Gui/Views/TextInput/TextValidateField.cs
@@ -368,7 +368,7 @@ public class TextValidateField : View, IDesignable, IValue<string>
             return true;
         }
 
-        var role = VisualRole.Editable;
+        VisualRole role = VisualRole.Editable;
         Attribute textColor = IsValid ? GetAttributeForRole (role) : SchemeManager.GetScheme (Schemes.Error).GetAttributeForRole (role);
 
         (int marginLeft, int marginRight) = GetMargins (Viewport.Width);
@@ -405,7 +405,7 @@ public class TextValidateField : View, IDesignable, IValue<string>
             return true;
         }
 
-        SetAttributeForRole (VisualRole.Focus);
+        SetAttribute (textColor with { Style = textColor.Style | TextStyle.Underline });
         Move (InsertionPoint + marginLeft, 0);
         AddRune ((Rune)_provider.DisplayText [InsertionPoint]);
 

--- a/Tests/UnitTestsParallelizable/Views/TextValidateFieldTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextValidateFieldTests.cs
@@ -787,4 +787,48 @@ public class TextValidateField_Regex_Provider_Tests : TestDriverBase
 
         Assert.Equal (before, field.Text);
     }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void Draw_FocusedCursor_PreservesEditableColors_AndAddsUnderline ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (4, 1);
+
+        Attribute editableAttribute = new (Color.BrightGreen, Color.Blue, TextStyle.Bold);
+        Scheme scheme = new ()
+        {
+            Editable = editableAttribute,
+            Focus = new (Color.BrightRed, Color.Magenta)
+        };
+
+        TextRegexProvider provider = new ("^[0-9]+$")
+        {
+            ValidateOnInput = false
+        };
+        TextValidateField field = new ()
+        {
+            Provider = provider,
+            Width = 4,
+            Height = 1
+        };
+        field.Text = "12";
+        field.SetScheme (scheme);
+
+        using Runnable top = new ();
+        top.Add (field);
+
+        app.Begin (top);
+        field.SetFocus ();
+        app.LayoutAndDraw ();
+
+        Cell cursorCell = app.Driver.Contents! [0, 0];
+        Attribute cursorAttribute = Assert.IsType<Attribute> (cursorCell.Attribute);
+
+        Assert.Equal ("1", cursorCell.Grapheme);
+        Assert.Equal (editableAttribute.Foreground, cursorAttribute.Foreground);
+        Assert.Equal (editableAttribute.Background, cursorAttribute.Background);
+        Assert.Equal (editableAttribute.Style | TextStyle.Underline, cursorAttribute.Style);
+    }
 }


### PR DESCRIPTION
## Fixes

- Fixes #5468

## Proposed Changes/Todos

- [x] Preserve the selected `Editable` or `Error` foreground and background colors at the focused insertion point.
- [x] Add only the intended cursor underline while preserving the field's existing text style.
- [x] Add regression coverage through the real ANSI test driver.

## Summary

`TextValidateField` redrew the insertion-point character with the `Focus` visual role after rendering the field with its selected `Editable` or `Error` attribute. When those roles used different colors, the cursor cell changed foreground and background even though only cursor appearance should change.

This change preserves the already-selected field attribute and adds only `Underline` to its existing style. The regression test renders through the real ANSI test driver and verifies the cursor glyph, foreground, background, and preservation of the existing `Bold` style.

## Changes

- Keep the focused cursor cell's current field colors instead of replacing them with `Focus` colors.
- Add `Underline` to the cursor cell without dropping the existing style.
- Cover the behavior with a deterministic ANSI-driver regression test.

## Visual evidence

<img width="514" height="344" alt="download" src="https://github.com/user-attachments/assets/4e520cd6-6444-4e0e-b356-6acd5249d556" />

The GIF alternates the same focused field rendered before and after the change. Before, the insertion cell uses the contrasting magenta/red `Focus` colors. After, it retains the green/blue `Editable` colors and gains only the cursor underline.

## Testing

- Focused `TextValidateField` tests: 39 passed, 0 failed.
- Full parallelizable tests: 17,543 passed, 17 declared skips, 0 failed.
- Full nonparallelizable tests: 72 passed, 2 declared skips, 0 failed.
- Root Debug build: PASS with 0 errors. It reported three warnings outside the candidate files; this change introduced no warnings in its source or test file.
- ScenarioRunner Release build: PASS.
- `git diff --check`: PASS.
- Deterministic real-ANSI-driver visual invariant: PASS.
- Independent review: PASS with no blockers.

The native Windows ScenarioRunner recording emitted no terminal events and was **not** successful validation. The visual evidence above comes from the deterministic real-ANSI-driver harness.

The regression test retains the repository-required AI-origin marker: `// CoPilot - GPT-5`.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/tui-cs/Terminal.Gui/blob/develop/.editorconfig) - if you use Visual Studio, hit `CTRL-K-D` to automatically reformat your files before committing.
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/tui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments) — not applicable; this change does not alter the public API.
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

# To pull down this PR locally:

```bash
git remote add copilot https://github.com/lyrae-versebound/Terminal.Gui.git
git fetch copilot lyrae/EXP-009-issue-5468
git checkout copilot/lyrae/EXP-009-issue-5468
```
