### PR TITLE
Fixes #5638. Scope ANSI key deduplication

### DIFF
--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
@@ -39,7 +39,9 @@ namespace Terminal.Gui.Drivers;
 /// </summary>
 public class AnsiInputProcessor : InputProcessorImpl<char>
 {
+    private long _inputPosition;
     private string _pendingKittyPrintableSuppression = string.Empty;
+    private long _pendingKittyPrintableSuppressionStartPosition;
 
     /// <inheritdoc/>
     /// <param name="inputBuffer">The input buffer to process.</param>
@@ -52,6 +54,9 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     /// <inheritdoc/>
     protected override void Process (char input)
     {
+        _inputPosition++;
+        InvalidatePendingKittyPrintableSuppression (input);
+
         foreach (Tuple<char, char> released in Parser.ProcessInput (Tuple.Create (input, input)))
         {
             ProcessAfterParsing (released.Item2);
@@ -62,7 +67,7 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     private protected override Key OnKeyboardEventParsed (AnsiKeyboardParserPattern pattern, Key keyEvent)
     {
         keyEvent = base.OnKeyboardEventParsed (pattern, keyEvent);
-        _pendingKittyPrintableSuppression = string.Empty;
+        ClearPendingKittyPrintableSuppression ();
 
         if (pattern is not KittyKeyboardPattern
             || keyEvent.EventType != KeyEventType.Press
@@ -78,6 +83,7 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
         if (!string.IsNullOrEmpty (printableText))
         {
             _pendingKittyPrintableSuppression = printableText;
+            _pendingKittyPrintableSuppressionStartPosition = _inputPosition + 1;
         }
 
         return keyEvent;
@@ -86,16 +92,45 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     /// <inheritdoc/>
     protected override bool ShouldSuppressFallbackKeyDown (Key key)
     {
+        string printableText = key.GetPrintableText ();
         string pendingPrintableText = _pendingKittyPrintableSuppression;
-        _pendingKittyPrintableSuppression = string.Empty;
+        long pendingStartPosition = _pendingKittyPrintableSuppressionStartPosition;
+        ClearPendingKittyPrintableSuppression ();
 
         if (string.IsNullOrEmpty (pendingPrintableText))
         {
             return false;
         }
 
-        string printableText = key.GetPrintableText ();
-        return string.Equals (printableText, pendingPrintableText, StringComparison.Ordinal);
+        long expectedLastPosition = pendingStartPosition + pendingPrintableText.Length - 1;
+
+        return _inputPosition == expectedLastPosition
+               && string.Equals (printableText, pendingPrintableText, StringComparison.Ordinal);
+    }
+
+    private void InvalidatePendingKittyPrintableSuppression (char input)
+    {
+        if (string.IsNullOrEmpty (_pendingKittyPrintableSuppression))
+        {
+            return;
+        }
+
+        long offset = _inputPosition - _pendingKittyPrintableSuppressionStartPosition;
+
+        if (offset >= 0
+            && offset < _pendingKittyPrintableSuppression.Length
+            && input == _pendingKittyPrintableSuppression [(int)offset])
+        {
+            return;
+        }
+
+        ClearPendingKittyPrintableSuppression ();
+    }
+
+    private void ClearPendingKittyPrintableSuppression ()
+    {
+        _pendingKittyPrintableSuppression = string.Empty;
+        _pendingKittyPrintableSuppressionStartPosition = 0;
     }
 
     /// <inheritdoc/>

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs
@@ -39,9 +39,7 @@ namespace Terminal.Gui.Drivers;
 /// </summary>
 public class AnsiInputProcessor : InputProcessorImpl<char>
 {
-    private static readonly TimeSpan PrintableSuppressionTimeout = TimeSpan.FromMilliseconds (50);
-    private string _pendingParsedPrintableSuppression = string.Empty;
-    private DateTime _pendingParsedPrintableSuppressionExpiresAt;
+    private string _pendingKittyPrintableSuppression = string.Empty;
 
     /// <inheritdoc/>
     /// <param name="inputBuffer">The input buffer to process.</param>
@@ -61,11 +59,13 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     }
 
     /// <inheritdoc/>
-    protected override Key OnKeyboardEventParsed (Key keyEvent)
+    private protected override Key OnKeyboardEventParsed (AnsiKeyboardParserPattern pattern, Key keyEvent)
     {
-        _pendingParsedPrintableSuppression = string.Empty;
+        keyEvent = base.OnKeyboardEventParsed (pattern, keyEvent);
+        _pendingKittyPrintableSuppression = string.Empty;
 
-        if (keyEvent.EventType != KeyEventType.Press
+        if (pattern is not KittyKeyboardPattern
+            || keyEvent.EventType != KeyEventType.Press
             || keyEvent.IsAlt
             || keyEvent.IsCtrl
             || keyEvent.IsModifierOnly)
@@ -77,8 +77,7 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
 
         if (!string.IsNullOrEmpty (printableText))
         {
-            _pendingParsedPrintableSuppression = printableText;
-            _pendingParsedPrintableSuppressionExpiresAt = CurrentTime + PrintableSuppressionTimeout;
+            _pendingKittyPrintableSuppression = printableText;
         }
 
         return keyEvent;
@@ -87,17 +86,16 @@ public class AnsiInputProcessor : InputProcessorImpl<char>
     /// <inheritdoc/>
     protected override bool ShouldSuppressFallbackKeyDown (Key key)
     {
-        string parsedPrintableText = _pendingParsedPrintableSuppression;
-        _pendingParsedPrintableSuppression = string.Empty;
+        string pendingPrintableText = _pendingKittyPrintableSuppression;
+        _pendingKittyPrintableSuppression = string.Empty;
 
-        if (string.IsNullOrEmpty (parsedPrintableText)
-            || CurrentTime > _pendingParsedPrintableSuppressionExpiresAt)
+        if (string.IsNullOrEmpty (pendingPrintableText))
         {
             return false;
         }
 
         string printableText = key.GetPrintableText ();
-        return string.Equals (printableText, parsedPrintableText, StringComparison.Ordinal);
+        return string.Equals (printableText, pendingPrintableText, StringComparison.Ordinal);
     }
 
     /// <inheritdoc/>

--- a/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs
@@ -684,6 +684,11 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
     public event EventHandler<Key>? Keyboard;
 
     /// <summary>
+    ///     Raised with the parser pattern that recognized a keyboard escape sequence.
+    /// </summary>
+    internal event Action<AnsiKeyboardParserPattern, Key>? KeyboardPatternMatched;
+
+    /// <summary>
     ///     Gets or sets whether to explicitly handle keyboard escape sequences by raising the <see cref="Keyboard"/> event.
     /// </summary>
     /// <remarks>
@@ -702,6 +707,7 @@ internal abstract class AnsiResponseParserBase (IHeld heldContent, ITimeProvider
         }
         else
         {
+            KeyboardPatternMatched?.Invoke (pattern, k);
             Keyboard?.Invoke (this, k);
         }
     }

--- a/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
+++ b/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
@@ -33,6 +33,9 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
     private readonly ITimeProvider _timeProvider;
     private readonly MouseInterpreter _mouseInterpreter;
 
+    /// <summary>Gets the current pipeline time.</summary>
+    protected DateTime CurrentTime => _timeProvider.Now;
+
     /// <summary>
     ///     Thread-safe input queue populated by <see cref="IInput{TInputRecord}"/> on the input thread.
     ///     Dequeued by <see cref="ProcessQueue"/> on the main loop thread.

--- a/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
+++ b/Terminal.Gui/Drivers/Input/InputProcessorImpl.cs
@@ -33,9 +33,6 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
     private readonly ITimeProvider _timeProvider;
     private readonly MouseInterpreter _mouseInterpreter;
 
-    /// <summary>Gets the current pipeline time.</summary>
-    protected DateTime CurrentTime => _timeProvider.Now;
-
     /// <summary>
     ///     Thread-safe input queue populated by <see cref="IInput{TInputRecord}"/> on the input thread.
     ///     Dequeued by <see cref="ProcessQueue"/> on the main loop thread.
@@ -81,19 +78,19 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
 
         Parser.Paste += (_, text) => RaisePasteEvent (text);
 
-        Parser.Keyboard += (_, keyEvent) =>
-                           {
-                               Key normalizedKeyEvent = OnKeyboardEventParsed (keyEvent);
+        Parser.KeyboardPatternMatched += (pattern, keyEvent) =>
+                                         {
+                                             Key normalizedKeyEvent = OnKeyboardEventParsed (pattern, keyEvent);
 
-                               if (normalizedKeyEvent.EventType == KeyEventType.Release)
-                               {
-                                   RaiseKeyUpEvent (normalizedKeyEvent);
-                               }
-                               else
-                               {
-                                   RaiseKeyDownEvent (normalizedKeyEvent);
-                               }
-                           };
+                                             if (normalizedKeyEvent.EventType == KeyEventType.Release)
+                                             {
+                                                 RaiseKeyUpEvent (normalizedKeyEvent);
+                                             }
+                                             else
+                                             {
+                                                 RaiseKeyDownEvent (normalizedKeyEvent);
+                                             }
+                                         };
 
         // Configure unexpected response handler
         Parser.UnexpectedResponseHandler = str =>
@@ -224,6 +221,15 @@ public abstract class InputProcessorImpl<TInputRecord> : IInputProcessor, IDispo
     /// <param name="keyEvent">The parsed key event.</param>
     /// <returns>The key event to forward.</returns>
     protected virtual Key OnKeyboardEventParsed (Key keyEvent) => keyEvent;
+
+    /// <summary>
+    ///     Called with the parser pattern that recognized a keyboard event before the event is forwarded to
+    ///     <see cref="KeyDown"/> or <see cref="KeyUp"/> subscribers.
+    /// </summary>
+    /// <param name="pattern">The parser pattern that recognized the input.</param>
+    /// <param name="keyEvent">The parsed key event.</param>
+    /// <returns>The key event to forward.</returns>
+    private protected virtual Key OnKeyboardEventParsed (AnsiKeyboardParserPattern pattern, Key keyEvent) => OnKeyboardEventParsed (keyEvent);
 
     /// <summary>
     ///     Gives derived processors a chance to suppress keydown events that come from fallback stream processing

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -238,12 +238,53 @@ public class KittyKeyboardPipelineTests
 
     // Codex - GPT-5 Codex
     [Fact]
-    public void Pipeline_MixedKittyAndLegacyPrintable_AfterSuppressionTimeout_RaisesBothKeyDowns ()
+    public void Pipeline_MixedKittyAndLegacyPrintable_AcrossDelay_DoesNotRaiseDuplicateKeyDown ()
     {
         (List<Key> down, List<Key> up) = InjectRawSequenceWithDelay (TimeSpan.FromMilliseconds (51), "\x1b[97u", "a");
 
+        Assert.Single (down);
+        Assert.Equal (Key.A, down [0]);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_KittyPortugueseKey_FollowedByTwoLegacyPrintables_SuppressesOnlyFirstFallback ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[231::59;;231u", "ç", "ç");
+
         Assert.Equal (2, down.Count);
-        Assert.All (down, key => Assert.Equal (Key.A, key));
+        Assert.All (down, key => Assert.Equal ("ç", key.GetPrintableText ()));
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_KittyPrintable_FollowedByNonmatchingFallback_ClearsSuppression ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[97u", "b", "a");
+
+        Assert.Equal ([Key.A, Key.B, Key.A], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_LegacyShiftTabFollowedByTab_RaisesBothKeyDowns ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[Z\t");
+
+        Assert.Equal ([Key.Tab.WithShift, Key.Tab], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void Pipeline_KittyTabAndLegacyTab_DoesNotRaiseDuplicateKeyDown ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[9u\t");
+
+        Assert.Equal ([Key.Tab], down);
         Assert.Empty (up);
     }
 

--- a/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs
@@ -270,6 +270,29 @@ public class KittyKeyboardPipelineTests
 
     // Codex - GPT-5.6
     [Fact]
+    public void Pipeline_KittyPrintable_InterveningParsedKey_PreservesLaterMatchingFallbackKey ()
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[97u\x1b[Aa");
+
+        Assert.Equal ([Key.A, Key.CursorUp, Key.A], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Theory]
+    [InlineData ("\x1b[<0;10;20M")]
+    [InlineData ("\x1b[?1;2c")]
+    [InlineData ("\x1b[200~x\x1b[201~")]
+    public void Pipeline_KittyPrintable_InterveningAnsiInput_PreservesLaterMatchingFallbackKey (string interveningInput)
+    {
+        (List<Key> down, List<Key> up) = InjectRawSequence ($"\x1b[97u{interveningInput}a");
+
+        Assert.Equal ([Key.A, Key.A], down);
+        Assert.Empty (up);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
     public void Pipeline_LegacyShiftTabFollowedByTab_RaisesBothKeyDowns ()
     {
         (List<Key> down, List<Key> up) = InjectRawSequence ("\x1b[Z\t");

--- a/plans/4918-restore-pre-4949-ansi-input-behavior.md
+++ b/plans/4918-restore-pre-4949-ansi-input-behavior.md
@@ -1,0 +1,27 @@
+# Restore Pre-#4949 ANSI Input Behavior
+
+## Problem Statement
+
+Windows Terminal previously emitted some Portuguese keyboard input as duplicated legacy characters while Kitty keyboard mode was enabled. Terminal.Gui expanded #4927's mixed Kitty-plus-legacy suppression through the #4949/#4977 raw-fallback workaround, which later evolved into a 50 ms suppression window. Windows Terminal fixed the underlying Kitty keyboard encoding defect, so Terminal.Gui can restore the behavior immediately before #4949 without the timing heuristic.
+
+## Implementation Steps
+
+1. Replace the timed ANSI printable-suppression state with the pre-#4949 single pending-printable state.
+2. Arm suppression only after an unmodified printable parsed key press, compare only the next fallback key, and never arm suppression from fallback input.
+3. Remove the protected input-pipeline clock accessor introduced solely for timed suppression.
+4. Carry the matching parser pattern through the internal input pipeline so only Kitty CSI-u input can arm suppression; legacy sequences such as Shift+Tab must remain lossless.
+5. Update pipeline regressions to verify time-independent mixed-input suppression, Portuguese Kitty-plus-legacy input, lossless repeated legacy input, and Shift+Tab followed by Tab.
+
+## File Changes
+
+- `Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs`: remove timed suppression and restore single-use pending suppression.
+- `Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs`: expose parser-pattern provenance to the internal input pipeline.
+- `Terminal.Gui/Drivers/Input/InputProcessorImpl.cs`: remove the unused protected clock accessor while retaining parser/fallback hooks.
+- `Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs`: update and add focused regression coverage.
+
+## Verification
+
+1. Run the focused `KittyKeyboardPipelineTests` class.
+2. Build the solution in Debug configuration.
+3. Run the full parallelizable unit-test project.
+4. Run the full non-parallelizable unit-test project.

--- a/plans/4918-restore-pre-4949-ansi-input-behavior.md
+++ b/plans/4918-restore-pre-4949-ansi-input-behavior.md
@@ -8,15 +8,16 @@ Windows Terminal previously emitted some Portuguese keyboard input as duplicated
 
 1. Replace the timed ANSI printable-suppression state with the pre-#4949 single pending-printable state.
 2. Arm suppression only after an unmodified printable parsed key press, compare only the next fallback key, and never arm suppression from fallback input.
-3. Remove the protected input-pipeline clock accessor introduced solely for timed suppression.
+3. Retain the protected input-pipeline clock accessor for compatibility, although suppression no longer uses time.
 4. Carry the matching parser pattern through the internal input pipeline so only Kitty CSI-u input can arm suppression; legacy sequences such as Shift+Tab must remain lossless.
-5. Update pipeline regressions to verify time-independent mixed-input suppression, Portuguese Kitty-plus-legacy input, lossless repeated legacy input, and Shift+Tab followed by Tab.
+5. Require the fallback duplicate to be adjacent in the raw input stream so intervening keyboard, mouse, paste, or response input invalidates suppression.
+6. Update pipeline regressions to verify time-independent mixed-input suppression, Portuguese Kitty-plus-legacy input, lossless repeated legacy input, Shift+Tab followed by Tab, and intervening parser input.
 
 ## File Changes
 
 - `Terminal.Gui/Drivers/AnsiDriver/AnsiInputProcessor.cs`: remove timed suppression and restore single-use pending suppression.
 - `Terminal.Gui/Drivers/AnsiHandling/AnsiResponseParserBase.cs`: expose parser-pattern provenance to the internal input pipeline.
-- `Terminal.Gui/Drivers/Input/InputProcessorImpl.cs`: remove the unused protected clock accessor while retaining parser/fallback hooks.
+- `Terminal.Gui/Drivers/Input/InputProcessorImpl.cs`: retain the protected clock accessor and route parser-pattern provenance through the parser/fallback hooks.
 - `Tests/UnitTestsParallelizable/Drivers/AnsiHandling/KittyKeyboardPipelineTests.cs`: update and add focused regression coverage.
 
 ## Verification


### PR DESCRIPTION
## Summary

- Fixes #5638

Scope ANSI printable-key de-duplication to actual Kitty CSI-u input so legacy key sequences remain lossless.

## Changes

- Remove the 50 ms printable-suppression window introduced by #5618.
- Carry parser-pattern provenance through the internal input pipeline.
- Arm fallback suppression only for Kitty keyboard patterns.
- Preserve immediate Kitty-plus-legacy duplicate suppression without timing heuristics.
- Require the legacy fallback to be adjacent in the raw input stream, invalidating suppression on intervening keyboard, mouse, paste, or response input.
- Retain the protected pipeline clock for external subclass compatibility.
- Add regressions for Shift+Tab followed by Tab, Kitty Tab fallback, Portuguese input, delayed input, nonmatching fallback input, and intervening parser input.

## Testing

- `KittyKeyboardPipelineTests`: 108 passed.
- `KittyKeyboardParsingTests`: 78 passed.
- `InputProcessorImplTests`: 31 passed, 1 existing skip.
- Non-parallelizable suite: 72 passed, 2 existing skips.
- Full parallelizable suite: 17,575 passed, 17 skipped; 5 unrelated existing ANSI color-output assertions failed locally.
- Direct library and test-project builds succeeded with no warnings in modified files.

## To pull down this PR locally:

```bash
git remote add copilot https://github.com/YourRobotOverlord/Terminal.Gui.git
git fetch copilot fix/revert-4949-4977
git checkout copilot/fix/revert-4949-4977
```
