### PR TITLE
Fixes #5640. Prevent custom renderer text overdraw

### DIFF
--- a/Terminal.Gui/Views/Code.cs
+++ b/Terminal.Gui/Views/Code.cs
@@ -98,6 +98,9 @@ public class Code : View, IDesignable
     }
 
     /// <inheritdoc/>
+    protected override bool OnDrawingText (DrawContext? context) => true;
+
+    /// <inheritdoc/>
     protected override bool OnDrawingContent (DrawContext? context)
     {
         int endLine = Math.Min (Viewport.Y + Viewport.Height, _lines.Count);

--- a/Terminal.Gui/Views/Color/ColorPicker.cs
+++ b/Terminal.Gui/Views/Color/ColorPicker.cs
@@ -106,6 +106,9 @@ public class ColorPicker : View, IValue<Color?>, IDesignable
     }
 
     /// <inheritdoc/>
+    protected override bool OnDrawingText (DrawContext? context) => true;
+
+    /// <inheritdoc/>
     protected override bool OnDrawingContent (DrawContext? context)
     {
         Attribute normal = GetAttributeForRole (VisualRole.Normal);

--- a/Terminal.Gui/Views/LinearRange/LinearRangeViewBase.cs
+++ b/Terminal.Gui/Views/LinearRange/LinearRangeViewBase.cs
@@ -1008,6 +1008,9 @@ public abstract class LinearRangeViewBase<TOption, TValue> : View, IOrientation,
     #region Drawing
 
     /// <inheritdoc/>
+    protected override bool OnDrawingText (DrawContext? context) => true;
+
+    /// <inheritdoc/>
     protected override bool OnDrawingContent (DrawContext? context)
     {
         // TODO: make this more surgical to reduce repaint

--- a/Terminal.Gui/Views/ProgressBar.cs
+++ b/Terminal.Gui/Views/ProgressBar.cs
@@ -229,7 +229,10 @@ public class ProgressBar : View, IDesignable
         return base.OnTextChanging (newText);
     }
 
-    ///<inheritdoc/>
+    /// <inheritdoc/>
+    protected override bool OnDrawingText (DrawContext? context) => true;
+
+    /// <inheritdoc/>
     protected override bool OnDrawingContent (DrawContext? context)
     {
         SetAttribute (GetAttributeForRole (VisualRole.Normal));

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.Drawing.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.Drawing.cs
@@ -3,6 +3,9 @@ namespace Terminal.Gui.Views;
 public partial class TextField
 {
     /// <inheritdoc/>
+    protected override bool OnDrawingText (DrawContext? context) => true;
+
+    /// <inheritdoc/>
     protected override bool OnGettingAttributeForRole (in VisualRole role, ref Attribute currentAttribute)
     {
         if (role == VisualRole.Normal)

--- a/Terminal.Gui/Views/TextInput/TextField/TextField.cs
+++ b/Terminal.Gui/Views/TextInput/TextField/TextField.cs
@@ -98,7 +98,7 @@ public partial class TextField : View, IDesignable, IValue<string>
 
         ReadOnly = false;
         Autocomplete = new TextFieldAutocomplete ();
-        Height = Dim.Auto (DimAutoStyle.Text, 1);
+        Height = Dim.Auto (DimAutoStyle.Text, minimumContentDim: 1, maximumContentDim: 1);
 
         CanFocus = true;
         Used = true;

--- a/Terminal.Gui/Views/TextInput/TextValidateField.cs
+++ b/Terminal.Gui/Views/TextInput/TextValidateField.cs
@@ -57,7 +57,7 @@ public class TextValidateField : View, IDesignable, IValue<string>
     /// </summary>
     public TextValidateField ()
     {
-        Height = Dim.Auto (minimumContentDim: 1);
+        Height = Dim.Auto (DimAutoStyle.Text, minimumContentDim: 1, maximumContentDim: 1);
         CanFocus = true;
 
         // Things this view knows how to do
@@ -396,6 +396,9 @@ public class TextValidateField : View, IDesignable, IValue<string>
 
         return true;
     }
+
+    /// <inheritdoc/>
+    protected override bool OnDrawingText (DrawContext? context) => true;
 
     /// <inheritdoc/>
     protected override bool OnDrawingContent (DrawContext? context)

--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Drawing.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Drawing.cs
@@ -12,6 +12,9 @@ public partial class TextView
     private bool _isDrawing;
 
     /// <inheritdoc/>
+    protected override bool OnDrawingText (DrawContext? context) => true;
+
+    /// <inheritdoc/>
     protected override bool OnDrawingContent (DrawContext? context)
     {
         _isDrawing = true;
@@ -494,4 +497,3 @@ public partial class TextView
         return GetAttributeForRole (VisualRole.Active);
     }
 }
-

--- a/Tests/UnitTestsParallelizable/Views/CustomTextRendererTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/CustomTextRendererTests.cs
@@ -1,0 +1,77 @@
+using UnitTests;
+
+namespace ViewsTests;
+
+public class CustomTextRendererTests : TestDriverBase
+{
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void ColorPicker_SuppressesGenericTextRendering ()
+    {
+        ColorPicker colorPicker = new () { Width = 32, Height = 5, Value = Color.BrightRed };
+
+        AssertGenericTextRenderingIsSuppressed (colorPicker);
+    }
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void LinearRangeViewBase_SuppressesGenericTextRendering ()
+    {
+        LinearSelector<string> linearSelector = new () { Width = 20, Height = 3, Text = "One,Two,Three" };
+
+        AssertGenericTextRenderingIsSuppressed (linearSelector);
+    }
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void ProgressBar_SuppressesGenericTextRendering ()
+    {
+        ProgressBar progressBar = new () { Width = 10, Height = 3, Fraction = 0.5F };
+
+        AssertGenericTextRenderingIsSuppressed (progressBar);
+    }
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void TextView_SuppressesGenericTextRendering ()
+    {
+        TextView textView = new () { Width = 10, Height = 3, Text = "custom text" };
+
+        AssertGenericTextRenderingIsSuppressed (textView);
+    }
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void Code_SuppressesGenericTextRendering ()
+    {
+        Code code = new () { Width = 10, Height = 3, Language = "cs", Text = "int answer = 42;" };
+
+        AssertGenericTextRenderingIsSuppressed (code);
+    }
+
+    private void AssertGenericTextRenderingIsSuppressed (View view)
+    {
+        using (view)
+        using (IDriver driver = CreateTestDriver (40, 8))
+        {
+            driver.Clip = new (driver.Screen);
+            view.Driver = driver;
+
+            bool drawingTextRaised = false;
+            bool drewTextRaised = false;
+            view.DrawingText += (_, _) => drawingTextRaised = true;
+            view.DrewText += (_, _) => drewTextRaised = true;
+
+            view.BeginInit ();
+            view.EndInit ();
+            view.LayoutSubViews ();
+
+            Assert.NotEmpty (view.Text);
+
+            view.Draw ();
+
+            Assert.False (drawingTextRaised);
+            Assert.False (drewTextRaised);
+        }
+    }
+}

--- a/Tests/UnitTestsParallelizable/Views/TabView/TabsFanOutDiagnosticTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TabView/TabsFanOutDiagnosticTests.cs
@@ -289,12 +289,9 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
         output.WriteLine ($"Sum of inactive DrawingContent:  {inactiveContentDraws}");
         output.WriteLine ($"Sum of inactive DrawingText:     {inactiveTextDraws}");
 
-        // Issue #5358 fix: inactive tabs' NeedsDraw is no longer set as a side-effect
-        // of the parent entering Draw(). DrawingText is the right metric here because
-        // it's gated on NeedsDraw inside DoDrawText — and Code does NOT override
-        // OnDrawingText (unlike OnClearingViewport / OnDrawingContent which Code
-        // intercepts, suppressing those events). DrawComplete fires unconditionally
-        // for clip-exclusion bookkeeping, so it is informational only.
+        // Code owns text rendering, so the generic DrawingText event must not fire
+        // for either the active or inactive tabs.
+        Assert.Equal (0, activeCounts.DrawingText);
         Assert.Equal (0, inactiveTextDraws);
 
         // Issue #5358 fix: the Tabs container itself no longer clears its viewport
@@ -349,28 +346,19 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
         ViewActivityCounters.Counts tabActiveCounts = tabCounters.Get (active);
         output.WriteLine (tabCounters.Report ("Tabbed scenario (5 scrolls of active tab):"));
 
-        int totalTabTextDraws = tabActiveCounts.DrawingText;
         int totalTabLayouts = tabActiveCounts.SubViewsLaidOut;
 
         for (var i = 1; i < TabCount; i++)
         {
-            totalTabTextDraws += tabCounters.Get (codes [i]).DrawingText;
             totalTabLayouts += tabCounters.Get (codes [i]).SubViewsLaidOut;
         }
 
-        double textDrawFanOut = singleCounts.DrawingText == 0 ? double.NaN : (double)totalTabTextDraws / singleCounts.DrawingText;
         double layoutFanOut = singleCounts.SubViewsLaidOut == 0 ? double.NaN : (double)totalTabLayouts / singleCounts.SubViewsLaidOut;
 
-        output.WriteLine ($"Tabbed total text draws / single text draws = {totalTabTextDraws} / {singleCounts.DrawingText} = {textDrawFanOut:F2}");
         output.WriteLine ($"Tabbed total layouts / single layouts       = {totalTabLayouts} / {singleCounts.SubViewsLaidOut} = {layoutFanOut:F2}");
 
-        Assert.True (singleCounts.DrawingText > 0, "Single-Code baseline must record text-draw activity (NeedsDraw-gated).");
-        Assert.True (tabActiveCounts.DrawingText > 0, "Active tab in tabbed scenario must record text-draw activity.");
-
-        // Issue #5358 fix: tabbed text-draw fan-out is now at parity with the single-Code baseline.
-        // DrawingText is gated on NeedsDraw, so it only fires on tabs whose NeedsDraw was set —
-        // which is just the active tab after the fix.
-        Assert.Equal (1.0, textDrawFanOut);
+        Assert.Equal (0, singleCounts.DrawingText);
+        Assert.Equal (0, tabActiveCounts.DrawingText);
 
         Assert.Equal (1.0, layoutFanOut);
 
@@ -417,8 +405,7 @@ public class TabsFanOutDiagnosticTests (ITestOutputHelper output) : TestDriverBa
         {
             ViewActivityCounters.Counts c = counters.Get (codes [i]);
 
-            // Issue #5358 fix: transparent inactive peers also stay out of NeedsDraw-gated work.
-            // DrawingText is the right per-Code metric (Code intercepts ClearedViewport / DrawingContent).
+            // Code suppresses the generic text pass regardless of transparency.
             Assert.Equal (0, c.DrawingText);
         }
 

--- a/Tests/UnitTestsParallelizable/Views/TextFieldDrawingTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldDrawingTests.cs
@@ -15,7 +15,7 @@ public class TextFieldDrawingTests : TestDriverBase
         app.Init (DriverRegistry.Names.ANSI);
         app.Driver!.SetScreenSize (30, 5);
 
-        Runnable runnable = new () { Width = 30, Height = 5 };
+        using Runnable runnable = new () { Width = 30, Height = 5 };
         TextField textField = new ()
         {
             Width = 30,
@@ -24,11 +24,19 @@ public class TextFieldDrawingTests : TestDriverBase
         };
 
         runnable.Add (textField);
-        app.Begin (runnable);
-        app.LayoutAndDraw ();
+        SessionToken token = app.Begin (runnable)!;
 
-        Assert.Equal (1, textField.Viewport.Height);
-        Assert.Equal (3, textField.Frame.Height);
+        try
+        {
+            app.LayoutAndDraw ();
+
+            Assert.Equal (1, textField.Viewport.Height);
+            Assert.Equal (3, textField.Frame.Height);
+        }
+        finally
+        {
+            app.End (token);
+        }
     }
 
     // CoPilot - GPT-5.6
@@ -39,15 +47,23 @@ public class TextFieldDrawingTests : TestDriverBase
         app.Init (DriverRegistry.Names.ANSI);
         app.Driver!.SetScreenSize (30, 3);
 
-        Runnable runnable = new () { Width = 30, Height = 3 };
+        using Runnable runnable = new () { Width = 30, Height = 3 };
         TextField textField = new () { Width = 30, Text = LongText };
         Label nextRow = new () { Y = 1, Text = "NEXT ROW" };
 
         runnable.Add (textField, nextRow);
-        app.Begin (runnable);
-        app.LayoutAndDraw ();
+        SessionToken token = app.Begin (runnable)!;
 
-        Assert.Equal ("NEXT ROW", GetRow (app.Driver, 1, 30).TrimEnd ());
+        try
+        {
+            app.LayoutAndDraw ();
+
+            Assert.Equal ("NEXT ROW", GetRow (app.Driver, 1, 30).TrimEnd ());
+        }
+        finally
+        {
+            app.End (token);
+        }
     }
 
     // CoPilot - GPT-5.6
@@ -58,15 +74,23 @@ public class TextFieldDrawingTests : TestDriverBase
         app.Init (DriverRegistry.Names.ANSI);
         app.Driver!.SetScreenSize (5, 3);
 
-        Runnable runnable = new () { Width = 5, Height = 3 };
+        using Runnable runnable = new () { Width = 5, Height = 3 };
         TextField textField = new () { Width = 5, Height = 3, Text = "abcdefghij" };
 
         runnable.Add (textField);
-        app.Begin (runnable);
-        app.LayoutAndDraw ();
+        SessionToken token = app.Begin (runnable)!;
 
-        Assert.Empty (GetRow (app.Driver, 1, 5).TrimEnd ());
-        Assert.Empty (GetRow (app.Driver, 2, 5).TrimEnd ());
+        try
+        {
+            app.LayoutAndDraw ();
+
+            Assert.Empty (GetRow (app.Driver, 1, 5).TrimEnd ());
+            Assert.Empty (GetRow (app.Driver, 2, 5).TrimEnd ());
+        }
+        finally
+        {
+            app.End (token);
+        }
     }
 
     private static string GetRow (IDriver driver, int row, int width)

