### PR TITLE
Addresses #5627. Skip clean runs during output flush

### DIFF
--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -173,92 +173,81 @@ public abstract class OutputBase
                 outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
             }
 
+            lastCol = 0;
+            var outputWidth = 0;
+
             // Process columns in row
             for (int col = left; col < cols; col++)
             {
-                lastCol = -1;
-                var outputWidth = 0;
+                // Skip clean cells, plus blank cells owned by raster images. Raster-owned
+                // blanks must not be emitted because normal text output would erase Sixel
+                // images and is unnecessary over Kitty's transparent-cleared placement.
+                bool skipRasterBlank = IsRasterCoveredBlankCell (buffer, row, col, rasterCellRectangles);
 
-                // Batch consecutive dirty cells
-                for (; col < cols; col++)
+                if (!buffer.Contents! [row, col].IsDirty || skipRasterBlank)
                 {
-                    // Skip clean cells, plus blank cells owned by raster images. Raster-owned
-                    // blanks must not be emitted because normal text output would erase Sixel
-                    // images and is unnecessary over Kitty's transparent-cleared placement.
-                    bool skipRasterBlank = IsRasterCoveredBlankCell (buffer, row, col, rasterCellRectangles);
-
-                    if (!buffer.Contents! [row, col].IsDirty || skipRasterBlank)
+                    if (skipRasterBlank)
                     {
-                        if (skipRasterBlank)
-                        {
-                            buffer.Contents [row, col].IsDirty = false;
-                        }
-
-                        if (outputStringBuilder.Length > 0)
-                        {
-                            // This clears outputStringBuilder
-                            WriteToConsole (outputStringBuilder, ref lastCol, ref outputWidth);
-                        }
-                        else if (lastCol == -1)
-                        {
-                            lastCol = col;
-                        }
-
-                        if (lastCol + 1 < cols)
-                        {
-                            lastCol++;
-                        }
-
-                        SetCursorPositionImpl (lastCol, row);
-
-                        continue;
-                    }
-
-                    if (lastCol == -1)
-                    {
-                        lastCol = col;
-                    }
-
-                    // Handle URL hyperlink state changes
-                    if (!IsLegacyConsole)
-                    {
-                        string? cellUrl = buffer.GetCellUrl (col, row);
-
-                        if (cellUrl != _lastUrl)
-                        {
-                            // If we were in a hyperlink, end it
-                            if (_lastUrl is { })
-                            {
-                                outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
-                            }
-
-                            // If starting a new hyperlink, begin it
-                            if (!string.IsNullOrEmpty (cellUrl))
-                            {
-                                outputStringBuilder.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
-                            }
-
-                            _lastUrl = cellUrl;
-                        }
-                    }
-
-                    // Append dirty cell as ANSI and mark clean
-                    Cell cell = buffer.Contents [row, col];
-                    buffer.Contents [row, col].IsDirty = false;
-                    AppendCellAnsi (cell, outputStringBuilder, ref redrawAttr, ref _redrawTextStyle, cols, ref col, ref outputWidth);
-
-                    if (col != lastCol)
-                    {
-                        // Was a wide grapheme so mark clean next cell
-                        // See https://github.com/tui-cs/Terminal.Gui/issues/4466
                         buffer.Contents [row, col].IsDirty = false;
                     }
+
+                    if (outputWidth > 0)
+                    {
+                        // This clears outputStringBuilder
+                        WriteToConsole (outputStringBuilder, ref lastCol, ref outputWidth);
+                    }
+
+                    continue;
+                }
+
+                // Position the cursor once at the beginning of each dirty run. Clean gaps
+                // are skipped without emitting one cursor-position sequence per cell.
+                if (outputWidth == 0 && col != lastCol)
+                {
+                    SetCursorPositionImpl (col, row);
+                    lastCol = col;
+                }
+
+                // Handle URL hyperlink state changes
+                if (!IsLegacyConsole)
+                {
+                    string? cellUrl = buffer.GetCellUrl (col, row);
+
+                    if (cellUrl != _lastUrl)
+                    {
+                        // If we were in a hyperlink, end it
+                        if (_lastUrl is { })
+                        {
+                            outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
+                        }
+
+                        // If starting a new hyperlink, begin it
+                        if (!string.IsNullOrEmpty (cellUrl))
+                        {
+                            outputStringBuilder.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
+                        }
+
+                        _lastUrl = cellUrl;
+                    }
+                }
+
+                // Append dirty cell as ANSI and mark clean
+                int cellCol = col;
+                Cell cell = buffer.Contents [row, col];
+                buffer.Contents [row, col].IsDirty = false;
+                AppendCellAnsi (cell, outputStringBuilder, ref redrawAttr, ref _redrawTextStyle, cols, ref col, ref outputWidth);
+
+                if (col != cellCol)
+                {
+                    // Was a wide grapheme so mark clean next cell
+                    // See https://github.com/tui-cs/Terminal.Gui/issues/4466
+                    buffer.Contents [row, col].IsDirty = false;
                 }
             }
 
             // Track row's URL status BEFORE the early-exit so _rowsWithUrls stays consistent
             // with the buffer state — even for rows whose cells were all flushed via WriteToConsole
