### PR TITLE
Fixes #5636 - Scope MainLoopSyncContext to running sessions (await-before-RunAsync deadlock)

### DIFF
--- a/Terminal.Gui/App/ApplicationImpl.Lifecycle.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Lifecycle.cs
@@ -80,8 +80,11 @@ internal partial class ApplicationImpl
         RaiseInitializedChanged (this, new EventArgs<bool> (true));
         SubscribeDriverEvents ();
 
+        // Created here; installed as the thread's ambient context only while a session is running
+        // (see Begin/Run). Installing it at Init time would make an await between Init and Run
+        // capture a context whose continuations only execute once the main loop is pumping —
+        // stranding the continuation that was going to start the loop (#5636).
         SynchronizationContext = new MainLoopSyncContext (this);
-        SynchronizationContext.SetSynchronizationContext (SynchronizationContext);
 
         _result = null;
 
@@ -305,13 +308,13 @@ internal partial class ApplicationImpl
         MainThreadId = null;
 
         // === 9. Reset synchronization context ===
-        // IMPORTANT: Always reset sync context, even if not initialized
-        // This ensures cleanup works correctly even if Shutdown is called without Init
-        // Reset synchronization context to allow the user to run async/await,
-        // as the main loop has been ended, the synchronization context from
-        // gui.cs does no longer process any callbacks. See #1084 for more details:
-        // (https://github.com/tui-cs/Terminal.Gui/issues/1084).
-        SynchronizationContext.SetSynchronizationContext (null);
+        // If this app's context is still the thread's ambient context, clear it so later
+        // async/await does not capture a context that no longer processes callbacks (#1084).
+        // A foreign ambient context (the caller's own) is left untouched.
+        if (SynchronizationContext is { } ownContext && System.Threading.SynchronizationContext.Current == ownContext)
+        {
+            System.Threading.SynchronizationContext.SetSynchronizationContext (null);
+        }
 
         // === 10. Unsubscribe from Application static property change events ===
         UnsubscribeApplicationEvents ();

--- a/Terminal.Gui/App/ApplicationImpl.Lifecycle.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Lifecycle.cs
@@ -306,6 +306,7 @@ internal partial class ApplicationImpl
         // === 8. Reset initialization state ===
         Initialized = false;
         MainThreadId = null;
+        ResetHasEndedSession ();
 
         // === 9. Reset synchronization context ===
         // If this app's context is still the thread's ambient context, clear it so later

--- a/Terminal.Gui/App/ApplicationImpl.Run.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Run.cs
@@ -136,7 +136,9 @@ internal partial class ApplicationImpl
         // Set the application reference in the runnable
         runnable.SetApp (this);
 
-        // Set the synchronization context to MainLoopSyncContext for this application
+        // Set the synchronization context to MainLoopSyncContext for this application, saving the
+        // caller's context on the token so End can restore it (#5636).
+        token.PreviousSynchronizationContext = System.Threading.SynchronizationContext.Current;
         SynchronizationContext.SetSynchronizationContext (SynchronizationContext);
 
         // Ensure the mouse is ungrabbed
@@ -511,8 +513,33 @@ internal partial class ApplicationImpl
 
         // Clear the Runnable from the token
         token.Runnable = null;
+        HasEndedSession = true;
         SessionEnded?.Invoke (this, new SessionTokenEventArgs (token));
+
+        // Restore the ambient context the caller had at Begin, so an await after a directly-begun
+        // session cannot capture a context that is no longer pumping (#5636). For nested sessions
+        // the previous context is the same app context, so the outermost End restores the caller's.
+        if (System.Threading.SynchronizationContext.Current == SynchronizationContext)
+        {
+            System.Threading.SynchronizationContext.SetSynchronizationContext (token.PreviousSynchronizationContext);
+        }
     }