--- a/Tests/UnitTestsParallelizable/Views/TextFieldDrawingTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextFieldDrawingTests.cs
@@ -1,0 +1,83 @@
+using System.Text;
+using UnitTests;
+
+namespace ViewsTests;
+
+public class TextFieldDrawingTests : TestDriverBase
+{
+    private const string LongText = "C/W Liners, Fabrics, Pipe Connections, 150mm Dia Perf Drain Pipe, Drain Works";
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void DefaultHeight_LongText_HasOneRowOfContent ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (30, 5);
+
+        Runnable runnable = new () { Width = 30, Height = 5 };
+        TextField textField = new ()
+        {
+            Width = 30,
+            Text = LongText,
+            BorderStyle = LineStyle.Single
+        };
+
+        runnable.Add (textField);
+        app.Begin (runnable);
+        app.LayoutAndDraw ();
+
+        Assert.Equal (1, textField.Viewport.Height);
+        Assert.Equal (3, textField.Frame.Height);
+    }
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void LongText_DoesNotOverdrawFollowingView ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (30, 3);
+
+        Runnable runnable = new () { Width = 30, Height = 3 };
+        TextField textField = new () { Width = 30, Text = LongText };
+        Label nextRow = new () { Y = 1, Text = "NEXT ROW" };
+
+        runnable.Add (textField, nextRow);
+        app.Begin (runnable);
+        app.LayoutAndDraw ();
+
+        Assert.Equal ("NEXT ROW", GetRow (app.Driver, 1, 30).TrimEnd ());
+    }
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void ExplicitHeight_DoesNotDrawWrappedBaseText ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (5, 3);
+
+        Runnable runnable = new () { Width = 5, Height = 3 };
+        TextField textField = new () { Width = 5, Height = 3, Text = "abcdefghij" };
+
+        runnable.Add (textField);
+        app.Begin (runnable);
+        app.LayoutAndDraw ();
+
+        Assert.Empty (GetRow (app.Driver, 1, 5).TrimEnd ());
+        Assert.Empty (GetRow (app.Driver, 2, 5).TrimEnd ());
+    }
+
+    private static string GetRow (IDriver driver, int row, int width)
+    {
+        StringBuilder builder = new ();
+
+        for (int column = 0; column < width; column++)
+        {
+            builder.Append (driver.Contents! [row, column]!.Grapheme);
+        }
+
+        return builder.ToString ();
+    }
+}