-            // during the inner loop (leaving outputStringBuilder empty at this point).
+            // during the row scan (leaving outputStringBuilder empty at this point).
             if (!IsLegacyConsole)
             {
                 if (rowHasUrlsNow)
@@ -299,8 +288,6 @@ public abstract class OutputBase
                 outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
                 _lastUrl = null;
             }
-
-            SetCursorPositionImpl (lastCol, row);
 
             Write (outputStringBuilder);
         }

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -202,11 +202,15 @@ public abstract class OutputBase
 
                 // Position the cursor once at the beginning of each dirty run. Clean gaps
                 // are skipped without emitting one cursor-position sequence per cell.
-                if (outputWidth == 0 && col != lastCol)
-                {
-                    SetCursorPositionImpl (col, row);
-                    lastCol = col;
-                }
+if (outputWidth == 0 && col != lastCol)
+{
+    if (!SetCursorPositionImpl (col, row))
+    {
+        return;
+    }
+
+    lastCol = col;
+}
 
                 // Handle URL hyperlink state changes
                 if (!IsLegacyConsole)

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -202,15 +202,15 @@ public abstract class OutputBase
 
                 // Position the cursor once at the beginning of each dirty run. Clean gaps
                 // are skipped without emitting one cursor-position sequence per cell.
-if (outputWidth == 0 && col != lastCol)
-{
-    if (!SetCursorPositionImpl (col, row))
-    {
-        return;
-    }
+                if (outputWidth == 0 && col != lastCol)
+                {
+                    if (!SetCursorPositionImpl (col, row))
+                    {
+                        return;
+                    }
 
-    lastCol = col;
-}
+                    lastCol = col;
+                }
 
                 // Handle URL hyperlink state changes
                 if (!IsLegacyConsole)