+
+    /// <summary>
+    ///     INTERNAL: Whether any session has ended. Once true (and no session is running), posts to
+    ///     <see cref="MainLoopSyncContext"/> fall back to the thread pool instead of queueing onto a
+    ///     loop that may never pump again.
+    /// </summary>
+    internal bool HasEndedSession { get; private set; }
+
+    /// <summary>
+    ///     INTERNAL: Whether work posted to <see cref="MainLoopSyncContext"/> can rely on the main
+    ///     loop to pump it: the app is initialized, and either a session is running or none has run
+    ///     to completion yet (posts made between Init and the first Run are pumped by that Run).
+    /// </summary>
+    internal bool CanPumpPostedWork => Initialized && (TopRunnable is { IsRunning: true } || !HasEndedSession);
+
+    internal void ResetHasEndedSession () => HasEndedSession = false;
 
     #endregion Session Lifecycle - End
 

--- a/Terminal.Gui/App/ApplicationImpl.Run.cs
+++ b/Terminal.Gui/App/ApplicationImpl.Run.cs
@@ -237,47 +237,59 @@ internal partial class ApplicationImpl
             throw new NotInitializedException (@"Init must be called before Run.");
         }
 
-        // Begin the session (adds to stack, raises IsRunningChanging/IsRunningChanged)
+        // Begin installs this app's MainLoopSyncContext as the thread's ambient context for the
+        // duration of the session; restore the caller's context on exit so an await after Run
+        // does not capture a context that is no longer pumping (#5636).
+        SynchronizationContext? previousContext = System.Threading.SynchronizationContext.Current;
 
-        SessionToken? token =
-
-            // Find it on the stack
-            runnable.IsRunning ? SessionStack?.FirstOrDefault (st => st.Runnable == runnable) : Begin (runnable);
-
-        if (token is null)
+        try
         {
-            Logging.Warning (@"Run - Begin session failed or was cancelled.");
+            // Begin the session (adds to stack, raises IsRunningChanging/IsRunningChanged)
 
-            return null;
+            SessionToken? token =
+
+                // Find it on the stack
+                runnable.IsRunning ? SessionStack?.FirstOrDefault (st => st.Runnable == runnable) : Begin (runnable);
+
+            if (token is null)
+            {
+                Logging.Warning (@"Run - Begin session failed or was cancelled.");
+
+                return null;
+            }
+
+            // Loop to handle the case where End is cancelled by an IsRunningChanging handler.
+            // When End is cancelled, IsRunning remains true; we reset StopRequested and re-run the loop.
+            while (true)
+            {
+                try
+                {
+                    // All runnables block until RequestStop() is called
+                    RunLoop (runnable, errorHandler);
+                }
+                finally
+                {
+                    // End the session (raises IsRunningChanging/IsRunningChanged, pops from stack)
+                    End (token);
+                }
+
+                // If End succeeded IsRunning is now false — we are done
+                if (!runnable.IsRunning)
+                {
+                    break;
+                }
+
+                // End was cancelled by an IsRunningChanging handler (e.g., "Are you sure?" veto).
+                // Reset StopRequested so RunLoop can re-enter its while condition correctly.
+                runnable.StopRequested = false;
+            }
+
+            return token.Result;
         }
-
-        // Loop to handle the case where End is cancelled by an IsRunningChanging handler.
-        // When End is cancelled, IsRunning remains true; we reset StopRequested and re-run the loop.
-        while (true)
+        finally
         {
-            try
-            {
-                // All runnables block until RequestStop() is called
-                RunLoop (runnable, errorHandler);
-            }
-            finally
-            {
-                // End the session (raises IsRunningChanging/IsRunningChanged, pops from stack)
-                End (token);
-            }
-
-            // If End succeeded IsRunning is now false — we are done
-            if (!runnable.IsRunning)
-            {
-                break;
-            }
-
-            // End was cancelled by an IsRunningChanging handler (e.g., "Are you sure?" veto).
-            // Reset StopRequested so RunLoop can re-enter its while condition correctly.
-            runnable.StopRequested = false;
+            System.Threading.SynchronizationContext.SetSynchronizationContext (previousContext);
         }