--- a/Tests/UnitTestsParallelizable/Views/TextValidateFieldDrawingTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextValidateFieldDrawingTests.cs
@@ -18,14 +18,22 @@ public class TextValidateFieldDrawingTests : TestDriverBase
         TextRegexProvider provider = new (".*") { Text = LongText, ValidateOnInput = false };
         TextValidateField field = new () { Width = 20, Provider = provider };
         Label nextRow = new () { Y = 1, Text = "NEXT ROW" };
-        Runnable runnable = new () { Width = 20, Height = 3 };
+        using Runnable runnable = new () { Width = 20, Height = 3 };
 
         runnable.Add (field, nextRow);
-        app.Begin (runnable);
-        app.LayoutAndDraw ();
+        SessionToken token = app.Begin (runnable)!;
 
-        Assert.Equal (1, field.Viewport.Height);
-        Assert.Equal ("NEXT ROW", GetRow (app.Driver, 1, 20).TrimEnd ());
+        try
+        {
+            app.LayoutAndDraw ();
+
+            Assert.Equal (1, field.Viewport.Height);
+            Assert.Equal ("NEXT ROW", GetRow (app.Driver, 1, 20).TrimEnd ());
+        }
+        finally
+        {
+            app.End (token);
+        }
     }
 
     // CoPilot - GPT-5.6
