### PR TITLE
Fixes #5632. Prevent Shortcut help text overdraw

### DIFF
--- a/Terminal.Gui/Views/Shortcut.cs
+++ b/Terminal.Gui/Views/Shortcut.cs
@@ -677,6 +677,9 @@ public class Shortcut : View, IOrientation, IDesignable
         HelpView.MouseHighlightStates = MouseState.None;
     }
 
+    /// <inheritdoc/>
+    protected override bool OnDrawingText (DrawContext? context) => true;
+
     /// <summary>
     ///     Gets or sets the help text displayed in the middle of the Shortcut. Identical in function to <see cref="HelpText"/>
     ///     .

--- a/Tests/UnitTestsParallelizable/Views/ShortcutDrawingTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/ShortcutDrawingTests.cs
@@ -1,0 +1,31 @@
+using UnitTests;
+
+namespace ViewsTests;
+
+public class ShortcutDrawingTests (ITestOutputHelper output) : TestDriverBase
+{
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void HelpText_Does_Not_Draw_Over_CommandView ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (20, 1);
+
+        Runnable runnable = new () { Width = 20, Height = 1 };
+        app.Begin (runnable);
+
+        Shortcut shortcut = new ()
+        {
+            Title = "_New",
+            HelpText = "New file",
+            Width = 20,
+            Height = 1
+        };
+
+        runnable.Add (shortcut);
+        app.LayoutAndDraw ();
+
+        DriverAssert.AssertDriverContentsWithFrameAre (" New       New file", output, app.Driver);
+    }
+}


### PR DESCRIPTION
## Summary

Prevent `Shortcut` from drawing its base `Text` over the `CommandView` and `HelpView` that own its visual content.

- Fixes #5632

## Changes

- Suppress the base text-rendering pass in `Shortcut` while preserving the new `Text`/`HelpText` synchronization and CWP behavior.
- Add a buffer-level regression test covering overlapping command and help text.

## Testing

- `dotnet build --configuration Debug --no-restore` — passed with 0 warnings and 0 errors.
- `ShortcutDrawingTests` — 1 passed.
- `ShortcutTests` — 137 passed.
- `MenuBarTests` — 48 passed, 1 existing skipped test.
- `UnitTests.NonParallelizable` — 72 passed, 2 existing skipped tests.
- Manually ran the UICatalog `MenuBars` scenario and verified the File menu renders `New`, `Open...`, `Save`, and `Exit` without duplicated help-text fragments.
- Full `UnitTests.Parallelizable` run: 17,569 passed and 17 skipped; 5 unrelated ANSI color-output assertions failed because the environment emitted 16-color sequences where those tests expected true-color sequences. One failure reproduces when run alone.

## To pull down this PR locally:

```bash
git remote add copilot https://github.com/YourRobotOverlord/Terminal.Gui.git
git fetch copilot fix/5632-shortcut-help-overdraw
git checkout copilot/fix/5632-shortcut-help-overdraw
```