-
-        return token.Result;
     }
 
     /// <inheritdoc/>

--- a/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
@@ -22,6 +22,21 @@ internal sealed class MainLoopSyncContext : SynchronizationContext
     {
         ArgumentNullException.ThrowIfNull (d);
 
+        // After Shutdown/Dispose no main loop can ever pump this queue; run the callback on the
+        // thread pool instead of stranding it (and any awaiter) forever (#5636).
+        if (!_app.Initialized)
+        {
+            ThreadPool.QueueUserWorkItem (
+                                          static s =>
+                                          {
+                                              (SendOrPostCallback callback, object? callbackState) = ((SendOrPostCallback, object?))s!;
+                                              callback (callbackState);
+                                          },
+                                          (d, state));
+
+            return;
+        }
+
         // Queue the task using the modern architecture
         _app.Invoke (() => d (state));
     }
@@ -31,7 +46,8 @@ internal sealed class MainLoopSyncContext : SynchronizationContext
     {
         ArgumentNullException.ThrowIfNull (d);
 
-        if (_app.MainThreadId == Thread.CurrentThread.ManagedThreadId)
+        // After Shutdown/Dispose no main loop can ever pump the queue; execute inline.
+        if (!_app.Initialized || _app.MainThreadId == Thread.CurrentThread.ManagedThreadId)
         {
             d (state);
 

--- a/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
@@ -17,14 +17,17 @@ internal sealed class MainLoopSyncContext : SynchronizationContext
     /// <inheritdoc/>
     public override SynchronizationContext CreateCopy () => new MainLoopSyncContext (_app);
 
+    private bool CanPump => _app is ApplicationImpl { CanPumpPostedWork: true };
+
     /// <inheritdoc/>
     public override void Post (SendOrPostCallback d, object? state)
     {
         ArgumentNullException.ThrowIfNull (d);
 
-        // After Shutdown/Dispose no main loop can ever pump this queue; run the callback on the
-        // thread pool instead of stranding it (and any awaiter) forever (#5636).
-        if (!_app.Initialized)
+        // With no main loop pumping (after Shutdown/Dispose, or after a session ended with none
+        // running), run the callback on the thread pool instead of stranding it — and any awaiter —
+        // forever (#5636). Posts made between Init and the first Run stay queued for that Run.
+        if (!CanPump)
         {
             ThreadPool.QueueUserWorkItem (
                                           static s =>
@@ -46,8 +49,8 @@ internal sealed class MainLoopSyncContext : SynchronizationContext
     {
         ArgumentNullException.ThrowIfNull (d);
 
-        // After Shutdown/Dispose no main loop can ever pump the queue; execute inline.
-        if (!_app.Initialized || _app.MainThreadId == Thread.CurrentThread.ManagedThreadId)
+        // With no main loop pumping, execute inline rather than waiting on a queue nothing drains.
+        if (!CanPump || _app.MainThreadId == Thread.CurrentThread.ManagedThreadId)
         {
             d (state);
 

--- a/Terminal.Gui/App/Runnable/SessionToken.cs
+++ b/Terminal.Gui/App/Runnable/SessionToken.cs
@@ -18,4 +18,11 @@ public class SessionToken
     ///     The result of the session. Typically set by the runnable in <see langword="IRunnable.IsRunningChanged"/>
     /// </summary>
     public object? Result { get; set; }
+
+    /// <summary>
+    ///     The ambient <see cref="SynchronizationContext"/> the caller had when
+    ///     <see cref="IApplication.Begin(IRunnable)"/> installed the app's context;
+    ///     restored by <see cref="IApplication.End(SessionToken)"/>.
+    /// </summary>
+    internal SynchronizationContext? PreviousSynchronizationContext { get; set; }
 }

--- a/Tests/UnitTests.NonParallelizable/Application/SynchronizationContextTests.cs
+++ b/Tests/UnitTests.NonParallelizable/Application/SynchronizationContextTests.cs
@@ -1,36 +1,51 @@
 // Copilot
+// Claude - Fable 5
 #nullable enable
 
 namespace UnitTests.NonParallelizable.ApplicationTests;
 
 /// <summary>
-///     Tests for the <see cref="SynchronizationContext"/> that is set during the Terminal.Gui application lifecycle.
-///     Must run non-concurrently because <see cref="IApplication.Init"/> and <see cref="IDisposable.Dispose"/> mutate
-///     the process-wide <see cref="SynchronizationContext.Current"/>.
+///     Tests for the <see cref="SynchronizationContext"/> contract of the Terminal.Gui application lifecycle.
+///     As of #5636, <see cref="IApplication.Init"/> does NOT install the app's main-loop context as the
+///     thread's ambient context — it becomes ambient only while a session is running (see Begin/Run) —
+///     so an <c>await</c> between <c>Init</c> and <c>Run</c>/<c>RunAsync</c> cannot capture a context
+///     whose continuations would be stranded on a not-yet-running main loop.
 /// </summary>
 public class SynchronizationContextTests
 {
     [Fact]
-    public void Init_SetsSynchronizationContext_Dispose_ClearsIt ()
+    public void Init_LeavesAmbientContext_Dispose_LeavesForeignContext ()
     {
-        IApplication app = Application.Create ();
+        SynchronizationContext? previous = SynchronizationContext.Current;
+        SynchronizationContext marker = new ();
 
         try
         {
-            app.Init (DriverRegistry.Names.ANSI);
+            SynchronizationContext.SetSynchronizationContext (marker);
 
-            Assert.NotNull (SynchronizationContext.Current);
+            IApplication app = Application.Create ();
+
+            try
+            {
+                app.Init (DriverRegistry.Names.ANSI);
+
+                Assert.Same (marker, SynchronizationContext.Current);
+            }
+            finally
+            {
+                app.Dispose ();
+            }
+
+            Assert.Same (marker, SynchronizationContext.Current);
         }
         finally
         {
-            app.Dispose ();
+            SynchronizationContext.SetSynchronizationContext (previous);
         }
-
-        Assert.Null (SynchronizationContext.Current);
     }
 
     [Fact]
-    public void Init_SynchronizationContext_CreateCopy_ReturnsDifferentInstance ()
+    public void App_SynchronizationContext_CreateCopy_ReturnsDifferentInstance ()
     {
         IApplication app = Application.Create ();
 
@@ -38,7 +53,7 @@ public class SynchronizationContextTests
         {
             app.Init (DriverRegistry.Names.ANSI);
 
-            SynchronizationContext context = SynchronizationContext.Current!;
+            SynchronizationContext context = ((ApplicationImpl)app).SynchronizationContext!;
             SynchronizationContext copy = context.CreateCopy ();
 
             Assert.NotNull (copy);

--- a/Tests/UnitTestsParallelizable/Application/ApplicationImplTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/ApplicationImplTests.cs
@@ -46,11 +46,24 @@ public class ApplicationImplTests
     }
 
     [Fact]
-    public void Dispose_Resets_SyncContext ()
+    public void Dispose_LeavesForeignAmbientSyncContext ()
     {
-        IApplication app = Application.Create ();
-        app.Dispose ();
-        Assert.Null (SynchronizationContext.Current);
+        SynchronizationContext? previous = SynchronizationContext.Current;
+        SynchronizationContext marker = new ();
+
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext (marker);
+
+            IApplication app = Application.Create ();
+            app.Dispose ();
+
+            Assert.Same (marker, SynchronizationContext.Current);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext (previous);
+        }
     }
 
     [Fact]
@@ -63,12 +76,14 @@ public class ApplicationImplTests
         int? callbackThreadId = null;
         ManualResetEventSlim callbackCalled = new (false);
 
-        SynchronizationContext.Current!.Post (_ =>
-                                              {
-                                                  callbackThreadId = Thread.CurrentThread.ManagedThreadId;
-                                                  callbackCalled.Set ();
-                                              },
-                                              null);
+        // As of #5636 Init no longer installs the app context as the thread's ambient context;
+        // posting to the app's own context before Run still lands on the main thread once the loop runs.
+        ((ApplicationImpl)app).SynchronizationContext!.Post (_ =>
+                                                             {
+                                                                 callbackThreadId = Thread.CurrentThread.ManagedThreadId;
+                                                                 callbackCalled.Set ();
+                                                             },
+                                                             null);
 
         app.AddTimeout (TimeSpan.FromMilliseconds (100),
                         () =>
@@ -128,7 +143,10 @@ public class ApplicationImplTests
 
         Assert.True (callbackCalled.Wait (TimeSpan.FromMilliseconds (200), TestContext.Current.CancellationToken));
         Assert.Equal (mainThreadId1, callbackThreadId1);
-        Assert.Equal (synchronizationContext1, SynchronizationContext.Current);
+
+        // The ambient context observed during app1's run is app1's own context; Run restores the
+        // caller's ambient context on exit (#5636), so compare against the app instance's context.
+        Assert.Same (((ApplicationImpl)app1).SynchronizationContext, synchronizationContext1);
 
         callbackCalled.Reset ();
 
@@ -163,9 +181,8 @@ public class ApplicationImplTests
 
         Assert.True (callbackCalled.Wait (TimeSpan.FromMilliseconds (200), TestContext.Current.CancellationToken));
         Assert.Equal (mainThreadId2, callbackThreadId2);
-        Assert.NotEqual (synchronizationContext1, SynchronizationContext.Current);
-        Assert.Equal (synchronizationContext2, SynchronizationContext.Current);
-        Assert.NotEqual (synchronizationContext1, synchronizationContext2);
+        Assert.Same (((ApplicationImpl)app2).SynchronizationContext, synchronizationContext2);
+        Assert.NotSame (synchronizationContext1, synchronizationContext2);
 
         app1.Dispose ();
         app2.Dispose ();

--- a/Tests/UnitTestsParallelizable/Application/RunAsyncTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/RunAsyncTests.cs
@@ -96,6 +96,38 @@ public class RunAsyncTests
         app.Dispose ();
     }
 
+    // Claude - Fable 5
+    // Repro for #5636: an await between Init and RunAsync must not deadlock. Pre-fix, Init
+    // installed the app's MainLoopSyncContext as the thread's ambient context; the await's
+    // continuation was posted to the not-yet-running main loop, so RunAsync was never reached.
+    [Fact]
+    public async Task RunAsync_AfterAwaitFollowingInit_DoesNotDeadlock ()
+    {
+        Task scenario = Task.Run (async () =>
+        {
+            IApplication app = Application.Create ();
+            app.Init (DriverRegistry.Names.ANSI);
+
+            // Resumes via the thread's ambient SynchronizationContext when one is installed.
+            await Task.Yield ();
+
+            Runnable runnable = new ();
+            using CancellationTokenSource cts = new ();
+
+            void OnIteration (object? s, EventArgs<IApplication?> a) => cts.Cancel ();
+
+            app.Iteration += OnIteration;
+            await app.RunAsync (runnable, cts.Token);
+            app.Iteration -= OnIteration;
+
+            runnable.Dispose ();
+            app.Dispose ();
+        });
+
+        // Fails with a timeout when the continuation after Task.Yield is stranded.
+        await scenario.WaitAsync (TimeSpan.FromSeconds (10), TestContext.Current.CancellationToken);
+    }
+
     [Fact]
     public async Task RunAsync_UnhandledException_FaultedTask ()
     {

--- a/Tests/UnitTestsParallelizable/Application/SyncContextLifecycleTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/SyncContextLifecycleTests.cs
@@ -79,6 +79,77 @@ public class SyncContextLifecycleTests
         }
     }
 
+    // The documented Begin/End building-block sequence must restore the caller's ambient context
+    // just like Run does — including nested sessions, where only the outermost End restores it.
+    [Fact]
+    public void Begin_End_RestoresAmbientSyncContext_IncludingNestedSessions ()
+    {
+        SynchronizationContext? previous = SynchronizationContext.Current;
+        SynchronizationContext marker = new ();
+
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext (marker);
+
+            IApplication app = Application.Create ();
+            app.Init (DriverRegistry.Names.ANSI);
+            SynchronizationContext appContext = ((ApplicationImpl)app).SynchronizationContext!;
+
+            using Runnable outer = new ();
+            using Runnable inner = new ();
+
+            SessionToken outerToken = app.Begin (outer)!;
+            Assert.Same (appContext, SynchronizationContext.Current);
+
+            SessionToken innerToken = app.Begin (inner)!;
+            Assert.Same (appContext, SynchronizationContext.Current);
+
+            app.End (innerToken);
+
+            // The outer session is still active; the app context stays ambient.
+            Assert.Same (appContext, SynchronizationContext.Current);
+
+            app.End (outerToken);
+
+            Assert.Same (marker, SynchronizationContext.Current);
+
+            app.Dispose ();
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext (previous);
+        }
+    }
+
+    // A continuation that captured the app context during a session can resume after the session
+    // ends; with no loop pumping (and the app still Initialized), it must not be stranded.
+    [Fact]
+    public void Post_AfterSessionEnded_StillExecutesCallback ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+
+        void OnIteration (object? s, EventArgs<IApplication?> a) => app.RequestStop ();
+
+        app.Iteration += OnIteration;
+
+        using (Runnable runnable = new ())
+        {
+            app.Run (runnable);
+        }
+
+        app.Iteration -= OnIteration;
+
+        SynchronizationContext context = ((ApplicationImpl)app).SynchronizationContext!;
+
+        using ManualResetEventSlim callbackCalled = new (false);
+        context.Post (_ => callbackCalled.Set (), null);
+
+        Assert.True (callbackCalled.Wait (TimeSpan.FromSeconds (2), TestContext.Current.CancellationToken));
+
+        app.Dispose ();
+    }
+
     [Fact]
     public void Post_AfterDispose_StillExecutesCallback ()
     {

--- a/Tests/UnitTestsParallelizable/Application/SyncContextLifecycleTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/SyncContextLifecycleTests.cs
@@ -1,0 +1,96 @@
+// Claude - Fable 5
+#nullable enable
+
+namespace ApplicationTests;
+
+/// <summary>
+///     Tests for the ambient <see cref="SynchronizationContext"/> contract across the application
+///     lifecycle (#5636): <see cref="IApplication.Init"/> must not install the app's main-loop context
+///     as the thread's ambient context (an <c>await</c> before <c>Run</c> would capture a context whose
+///     continuations only run once the loop is pumping — a startup deadlock). The app context is
+///     ambient only while a session is running, and the caller's context is restored afterwards.
+/// </summary>
+[Collection ("Application Tests")]
+public class SyncContextLifecycleTests
+{
+    [Fact]
+    public void Init_DoesNotChangeAmbientSynchronizationContext ()
+    {
+        SynchronizationContext? previous = SynchronizationContext.Current;
+        SynchronizationContext marker = new ();
+
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext (marker);
+
+            IApplication app = Application.Create ();
+            app.Init (DriverRegistry.Names.ANSI);
+
+            Assert.Same (marker, SynchronizationContext.Current);
+
+            app.Dispose ();
+
+            Assert.Same (marker, SynchronizationContext.Current);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext (previous);
+        }
+    }
+
+    [Fact]
+    public void Run_SetsAppSyncContextDuringRun_AndRestoresAmbientAfter ()
+    {
+        SynchronizationContext? previous = SynchronizationContext.Current;
+        SynchronizationContext marker = new ();
+
+        try
+        {
+            SynchronizationContext.SetSynchronizationContext (marker);
+
+            IApplication app = Application.Create ();
+            app.Init (DriverRegistry.Names.ANSI);
+
+            SynchronizationContext? duringRun = null;
+
+            void OnIteration (object? s, EventArgs<IApplication?> a)
+            {
+                duringRun = SynchronizationContext.Current;
+                app.RequestStop ();
+            }
+
+            app.Iteration += OnIteration;
+
+            using (Runnable runnable = new ())
+            {
+                app.Run (runnable);
+            }
+
+            app.Iteration -= OnIteration;
+
+            Assert.Same (((ApplicationImpl)app).SynchronizationContext, duringRun);
+            Assert.Same (marker, SynchronizationContext.Current);
+
+            app.Dispose ();
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext (previous);
+        }
+    }
+
+    [Fact]
+    public void Post_AfterDispose_StillExecutesCallback ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        SynchronizationContext context = ((ApplicationImpl)app).SynchronizationContext!;
+        app.Dispose ();
+
+        // No main loop can ever pump this; the callback must not be stranded (or throw).
+        using ManualResetEventSlim callbackCalled = new (false);
+        context.Post (_ => callbackCalled.Set (), null);
+
+        Assert.True (callbackCalled.Wait (TimeSpan.FromSeconds (2), TestContext.Current.CancellationToken));
+    }
+}


### PR DESCRIPTION
Fixes #5636. Stacked on #5416 (`tig/remove-cm-followup`).

## Root cause

Since #5588, `Init` installed the app's `MainLoopSyncContext` as the calling thread's **ambient** `SynchronizationContext`. Any `await` between `Init` and `Run`/`RunAsync` captured that context; its `Post` queues work onto the main loop — **which is not running yet** — so the continuation (the code about to start the loop) was stranded and the app hung at startup while the input thread spun. `ConfigureAwait (false)` avoids the capture, which is exactly the workaround tui-cs/clet shipped (clet#202).

## Fix

- `Init` creates the context but no longer installs it as ambient. `Begin` still installs it for the duration of a session, so `await`s **inside event handlers** keep marshaling to the main loop (the #5579 contract is preserved — `Open_Calls_ContinueWith_On_UIThread` and both `Init_Posts_*` tests still pass).
- `Run` saves the caller's ambient context and restores it in a `finally`, so an `await` after `Run` returns can't capture a stopped-pumping context.
- `ResetState` clears the ambient context only when it's this app's own; a caller-owned context is left untouched.
- `MainLoopSyncContext.Post`/`Send` fall back to thread pool / inline execution once the app is no longer `Initialized` — callbacks posted after `Shutdown`/`Dispose` execute instead of being stranded (previously `Post` threw `NotInitializedException` via `Invoke`).

## Test-first

`RunAsync_AfterAwaitFollowingInit_DoesNotDeadlock` reproduces the exact #5636 scenario (`Init` → `await Task.Yield ()` → `RunAsync`) on a dedicated thread: it failed with a 10s timeout before the fix and passes in ~2s after. New `SyncContextLifecycleTests` pin the Init/Run/Dispose ambient-context contract and the post-dispose `Post` fallback. Tests that encoded the #5588 ambient-at-Init behavior (`SynchronizationContextTests`, `Dispose_Resets_SyncContext`, the `Init_Posts_*` post-run assertions) were updated to the new contract.

## Verification

- Parallelizable: **17,564 passed**
- Non-parallelizable: **32 passed**
- Integration: **437 passed**

Once this merges into the 5416 branch, tui-cs/clet can drop its `ConfigureAwait (false)` workaround (clet#202).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGq38GbuZPAEa5wZHkmPiZ