@@ -38,14 +46,22 @@ public class TextValidateFieldDrawingTests : TestDriverBase
 
         TextRegexProvider provider = new (".*") { Text = LongText, ValidateOnInput = false };
         TextValidateField field = new () { Width = 5, Height = 3, Provider = provider };
-        Runnable runnable = new () { Width = 5, Height = 3 };
+        using Runnable runnable = new () { Width = 5, Height = 3 };
 
         runnable.Add (field);
-        app.Begin (runnable);
-        app.LayoutAndDraw ();
+        SessionToken token = app.Begin (runnable)!;
 
-        Assert.Empty (GetRow (app.Driver, 1, 5).TrimEnd ());
-        Assert.Empty (GetRow (app.Driver, 2, 5).TrimEnd ());
+        try
+        {
+            app.LayoutAndDraw ();
+
+            Assert.Empty (GetRow (app.Driver, 1, 5).TrimEnd ());
+            Assert.Empty (GetRow (app.Driver, 2, 5).TrimEnd ());
+        }
+        finally
+        {
+            app.End (token);
+        }
     }
 
     private static string GetRow (IDriver driver, int row, int width)

--- a/Tests/UnitTestsParallelizable/Views/TextValidateFieldDrawingTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/TextValidateFieldDrawingTests.cs
@@ -1,0 +1,62 @@
+using System.Text;
+using UnitTests;
+
+namespace ViewsTests;
+
+public class TextValidateFieldDrawingTests : TestDriverBase
+{
+    private const string LongText = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void DefaultHeight_LongText_HasOneRowAndDoesNotOverdrawFollowingView ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (20, 3);
+
+        TextRegexProvider provider = new (".*") { Text = LongText, ValidateOnInput = false };
+        TextValidateField field = new () { Width = 20, Provider = provider };
+        Label nextRow = new () { Y = 1, Text = "NEXT ROW" };
+        Runnable runnable = new () { Width = 20, Height = 3 };
+
+        runnable.Add (field, nextRow);
+        app.Begin (runnable);
+        app.LayoutAndDraw ();
+
+        Assert.Equal (1, field.Viewport.Height);
+        Assert.Equal ("NEXT ROW", GetRow (app.Driver, 1, 20).TrimEnd ());
+    }
+
+    // CoPilot - GPT-5.6
+    [Fact]
+    public void ExplicitHeight_DoesNotDrawWrappedBaseText ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (5, 3);
+
+        TextRegexProvider provider = new (".*") { Text = LongText, ValidateOnInput = false };
+        TextValidateField field = new () { Width = 5, Height = 3, Provider = provider };
+        Runnable runnable = new () { Width = 5, Height = 3 };
+
+        runnable.Add (field);
+        app.Begin (runnable);
+        app.LayoutAndDraw ();
+
+        Assert.Empty (GetRow (app.Driver, 1, 5).TrimEnd ());
+        Assert.Empty (GetRow (app.Driver, 2, 5).TrimEnd ());
+    }
+
+    private static string GetRow (IDriver driver, int row, int width)
+    {
+        StringBuilder builder = new ();
+
+        for (int column = 0; column < width; column++)
+        {
+            builder.Append (driver.Contents! [row, column]!.Grapheme);
+        }
+
+        return builder.ToString ();
+    }
+}


