### PR TITLE
Fixes #5638. Scope ANSI key deduplication

### DIFF
--- a/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
@@ -222,11 +222,6 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
                                           {
                                               if (!result.IsSupported)
                                               {
-                                                  if (_inputProcessor is AnsiInputProcessor unsupportedAnsiInputProcessor)
-                                                  {
-                                                      unsupportedAnsiInputProcessor.SetKittyKeyboardEnabled (false);
-                                                  }
-
                                                   Trace.Lifecycle (app?.MainThreadId?.ToString (), "KittyKeyboard", "Kitty keyboard mode not enabled");
 
                                                   return;
@@ -234,12 +229,6 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
 
                                               // Kitty is supported. Store the capabilities and set the flags we care about.
                                               _driver?.SetKittyKeyboardCapabilities (result);
-
-                                              if (_inputProcessor is AnsiInputProcessor supportedAnsiInputProcessor)
-                                              {
-                                                  supportedAnsiInputProcessor.SetKittyKeyboardEnabled (true);
-                                              }
-
                                               kittyKeyboardDetector.Enable (EscSeqUtils.KittyKeyboardRequestedFlags);
 
                                               Trace.Lifecycle (app?.MainThreadId?.ToString (),

--- a/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopCoordinator.cs
@@ -222,6 +222,11 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
                                           {
                                               if (!result.IsSupported)
                                               {
+                                                  if (_inputProcessor is AnsiInputProcessor unsupportedAnsiInputProcessor)
+                                                  {
+                                                      unsupportedAnsiInputProcessor.SetKittyKeyboardEnabled (false);
+                                                  }
+
                                                   Trace.Lifecycle (app?.MainThreadId?.ToString (), "KittyKeyboard", "Kitty keyboard mode not enabled");
 
                                                   return;
@@ -229,6 +234,12 @@ internal class MainLoopCoordinator<TInputRecord> : IMainLoopCoordinator where TI
 
                                               // Kitty is supported. Store the capabilities and set the flags we care about.
                                               _driver?.SetKittyKeyboardCapabilities (result);
+
+                                              if (_inputProcessor is AnsiInputProcessor supportedAnsiInputProcessor)
+                                              {
+                                                  supportedAnsiInputProcessor.SetKittyKeyboardEnabled (true);
+                                              }
+
                                               kittyKeyboardDetector.Enable (EscSeqUtils.KittyKeyboardRequestedFlags);
 
                                               Trace.Lifecycle (app?.MainThreadId?.ToString (),

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
@@ -39,9 +39,8 @@ namespace Terminal.Gui.Drivers;
 /// </summary>
 public class AnsiInputProcessor : InputProcessorImpl<char>
 {
-    private static readonly TimeSpan PrintableSuppressionTimeout = TimeSpan.FromMilliseconds (50);
-    private string _pendingParsedPrintableSuppression = string.Empty;
-    private DateTime _pendingParsedPrintableSuppressionExpiresAt;
+    private bool _isKittyKeyboardEnabled;
+    private string _pendingPrintableSuppression = string.Empty;
 
     /// <inheritdoc/>
     /// <param name="inputBuffer">The input buffer to process.</param>
@@ -63,12 +62,9 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     /// <inheritdoc/>
     protected override Key OnKeyboardEventParsed (Key keyEvent)
     {
-        _pendingParsedPrintableSuppression = string.Empty;
+        _pendingPrintableSuppression = string.Empty;
 
-        if (keyEvent.EventType != KeyEventType.Press
-            || keyEvent.IsAlt
-            || keyEvent.IsCtrl
-            || keyEvent.IsModifierOnly)
+        if (keyEvent.EventType != KeyEventType.Press || keyEvent.IsAlt || keyEvent.IsCtrl || keyEvent.IsModifierOnly)
         {
             return keyEvent;
         }
@@ -77,8 +73,7 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
 
         if (!string.IsNullOrEmpty (printableText))
         {
-            _pendingParsedPrintableSuppression = printableText;
-            _pendingParsedPrintableSuppressionExpiresAt = CurrentTime + PrintableSuppressionTimeout;
+            _pendingPrintableSuppression = printableText;
         }
 
         return keyEvent;
@@ -87,18 +82,29 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     /// <inheritdoc/>
     protected override bool ShouldSuppressFallbackKeyDown (Key key)
     {
-        string parsedPrintableText = _pendingParsedPrintableSuppression;
-        _pendingParsedPrintableSuppression = string.Empty;
-
-        if (string.IsNullOrEmpty (parsedPrintableText)
-            || CurrentTime > _pendingParsedPrintableSuppressionExpiresAt)
+        if (string.IsNullOrEmpty (_pendingPrintableSuppression))
         {
+            if (_isKittyKeyboardEnabled)
+            {
+                string fallbackPrintableText = key.GetPrintableText ();
+
+                if (!string.IsNullOrEmpty (fallbackPrintableText))
+                {
+                    _pendingPrintableSuppression = fallbackPrintableText;
+                }
+            }
+
             return false;
         }
 
         string printableText = key.GetPrintableText ();
-        return string.Equals (printableText, parsedPrintableText, StringComparison.Ordinal);
+        bool suppress = string.Equals (printableText, _pendingPrintableSuppression, StringComparison.Ordinal);
+        _pendingPrintableSuppression = string.Empty;
+
+        return suppress;
     }
+
+    internal void SetKittyKeyboardEnabled (bool enabled) => _isKittyKeyboardEnabled = enabled;
 
     /// <inheritdoc/>
     public override void InjectKeyDownEvent (Key key)

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
@@ -39,8 +39,9 @@ namespace Terminal.Gui.Drivers;
 /// </summary>
 public class AnsiInputProcessor : InputProcessorImpl<char>
 {
-    private bool _isKittyKeyboardEnabled;
-    private string _pendingPrintableSuppression = string.Empty;
+    private long _inputPosition;
+    private string _pendingKittyPrintableSuppression = string.Empty;
+    private long _pendingKittyPrintableSuppressionStartPosition;
 
     /// <inheritdoc/>
     /// <param name="inputBuffer">The input buffer to process.</param>
@@ -53,6 +54,9 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     /// <inheritdoc/>
     protected override void Process (char input)
     {
+        _inputPosition++;
+        InvalidatePendingKittyPrintableSuppression (input);
+
         foreach (Tuple<char, char> released in Parser.ProcessInput (Tuple.Create (input, input)))
         {
             ProcessAfterParsing (released.Item2);
@@ -60,11 +64,16 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     }
 
     /// <inheritdoc/>
-    protected override Key OnKeyboardEventParsed (Key keyEvent)
+    private protected override Key OnKeyboardEventParsed (AnsiKeyboardParserPattern pattern, Key keyEvent)
     {
-        _pendingPrintableSuppression = string.Empty;
+        keyEvent = base.OnKeyboardEventParsed (pattern, keyEvent);
+        ClearPendingKittyPrintableSuppression ();
 
-        if (keyEvent.EventType != KeyEventType.Press || keyEvent.IsAlt || keyEvent.IsCtrl || keyEvent.IsModifierOnly)
+        if (pattern is not KittyKeyboardPattern
+            || keyEvent.EventType != KeyEventType.Press
+            || keyEvent.IsAlt
+            || keyEvent.IsCtrl
+            || keyEvent.IsModifierOnly)
         {
             return keyEvent;
         }
@@ -73,7 +82,8 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
 
         if (!string.IsNullOrEmpty (printableText))
         {
-            _pendingPrintableSuppression = printableText;
+            _pendingKittyPrintableSuppression = printableText;
+            _pendingKittyPrintableSuppressionStartPosition = _inputPosition + 1;
         }
 
         return keyEvent;
@@ -82,29 +92,46 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     /// <inheritdoc/>
     protected override bool ShouldSuppressFallbackKeyDown (Key key)
     {
-        if (string.IsNullOrEmpty (_pendingPrintableSuppression))
+        string printableText = key.GetPrintableText ();
+        string pendingPrintableText = _pendingKittyPrintableSuppression;
+        long pendingStartPosition = _pendingKittyPrintableSuppressionStartPosition;
+        ClearPendingKittyPrintableSuppression ();
+
+        if (string.IsNullOrEmpty (pendingPrintableText))
         {
-            if (_isKittyKeyboardEnabled)
-            {
-                string fallbackPrintableText = key.GetPrintableText ();
-
-                if (!string.IsNullOrEmpty (fallbackPrintableText))
-                {
-                    _pendingPrintableSuppression = fallbackPrintableText;
-                }
-            }
-
             return false;
         }
 
-        string printableText = key.GetPrintableText ();
-        bool suppress = string.Equals (printableText, _pendingPrintableSuppression, StringComparison.Ordinal);
-        _pendingPrintableSuppression = string.Empty;
+        long expectedLastPosition = pendingStartPosition + pendingPrintableText.Length - 1;
 
-        return suppress;
+        return _inputPosition == expectedLastPosition
+               && string.Equals (printableText, pendingPrintableText, StringComparison.Ordinal);
     }
 
-    internal void SetKittyKeyboardEnabled (bool enabled) => _isKittyKeyboardEnabled = enabled;
+    private void InvalidatePendingKittyPrintableSuppression (char input)
+    {
+        if (string.IsNullOrEmpty (_pendingKittyPrintableSuppression))
+        {
+            return;
+        }
+
+        long offset = _inputPosition - _pendingKittyPrintableSuppressionStartPosition;
+
+        if (offset >= 0
+            && offset < _pendingKittyPrintableSuppression.Length
+            && input == _pendingKittyPrintableSuppression [(int)offset])
+        {
+            return;
+        }
+
+        ClearPendingKittyPrintableSuppression ();
+    }
+
+    private void ClearPendingKittyPrintableSuppression ()
+    {
+        _pendingKittyPrintableSuppression = string.Empty;
+        _pendingKittyPrintableSuppressionStartPosition = 0;
+    }
 
     /// <inheritdoc/>
     public override void InjectKeyDownEvent (Key key)

--- a/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
@@ -684,6 +684,11 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
     public event EventHandler<Key>? Keyboard;
 
     /// <summary>
+    ///     Raised with the parser pattern that recognized a keyboard escape sequence.
+    /// </summary>
+    internal event Action<AnsiKeyboardParserPattern, Key>? KeyboardPatternMatched;
+
+    /// <summary>
     ///     Gets or sets whether to explicitly handle keyboard escape sequences by raising the <see cref="Keyboard"/> event.
     /// </summary>
     /// <remarks>
@@ -702,6 +707,7 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
         }
         else
         {
+            KeyboardPatternMatched?.Invoke (pattern, k);
             Keyboard?.Invoke (this, k);
         }
     }

--- a/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
+++ b/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
@@ -78,19 +78,19 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
 
         Parser.Paste += (_, text) => RaisePasteEvent (text);
 
-        Parser.Keyboard += (_, keyEvent) =>
-                           {
-                               Key normalizedKeyEvent = OnKeyboardEventParsed (keyEvent);
+        Parser.KeyboardPatternMatched += (pattern, keyEvent) =>
+                                         {
+                                             Key normalizedKeyEvent = OnKeyboardEventParsed (pattern, keyEvent);
 
-                               if (normalizedKeyEvent.EventType == KeyEventType.Release)
-                               {
-                                   RaiseKeyUpEvent (normalizedKeyEvent);
-                               }
-                               else
-                               {
-                                   RaiseKeyDownEvent (normalizedKeyEvent);
-                               }
-                           };
+                                             if (normalizedKeyEvent.EventType == KeyEventType.Release)
+                                             {
+                                                 RaiseKeyUpEvent (normalizedKeyEvent);
+                                             }
+                                             else
+                                             {
+                                                 RaiseKeyDownEvent (normalizedKeyEvent);
+                                             }
+                                         };
 
         // Configure unexpected response handler
         Parser.UnexpectedResponseHandler = str =>
@@ -221,6 +221,15 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
     /// <param name="keyEvent">The parsed key event.</param>
     /// <returns>The key event to forward.</returns>
     protected virtual Key OnKeyboardEventParsed (Key keyEvent) => keyEvent;
+
+    /// <summary>
+    ///     Called when the ANSI parser raises a keyboard event before it is forwarded to <see cref="KeyDown"/> or
+    ///     <see cref="KeyUp"/> subscribers.
+    /// </summary>
+    /// <param name="pattern">The parser pattern that recognized the input.</param>
+    /// <param name="keyEvent">The parsed key event.</param>
+    /// <returns>The key event to forward.</returns>
+    private protected virtual Key OnKeyboardEventParsed (AnsiKeyboardParserPattern pattern, Key keyEvent) => OnKeyboardEventParsed (keyEvent);
 
     /// <summary>
     ///     Gives derived processors a chance to suppress keydown events that come from fallback stream processing

--- a/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
+++ b/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
@@ -33,9 +33,6 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
     private readonly ITimeProvider _timeProvider;
     private readonly MouseInterpreter _mouseInterpreter;
 
-    /// <summary>Gets the current pipeline time.</summary>
-    protected DateTime CurrentTime => _timeProvider.Now;
-
     /// <summary>
     ///     Thread-safe input queue populated by <see cref="IInput{TInputRecord}"/> on the input thread.
     ///     Dequeued by <see cref="ProcessQueue"/> on the main loop thread.

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -15,15 +15,15 @@ public class KittyKeyboardPipelineTests
     /// </summary>
     private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequence (params string [] sequences)
     {
-        return InjectRawSequenceCore (TimeSpan.Zero, sequences);
+        return InjectRawSequenceCore (false, sequences);
     }
 
-    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceWithDelay (TimeSpan delay, params string [] sequences)
+    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceWithKittyEnabled (params string [] sequences)
     {
-        return InjectRawSequenceCore (delay, sequences);
+        return InjectRawSequenceCore (true, sequences);
     }
 
-    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceCore (TimeSpan delay, params string [] sequences)
+    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceCore (bool kittyKeyboardEnabled, params string [] sequences)
     {
         VirtualTimeProvider timeProvider = new ();
         timeProvider.SetTime (new DateTime (2025, 1, 1, 12, 0, 0));
@@ -37,23 +37,17 @@ public class KittyKeyboardPipelineTests
         app.Keyboard.KeyUp += (_, key) => keyUpEvents.Add (key);
 
         IInputProcessor processor = app.Driver?.GetInputProcessor ()!;
+        ((AnsiInputProcessor)processor).SetKittyKeyboardEnabled (kittyKeyboardEnabled);
         ConcurrentQueue<char> queue = ((AnsiInputProcessor)processor).InputQueue;
 
-        for (var sequenceIndex = 0; sequenceIndex < sequences.Length; sequenceIndex++)
+        foreach (string seq in sequences)
         {
-            string seq = sequences [sequenceIndex];
-
             foreach (char ch in seq)
             {
                 queue.Enqueue (ch);
             }
 
             processor.ProcessQueue ();
-
-            if (sequenceIndex < sequences.Length - 1)
-            {
-                timeProvider.Advance (delay);
-            }
         }
 
         return (keyDownEvents, keyUpEvents);
@@ -221,9 +215,9 @@ public class KittyKeyboardPipelineTests
 
     #endregion
 
-    #region Kitty + Legacy Input
+    #region Mixed Kitty + Legacy Duplicate Input
 
-    // Codex - GPT-5 Codex
+    // Copilot
     [Fact]
     public void Pipeline_MixedKittyAndLegacyPrintable_DoesNotRaiseDuplicateKeyDown ()
     {
@@ -236,29 +230,27 @@ public class KittyKeyboardPipelineTests
         Assert.Empty (up);
     }
 
-    // Codex - GPT-5 Codex
-    [Fact]
-    public void Pipeline_MixedKittyAndLegacyPrintable_AfterSuppressionTimeout_RaisesBothKeyDowns ()
+    // Copilot
+    [Theory]
+    [InlineData ("«")]
+    [InlineData ("»")]
+    [InlineData ("ç")]
+    [InlineData ("Ç")]
+    [InlineData ("º")]
+    [InlineData ("ª")]
+    public void Pipeline_LegacyPrintable_PortugueseKeys_WhenKittyEnabled_DoesNotRaiseDuplicateKeyDown (string printable)
     {
-        (List<Key> down, List<Key> up) = InjectRawSequenceWithDelay (TimeSpan.FromMilliseconds (51), "\x1b[97u", "a");
+        // Issue #4918 (PT keyboard): some glyphs may still arrive as duplicated legacy printable input
+        // even when kitty is enabled. A single keypress should still produce one KeyDown.
+        string duplicatedInput = printable + printable;
+        (List<Key> down, List<Key> up) = InjectRawSequenceWithKittyEnabled (duplicatedInput);
 
-        Assert.Equal (2, down.Count);
-        Assert.All (down, key => Assert.Equal (Key.A, key));
+        Assert.Single (down);
+        Assert.Equal (printable, down [0].GetPrintableText ());
         Assert.Empty (up);
     }
 
-    // Codex - GPT-5 Codex
-    [Fact]
-    public void Pipeline_RepeatedLegacyPrintableInput_DoesNotSelfArmSuppression ()
-    {
-        (List<Key> down, List<Key> up) = InjectRawSequence ("jjjj");
-
-        Assert.Equal (4, down.Count);
-        Assert.Equal ("jjjj", string.Concat (down.Select (key => key.GetPrintableText ())));
-        Assert.Empty (up);
-    }
-
-    // Codex - GPT-5 Codex
+    // Copilot
     [Fact]
     public void Pipeline_MixedKittyAssociatedTextAndLegacyPrintable_DoesNotRaiseDuplicateKeyDown ()
     {

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -15,16 +15,6 @@ public class KittyKeyboardPipelineTests
     /// </summary>
     private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequence (params string [] sequences)
     {
-        return InjectRawSequenceCore (false, sequences);
-    }
-
-    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceWithKittyEnabled (params string [] sequences)
-    {
-        return InjectRawSequenceCore (true, sequences);
-    }
-
-    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceCore (bool kittyKeyboardEnabled, params string [] sequences)
-    {
         VirtualTimeProvider timeProvider = new ();
         timeProvider.SetTime (new DateTime (2025, 1, 1, 12, 0, 0));
 
@@ -37,7 +27,6 @@ public class KittyKeyboardPipelineTests
         app.Keyboard.KeyUp += (_, key) => keyUpEvents.Add (key);
 
         IInputProcessor processor = app.Driver?.GetInputProcessor ()!;
-        ((AnsiInputProcessor)processor).SetKittyKeyboardEnabled (kittyKeyboardEnabled);
         ConcurrentQueue<char> queue = ((AnsiInputProcessor)processor).InputQueue;
 
         foreach (string seq in sequences)
@@ -51,6 +40,12 @@ public class KittyKeyboardPipelineTests
         }
 
         return (keyDownEvents, keyUpEvents);
+    }
+
+    private static (List<Key> KeyDown, List<Key> KeyUp) InjectRawSequenceByCharacter (string sequence)
+    {
+        string [] characters = sequence.Select (character => character.ToString ()).ToArray ();
+        return InjectRawSequence (characters);
     }
 
     #region CSI u Event Types
@@ -223,30 +218,30 @@ public class KittyKeyboardPipelineTests
     {
         // Reproduces terminals that emit kitty CSI-u and a legacy printable char for the same keypress.
         // Expected behavior: a single logical key event should be raised.
-        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[97u", "a");
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[97ua");
 
         Assert.Single (down);
         Assert.Equal (Key.A, down [0]);
         Assert.Empty (up);
     }
 
-    // Copilot
-    [Theory]
-    [InlineData ("«")]
-    [InlineData ("»")]
-    [InlineData ("ç")]
-    [InlineData ("Ç")]
-    [InlineData ("º")]
-    [InlineData ("ª")]
-    public void Pipeline_LegacyPrintable_PortugueseKeys_WhenKittyEnabled_DoesNotRaiseDuplicateKeyDown (string printable)
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_MixedKittyAndLegacyPrintable_AcrossProcessingDrains_DoesNotRaiseDuplicateKeyDown ()
     {
-        // Issue #4918 (PT keyboard): some glyphs may still arrive as duplicated legacy printable input
-        // even when kitty is enabled. A single keypress should still produce one KeyDown.
-        string duplicatedInput = printable + printable;
-        (List<Key> down, List<Key> up) = InjectRawSequenceWithKittyEnabled (duplicatedInput);
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[97u", "a");
 
-        Assert.Single (down);
-        Assert.Equal (printable, down [0].GetPrintableText ());
+        Assert.Equal ([Key.A], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_MixedKittyAndLegacyPrintable_OneCharacterPerProcessingDrain_DoesNotRaiseDuplicateKeyDown ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequenceByCharacter ("\x1b[97ua");
+
+        Assert.Equal ([Key.A], down);
         Assert.Empty (up);
     }
 
@@ -256,10 +251,74 @@ public class KittyKeyboardPipelineTests
     {
         // Reproduces terminals that emit a kitty key event with associated text plus a legacy char.
         // ESC[49;2;33u = shifted '1' producing associated text '!'
-        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[49;2;33u", "!");
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[49;2;33u!");
 
         Assert.Single (down);
         Assert.Equal ("!", down [0].GetPrintableText ());
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_LegacyShiftTabFollowedByTab_RaisesBothKeyDowns ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[Z\t");
+
+        Assert.Equal ([Key.Tab.WithShift, Key.Tab], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_KittyTabAndLegacyTab_DoesNotRaiseDuplicateKeyDown ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[9u\t");
+
+        Assert.Equal ([Key.Tab], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_KittyPrintable_InterveningRawKey_PreservesLaterMatchingFallbackKey ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[97uba");
+
+        Assert.Equal ([Key.A, Key.B, Key.A], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_KittyPrintable_InterveningParsedKey_PreservesLaterMatchingFallbackKey ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[97u\x1b[Aa");
+
+        Assert.Equal ([Key.A, Key.CursorUp, Key.A], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Theory]
+    [InlineData ("\x1b[<0;10;20M")]
+    [InlineData ("\x1b[?1;2c")]
+    [InlineData ("\x1b[<1;2z")]
+    public void Pipeline_KittyPrintable_InterveningAnsiInput_PreservesLaterMatchingFallbackKey (string interveningInput)
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ($"\x1b[97u{interveningInput}a");
+
+        Assert.Equal ([Key.A, Key.A], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_KittyAndLegacySurrogatePair_OneCharacterPerProcessingDrain_DoesNotRaiseDuplicateKeyDown ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequenceByCharacter ("\x1b[128512u😀");
+
+        Assert.Single (down);
+        Assert.Equal (0x1f600, down [0].AsRune.Value);
         Assert.Empty (up);
     }
 
@@ -289,6 +348,22 @@ public class KittyKeyboardPipelineTests
         Assert.Equal (12, down.Count);
         Assert.Equal ("111222333444", string.Concat (down.Select (key => key.GetPrintableText ())));
         Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Theory]
+    [InlineData ("jjjj")]
+    [InlineData ("aaaa")]
+    [InlineData ("çç")]
+    public void Pipeline_RepeatedLegacyPrintableInput_PreservesEveryCharacterRegardlessOfChunking (string input)
+    {
+        (List<Key> wholeDown, List<Key> wholeUp) = InjectRawSequence (input);
+        (List<Key> chunkedDown, List<Key> chunkedUp) = InjectRawSequenceByCharacter (input);
+
+        Assert.Equal (input, string.Concat (wholeDown.Select (key => key.GetPrintableText ())));
+        Assert.Equal (input, string.Concat (chunkedDown.Select (key => key.GetPrintableText ())));
+        Assert.Empty (wholeUp);
+        Assert.Empty (chunkedUp);
     }
 
     // Copilot


### PR DESCRIPTION
## Summary

Revert the timing-based printable suppression from #5618 and replace it with strict stream-adjacent kitty/legacy deduplication that preserves fallback input losslessly.

- Fixes #5638

## Changes

- preserve the ANSI parser pattern that recognized each parsed key event
- arm suppression only for printable press events recognized by `KittyKeyboardPattern`, so legacy `ESC[Z` Shift+Tab cannot suppress a following Tab
- track raw UTF-16 input position and suppress only an identical legacy fallback that begins immediately after its kitty sequence
- support a UTF-16 surrogate pair as one adjacent fallback key
- invalidate the candidate on the first different raw key, parsed sequence, mouse/response bytes, malformed sequence, or other intervening input
- keep the rule identical across one queue drain, separate drains, and one character per drain
- remove fallback-only raw/raw suppression, kitty capability plumbing, queue-drain semantics, and the 50 ms timeout

The ANSI `ConcurrentQueue<char>` has no physical-key identity, so fallback-only repeated characters are always delivered literally. #4918 remains open for a future terminal/source-level provenance solution.

## Testing

- `dotnet build --configuration Debug --no-restore` — succeeded with 0 warnings and 0 errors
- `KittyKeyboardPipelineTests` — 111 passed
- `AnsiKeyboardParserTests` — 103 passed
- `AnsiResponseParserTests` — 59 passed
- `InputProcessorImplTests` — 31 passed, 1 pre-existing skip
- `AnsiInputOutputTests` — 7 passed
- `AnsiInputTestableTests` — 38 passed
- full parallelizable suite — 17,587 passed, 17 pre-existing skips
- non-parallelizable suite — 72 passed, 2 pre-existing skips
- integration suite — 437 passed

## To pull down this PR locally:

```bash
git remote add yourrobotoverlord https://github.com/YourRobotOverlord/Terminal.Gui.git
git fetch yourrobotoverlord fix/5638-revert-5618-reimpl-dedup
git checkout yourrobotoverlord/fix/5638-revert-5618-reimpl-dedup
```