### PR TITLE
Fixes #5639. Harden TextView text synchronization

### DIFF
--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
@@ -196,13 +196,19 @@ public partial class TextView
 
             // Keep base View._text in sync
             SetTextDirect (value);
+            SetNeedsDraw ();
+            _historyText.Clear (_model.GetAllLines ());
 
             _ownSetterActive = true;
-            RaiseTextChanged ();
-            _ownSetterActive = false;
-            SetNeedsDraw ();
 
-            _historyText.Clear (_model.GetAllLines ());
+            try
+            {
+                RaiseTextChanged ();
+            }
+            finally
+            {
+                _ownSetterActive = false;
+            }
         }
     }
 

--- a/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
+++ b/Terminal.Gui/Views/TextInput/TextView/TextView.Text.cs
@@ -199,7 +199,7 @@ public partial class TextView
             SetNeedsDraw ();
             _historyText.Clear (_model.GetAllLines ());
 
-            _ownSetterActive = true;
+            _skipNextTextChangedSync = true;
 
             try
             {
@@ -207,13 +207,13 @@ public partial class TextView
             }
             finally
             {
-                _ownSetterActive = false;
+                _skipNextTextChangedSync = false;
             }
         }
     }
 
-    /// <summary>Tracks whether the <c>new Text</c> setter is active to avoid redundant sync in <see cref="OnTextChanged"/>.</summary>
-    private bool _ownSetterActive;
+    /// <summary>Tracks whether the next <see cref="OnTextChanged"/> call should skip redundant model synchronization.</summary>
+    private bool _skipNextTextChangedSync;
 
     /// <inheritdoc/>
     /// <remarks>
@@ -223,8 +223,10 @@ public partial class TextView
     protected override void OnTextChanged ()
     {
         // Skip sync when called from our own `new Text` setter — it already updated the model.
-        if (_ownSetterActive)
+        if (_skipNextTextChangedSync)
         {
+            // Consume before TextChanged subscribers run so reentrant polymorphic sets synchronize normally.
+            _skipNextTextChangedSync = false;
             base.OnTextChanged ();
 
             return;

--- a/Tests/UnitTestsParallelizable/ViewBase/TextCwpTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/TextCwpTests.cs
@@ -205,6 +205,30 @@ public class TextCwpTests
         Assert.False (textView.IsDirty);
     }
 
+    // Codex - GPT-5.6
+    [Fact]
+    public void TextView_TextChanged_Reentrant_Polymorphic_Set_Syncs_Internal_Model ()
+    {
+        TextView textView = new ();
+        bool reentered = false;
+
+        textView.TextChanged += (_, _) =>
+                                {
+                                    if (reentered)
+                                    {
+                                        return;
+                                    }
+
+                                    reentered = true;
+                                    ((View)textView).Text = "second";
+                                };
+
+        textView.Text = "first";
+
+        Assert.Equal ("second", ((View)textView).Text);
+        Assert.Equal ("second", textView.Text);
+    }
+
     /// <summary>
     ///     CR Issue 4: A newly constructed <see cref="ProgressBar"/> should have <see cref="View.Text"/>
     ///     set to "0%" so that <see cref="ProgressBarFormat.SimplePlusPercentage"/> renders the percentage

--- a/Tests/UnitTestsParallelizable/ViewBase/TextCwpTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/TextCwpTests.cs
@@ -207,7 +207,7 @@ public class TextCwpTests
 
     // Codex - GPT-5.6
     [Fact]
-    public void TextView_TextChanged_Reentrant_Polymorphic_Set_Syncs_Internal_Model ()
+    public void TextView_TextChanged_ReentrantPolymorphicSet_SyncsInternalModel ()
     {
         TextView textView = new ();
         bool reentered = false;

--- a/Tests/UnitTestsParallelizable/ViewBase/TextCwpTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/TextCwpTests.cs
@@ -176,6 +176,35 @@ public class TextCwpTests
         Assert.Equal ("hello", tv.Text);
     }
 
+    // Codex - GPT-5.6
+    [Fact]
+    public void TextView_Text_Set_Survives_Throwing_TextChanged_Subscriber ()
+    {
+        TextView textView = new ();
+        EventHandler thrower = (_, _) => throw new InvalidOperationException ("Subscriber failure.");
+        textView.TextChanged += thrower;
+
+        Assert.Throws<InvalidOperationException> (() => textView.Text = "first");
+
+        textView.TextChanged -= thrower;
+        ((View)textView).Text = "second";
+
+        Assert.Equal ("second", textView.Text);
+    }
+
+    // Codex - GPT-5.6
+    [Fact]
+    public void TextView_Text_Set_Throwing_TextChanged_Subscriber_Clears_History_Baseline ()
+    {
+        TextView textView = new ();
+        textView.TextChanged += (_, _) => throw new InvalidOperationException ("Subscriber failure.");
+
+        Assert.Throws<InvalidOperationException> (() => textView.Text = "first");
+
+        Assert.Equal ("first", textView.Text);
+        Assert.False (textView.IsDirty);
+    }
+
     /// <summary>
     ///     CR Issue 4: A newly constructed <see cref="ProgressBar"/> should have <see cref="View.Text"/>
     ///     set to "0%" so that <see cref="ProgressBarFormat.SimplePlusPercentage"/> renders the percentage


### PR DESCRIPTION
## Summary

Hardens `TextView.Text` synchronization when post-change notification throws or performs a reentrant polymorphic assignment.

- Fixes #5639

## Changes

- Finalize draw and history state before raising `TextChanged`.
- Reset the synchronization guard in `finally` after subscriber failures.
- Consume the guard before subscriber dispatch so reentrant `View.Text` assignments update the internal model.
- Add regression tests for exception recovery, history consistency, and reentrant polymorphic synchronization.

## Testing

- `dotnet build --configuration Debug --no-restore` — passed with 0 errors and 3 pre-existing XML documentation warnings.
- Text CWP tests — 27 passed.
- TextView tests — 430 passed, 4 skipped.
- Non-parallel tests — 72 passed, 2 skipped.
- Full parallel suite — 17,585 passed, 17 skipped, and 4 unrelated ANSI color-encoding expectation failures in `SchemeColorNoneDerivationTests` and `ViewDrawingClippingTests`.

## To pull down this PR locally:

```bash
git remote add copilot https://github.com/YourRobotOverlord/Terminal.Gui.git
git fetch copilot fix/5639-textview-setter-guard
git checkout copilot/fix/5639-textview-setter-guard
```