### PR DESCRIPTION
## Summary

Keep single-line text inputs at one content row and prevent views with custom renderers from also running the generic `View.Text` renderer.

- Fixes #5640
- Fixes #5637

## Changes

- Clamp the default auto-height of `TextField` and `TextValidateField` to one content row.
- Suppress generic text drawing in `TextField`, `TextValidateField`, `ColorPicker`, `LinearRangeViewBase`, `ProgressBar`, `TextView`, and `Code`.
- Add parallel regression tests for long text, following-view overdraw, explicit heights, and custom-renderer suppression.
- Update the `Code` tab fan-out diagnostics now that `DrawingText` is intentionally suppressed.

## Testing

- `dotnet build --no-restore`
  - Succeeded with no errors or new warnings.
- Affected-view and regression suites
  - 412 tests passed.
- `Tests/UnitTests.NonParallelizable`
  - 72 passed, 2 skipped.
- Full parallelizable suite
  - 17,582 passed, 17 skipped.
  - Four known baseline ANSI-output failures remain: three color-derivation assertions and one border-clipping output assertion.

## To pull down this PR locally:

```bash
git remote add copilot https://github.com/YourRobotOverlord/Terminal.Gui.git
git fetch copilot fix/textfield-long-text-overdraw
git checkout copilot/fix/textfield-long-text-overdraw
```