--- a/Tests/Benchmarks/ConsoleDrivers/OutputBuffer/OutputWriteBenchmark.cs
+++ b/Tests/Benchmarks/ConsoleDrivers/OutputBuffer/OutputWriteBenchmark.cs
@@ -1,0 +1,232 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using Terminal.Gui.Drivers;
+
+namespace Terminal.Gui.Benchmarks.ConsoleDrivers.OutputBuffer;
+
+/// <summary>
+///     Measures output flushing for full and sparse 270x72 frames.
+/// </summary>
+/// <remarks>
+///     The sparse frame matches issue #5627: the first and last cells of every row are dirty,
+///     with a large clean gap between them.
+///     <para>
+///         Run the BenchmarkDotNet cases with:
+///         <code>dotnet run --project Tests/Benchmarks -c Release -- --filter "*OutputWriteBenchmark*"</code>
+///     </para>
+/// </remarks>
+[MemoryDiagnoser]
+[BenchmarkCategory ("Output", "Latency")]
+public class OutputWriteBenchmark
+{
+    private const int COLS = 270;
+    private const int ROWS = 72;
+    private const int CONPTY_WARMUP_FRAMES = 3;
+    private const int CONPTY_MEASURED_FRAMES = 20;
+
+    private OutputBufferImpl _fullBuffer = null!;
+    private MeasuringOutput _output = null!;
+    private OutputBufferImpl _sparseBuffer = null!;
+
+    /// <summary>
+    ///     Creates and warms the output buffers before benchmarking.
+    /// </summary>
+    [GlobalSetup]
+    public void Setup ()
+    {
+        _fullBuffer = CreateBuffer ();
+        _sparseBuffer = CreateBuffer ();
+        _output = new ();
+
+        _output.Write (_fullBuffer);
+        _output.Write (_sparseBuffer);
+    }
+
+    /// <summary>
+    ///     Marks every cell dirty before measuring a full-frame flush.
+    /// </summary>
+    [IterationSetup (Target = nameof (FullFrame))]
+    public void PrepareFullFrame ()
+    {
+        MarkFullFrame (_fullBuffer);
+        _output.ResetCounters ();
+    }
+
+    /// <summary>
+    ///     Marks only the first and last cells of every row dirty before measuring a sparse flush.
+    /// </summary>
+    [IterationSetup (Target = nameof (SparseBorderFrame))]
+    public void PrepareSparseBorderFrame ()
+    {
+        MarkSparseBorderFrame (_sparseBuffer);
+        _output.ResetCounters ();
+    }
+
+    /// <summary>
+    ///     Flushes a frame in which every cell is dirty.
+    /// </summary>
+    [Benchmark (Baseline = true)]
+    public long FullFrame ()
+    {
+        _output.Write (_fullBuffer);
+
+        return _output.CharactersWritten;
+    }
+
+    /// <summary>
+    ///     Flushes a frame with dirty border cells separated by clean interior cells.
+    /// </summary>
+    [Benchmark]
+    public long SparseBorderFrame ()
+    {
+        _output.Write (_sparseBuffer);
+
+        return _output.CharactersWritten;
+    }
+
+    /// <summary>
+    ///     Measures sparse-frame output through <see cref="WindowsOutput"/> under Windows Terminal or ConPTY
+    ///     and writes the timing summary to <paramref name="resultPath"/>.
+    /// </summary>
+    /// <param name="resultPath">Path for the JSON timing summary.</param>
+    public static void RunConPty (string resultPath)
+    {
+        if (!OperatingSystem.IsWindows ())
+        {
+            throw new PlatformNotSupportedException ("The ConPTY output benchmark requires Windows.");
+        }
+
+        if (Console.IsOutputRedirected)
+        {
+            throw new InvalidOperationException ("Run the ConPTY output benchmark from Windows Terminal or tuirec.");
+        }
+
+        if (string.IsNullOrWhiteSpace (resultPath))
+        {
+            throw new ArgumentException ("A result path is required.", nameof (resultPath));
+        }
+
+        OutputBufferImpl buffer = CreateBuffer ();
+        double [] samples = new double [CONPTY_MEASURED_FRAMES];
+
+        using (WindowsOutput output = new ())
+        {
+            output.Write (buffer);
+
+            for (var frame = 0; frame < CONPTY_WARMUP_FRAMES; frame++)
+            {
+                MarkSparseBorderFrame (buffer);
+                output.Write (buffer);
+            }
+
+            for (var frame = 0; frame < CONPTY_MEASURED_FRAMES; frame++)
+            {
+                MarkSparseBorderFrame (buffer);
+                long started = Stopwatch.GetTimestamp ();
+                output.Write (buffer);
+                samples [frame] = Stopwatch.GetElapsedTime (started).TotalMilliseconds;
+            }
+        }
+
+        Array.Sort (samples);
+        int p95Index = (int)Math.Ceiling (samples.Length * 0.95) - 1;
+        double median = (samples [samples.Length / 2 - 1] + samples [samples.Length / 2]) / 2;
+        string fullResultPath = Path.GetFullPath (resultPath);
+        string? resultDirectory = Path.GetDirectoryName (fullResultPath);
+
+        if (!string.IsNullOrEmpty (resultDirectory))
+        {
+            Directory.CreateDirectory (resultDirectory);
+        }
+
+        string json = JsonSerializer.Serialize (new
+        {
+            Columns = COLS,
+            Rows = ROWS,
+            WarmupFrames = CONPTY_WARMUP_FRAMES,
+            MeasuredFrames = CONPTY_MEASURED_FRAMES,
+            MeanMilliseconds = samples.Average (),
+            MedianMilliseconds = median,
+            P95Milliseconds = samples [p95Index],
+            MinMilliseconds = samples [0],
+            MaxMilliseconds = samples [^1]
+        }, new JsonSerializerOptions { WriteIndented = true });
+
+        File.WriteAllText (fullResultPath, json);
+    }
+
+    private static OutputBufferImpl CreateBuffer ()
+    {
+        OutputBufferImpl buffer = new ();
+        buffer.SetSize (COLS, ROWS);
+
+        for (var row = 0; row < ROWS; row++)
+        {
+            buffer.Move (0, row);
+            buffer.AddRune ('|');
+            buffer.Move (COLS - 1, row);
+            buffer.AddRune ('|');
+        }
+
+        return buffer;
+    }
+
+    private static void MarkFullFrame (OutputBufferImpl buffer)
+    {
+        for (var row = 0; row < ROWS; row++)
+        {
+            for (var col = 0; col < COLS; col++)
+            {
+                buffer.Contents! [row, col].IsDirty = true;
+            }
+
+            buffer.DirtyLines [row] = true;
+        }
+    }
+
+    private static void MarkSparseBorderFrame (OutputBufferImpl buffer)
+    {
+        for (var row = 0; row < ROWS; row++)
+        {
+            buffer.Contents! [row, 0].IsDirty = true;
+            buffer.Contents [row, COLS - 1].IsDirty = true;
+            buffer.DirtyLines [row] = true;
+        }
+    }
+
+    private sealed class MeasuringOutput : OutputBase
+    {
+        public long CharactersWritten { get; private set; }
+
+        public int CursorMoves { get; private set; }
+
+        public int Writes { get; private set; }
+
+        public void ResetCounters ()
+        {
+            CharactersWritten = 0;
+            CursorMoves = 0;
+            Writes = 0;
+        }
+
+        protected override bool SetCursorPositionImpl (int screenPositionX, int screenPositionY)
+        {
+            CursorMoves++;
+
+            StringBuilder sequence = new ();
+            EscSeqUtils.CSI_AppendCursorPosition (sequence, screenPositionY + 1, screenPositionX + 1);
+            string cursorSequence = sequence.ToString ();
+            CharactersWritten += cursorSequence.Length;
+
+            return true;
+        }
+
+        protected override void Write (StringBuilder output)
+        {
+            Writes++;
+            CharactersWritten += output.Length;
+        }
+    }
+}

--- a/Tests/Benchmarks/Program.cs
+++ b/Tests/Benchmarks/Program.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
+using Terminal.Gui.Benchmarks.ConsoleDrivers.OutputBuffer;
 using Terminal.Gui.Benchmarks.ViewBase;
 
 namespace Terminal.Gui.Benchmarks;
@@ -21,6 +22,16 @@ internal class Program
                 case "scenarios":
                 case "scenario":
                     ScenarioMemoryBenchmark.Run ();
+
+                    return;
+
+                case "output-conpty":
+                    if (args.Length < 2)
+                    {
+                        throw new ArgumentException ("Usage: output-conpty <result-path>");
+                    }
+
+                    OutputWriteBenchmark.RunConPty (args [1]);
 
                     return;
             }

--- a/Tests/Benchmarks/README.md
+++ b/Tests/Benchmarks/README.md
@@ -171,6 +171,25 @@ dotnet run --project Tests/Benchmarks -c Release -- --filter '*Config*' '*Scheme
 - Use BenchmarkDotNet for formal timing benchmarks with statistical rigor
 - Document what each benchmark measures
 
+## Output Flush Benchmarks
+
+`OutputWriteBenchmark` compares a full 270x72 frame with a sparse frame whose first and last cells
+are dirty on every row. The sparse case reproduces the shape reported in issue #5627.
+
+```powershell
+dotnet run --project Tests/Benchmarks -c Release -- --filter "*OutputWriteBenchmark*" --job short --exporters json
+```
+
+To measure the real Windows output path, run the benchmark through Windows Terminal or `tuirec` and
+provide a JSON result path:
+
+```powershell
+dotnet run --project Tests/Benchmarks -c Release -- output-conpty "$env:TEMP\tg-output-conpty.json"
+```
+
+The ConPTY benchmark requires Windows with output attached to a terminal. It warms three sparse
+frames, measures twenty frames, and records mean, median, p95, minimum, and maximum frame latency.
+
 ## Continuous Integration
 
 ### Layer 1: Performance Smoke Tests

--- a/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
@@ -155,6 +155,66 @@ public class OutputBaseTests
         Assert.Equal (0, output.Writes);
     }
 
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void Write_SparseBorderFrame_MovesCursorOncePerDirtyRun ()
+    {
+        const int COLS = 270;
+        const int ROWS = 72;
+        CountingOutput output = new ();
+        OutputBufferImpl buffer = new ();
+        buffer.SetSize (COLS, ROWS);
+        output.Write (buffer);
+        output.ResetCounters ();
+
+        for (var row = 0; row < ROWS; row++)
+        {
+            buffer.Contents! [row, 0].IsDirty = true;
+            buffer.Contents [row, COLS - 1].IsDirty = true;
+            buffer.DirtyLines [row] = true;
+        }
+
+        output.Write (buffer);
+
+        Assert.Equal (ROWS * 2, output.CursorMoves);
+        Assert.Equal (ROWS * 2, output.Writes);
+
+        for (var row = 0; row < ROWS; row++)
+        {
+            Assert.Equal (new Point (0, row), output.CursorPositions [row * 2]);
+            Assert.Equal (new Point (COLS - 1, row), output.CursorPositions [row * 2 + 1]);
+            Assert.False (buffer.Contents! [row, 0].IsDirty);
+            Assert.False (buffer.Contents [row, COLS - 1].IsDirty);
+            Assert.False (buffer.DirtyLines [row]);
+        }
+    }
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void Write_MultipleDirtyRuns_SkipsLeadingInteriorAndTrailingCleanCells ()
+    {
+        CountingOutput output = new ();
+        OutputBufferImpl buffer = new ();
+        buffer.SetSize (10, 1);
+        output.Write (buffer);
+        output.ResetCounters ();
+
+        buffer.Contents! [0, 2].IsDirty = true;
+        buffer.Contents [0, 3].IsDirty = true;
+        buffer.Contents [0, 8].IsDirty = true;
+        buffer.DirtyLines [0] = true;
+
+        output.Write (buffer);
+
+        Point [] expectedCursorPositions = [new (0, 0), new (2, 0), new (8, 0)];
+        Assert.Equal (expectedCursorPositions, output.CursorPositions);
+        Assert.Equal (2, output.Writes);
+        Assert.False (buffer.Contents [0, 2].IsDirty);
+        Assert.False (buffer.Contents [0, 3].IsDirty);
+        Assert.False (buffer.Contents [0, 8].IsDirty);
+        Assert.False (buffer.DirtyLines [0]);
+    }
+
     // CoPilot - GPT-5
     [Fact]
     public void FillRect_MarksDirtyLine_AfterPreviousFlush ()
@@ -1965,18 +2025,22 @@ public class OutputBaseTests
 
     private sealed class CountingOutput : OutputBase
     {
+        public List<Point> CursorPositions { get; } = [];
+
         public int CursorMoves { get; private set; }
 
         public int Writes { get; private set; }
 
         public void ResetCounters ()
         {
+            CursorPositions.Clear ();
             CursorMoves = 0;
             Writes = 0;
         }
 
         protected override bool SetCursorPositionImpl (int screenPositionX, int screenPositionY)
         {
+            CursorPositions.Add (new Point (screenPositionX, screenPositionY));
             CursorMoves++;
 
             return true;


### PR DESCRIPTION
## Summary

Optimize `OutputBase.Write` so sparse dirty rows skip clean gaps instead of emitting one cursor-position operation per clean cell.

- Closes #5627
- Related work: #5601 and #5602 skip wholly clean rows; this PR handles clean gaps within dirty rows

## Changes

- Accumulate and flush consecutive dirty cells as output runs
- Position the cursor once at the beginning of each dirty run
- Preserve hyperlink, raster, wide-grapheme, legacy-console, and dirty-row behavior
- Add 270x72 full-frame and sparse-border BenchmarkDotNet coverage
- Add a Windows ConPTY benchmark command and regression tests

## Benchmarks

| Case | Before | After | Result |
|---|---:|---:|---:|
| Sparse BenchmarkDotNet mean | 2.741 ms | 0.704 ms | 3.89x faster |
| Sparse allocation | 3.83 MiB | 300.53 KiB | 92.3% lower |
| Sparse cursor calls | 19,440 | 144 | 135x fewer |
| ConPTY median | 347.196 ms | 5.713 ms | 60.8x faster |
| ConPTY p95 | 353.920 ms | 6.070 ms | 58.3x faster |

Full-frame BenchmarkDotNet performance remained effectively flat. Content writes remain unchanged at 144 for the sparse frame.

## Testing

- Debug build: 0 warnings, 0 errors
- `OutputBaseTests`: 73 passed
- Parallelizable unit tests: 17,575 passed, 17 skipped
- Non-parallelizable unit tests: 72 passed, 2 skipped
- Integration tests: 437 passed
- ConPTY captures used tuirec v0.9.1 at 270x72

## To pull down this PR locally:

```bash
git remote add yor https://github.com/YourRobotOverlord/Terminal.Gui.git
git fetch yor fix/skip-clean-runs
git checkout --track yor/fix/skip-clean-runs
```