### PR TITLE
fix: AnsiOutput/Utf8Buffer robustness + Unix zero-alloc

### DIFF
--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -356,8 +356,8 @@ public class AnsiOutput : OutputBase, IOutput
         }
         catch (Exception ex)
         {
-            // Swallowed for unit tests (degraded/no-terminal scenarios); traced for production diagnostics.
-            Trace.Lifecycle (nameof (AnsiOutput), "Write", $"Output write failed: {ex.Message}");
+            // Swallowed for unit tests (degraded/no-terminal scenarios); logged for production diagnostics.
+            Logging.Error ($"Output write failed in {nameof (AnsiOutput)}: {ex.Message}");
         }
     }
 

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -354,9 +354,10 @@ public class AnsiOutput : OutputBase, IOutput
                     break;
             }
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // ignore for unit tests
+            // Swallowed for unit tests (degraded/no-terminal scenarios); traced for production diagnostics.
+            Trace.Lifecycle (nameof (AnsiOutput), "Write", $"Output write failed: {ex.Message}");
         }
     }
 

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -296,8 +296,6 @@ public class AnsiOutput : OutputBase, IOutput
     /// </summary>
     protected override void Write (ReadOnlySpan<byte> output)
     {
-        base.Write (output);
-
         try
         {
             switch (_platform)
@@ -306,11 +304,13 @@ public class AnsiOutput : OutputBase, IOutput
                     if (_batchMode && _pendingCursorMoves.Length > 0)
                     {
                         _pendingCursorMoves.AppendBytes (output);
+                        base.Write (_pendingCursorMoves.AsSpan ());
                         _windowsVTOutput!.Write (_pendingCursorMoves.AsSpan ());
                         _pendingCursorMoves.Clear ();
                     }
                     else
                     {
+                        base.Write (output);
                         _windowsVTOutput!.Write (output);
                     }
 
@@ -320,18 +320,21 @@ public class AnsiOutput : OutputBase, IOutput
                     if (_batchMode && _pendingCursorMoves.Length > 0)
                     {
                         _pendingCursorMoves.AppendBytes (output);
-                        UnixIOHelper.TryWriteStdout (_pendingCursorMoves.AsSpan ().ToArray ());
+                        base.Write (_pendingCursorMoves.AsSpan ());
+                        WriteUnix (_pendingCursorMoves.AsSpan ());
                         _pendingCursorMoves.Clear ();
                     }
                     else
                     {
-                        UnixIOHelper.TryWriteStdout (output.ToArray ());
+                        base.Write (output);
+                        WriteUnix (output);
                     }
 
                     return;
 
                 case AnsiPlatform.Degraded:
                 default:
+                    base.Write (output);
                     break;
             }
         }
@@ -343,9 +346,34 @@ public class AnsiOutput : OutputBase, IOutput
 
     private Cursor _currentCursor;
 
+    /// <summary>
+    ///     Copies <paramref name="output"/> into a reusable backing array and writes to stdout,
+    ///     avoiding <see cref="ReadOnlySpan{T}.ToArray"/> allocation on every call.
+    /// </summary>
+    private void WriteUnix (ReadOnlySpan<byte> output)
+    {
+        int len = output.Length;
+
+        if (len == 0)
+        {
+            return;
+        }
+
+        if (_unixWriteBuffer is null || _unixWriteBuffer.Length < len)
+        {
+            _unixWriteBuffer = new byte [len];
+        }
+
+        output.CopyTo (_unixWriteBuffer);
+        UnixIOHelper.TryWriteStdout (_unixWriteBuffer, len);
+    }
+
     // PERF: Batch mode — defer cursor-move sequences to merge with cell content, reducing WriteFile P/Invoke count
     private readonly Utf8Buffer _pendingCursorMoves = new ();
     private bool _batchMode;
+
+    // PERF: Reusable backing array for Unix writes — avoids ToArray() allocation on every Write call.
+    private byte []? _unixWriteBuffer;
 
     /// <inheritdoc/>
     public Cursor GetCursor () => _currentCursor;

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -277,10 +277,75 @@ public class AnsiOutput : OutputBase, IOutput
     public override void Write (IOutputBuffer buffer)
     {
         _lastBuffer = buffer;
+        _batchMode = true;
         base.Write (buffer);
+        _batchMode = false;
+
+        // Flush any remaining deferred cursor moves
+        if (_pendingCursorMoves.Length > 0)
+        {
+            Write (_pendingCursorMoves.AsSpan ());
+            _pendingCursorMoves.Clear ();
+        }
+    }
+
+    /// <summary>
+    ///     PERF: Write pre-encoded UTF-8 bytes directly to the terminal.
+    ///     In batch mode, merges deferred cursor moves with cell content into one WriteFile.
+    ///     This is the hot-path write — zero string/byte[] allocation, zero encoding.
+    /// </summary>
+    protected override void Write (ReadOnlySpan<byte> output)
+    {
+        base.Write (output);
+
+        try
+        {
+            switch (_platform)
+            {
+                case AnsiPlatform.WindowsVT:
+                    if (_batchMode && _pendingCursorMoves.Length > 0)
+                    {
+                        _pendingCursorMoves.AppendBytes (output);
+                        _windowsVTOutput!.Write (_pendingCursorMoves.AsSpan ());
+                        _pendingCursorMoves.Clear ();
+                    }
+                    else
+                    {
+                        _windowsVTOutput!.Write (output);
+                    }
+
+                    break;
+
+                case AnsiPlatform.UnixRaw:
+                    if (_batchMode && _pendingCursorMoves.Length > 0)
+                    {
+                        _pendingCursorMoves.AppendBytes (output);
+                        UnixIOHelper.TryWriteStdout (_pendingCursorMoves.AsSpan ().ToArray ());
+                        _pendingCursorMoves.Clear ();
+                    }
+                    else
+                    {
+                        UnixIOHelper.TryWriteStdout (output.ToArray ());
+                    }
+
+                    return;
+
+                case AnsiPlatform.Degraded:
+                default:
+                    break;
+            }
+        }
+        catch (Exception)
+        {
+            // ignore for unit tests
+        }
     }
 
     private Cursor _currentCursor;
+
+    // PERF: Batch mode — defer cursor-move sequences to merge with cell content, reducing WriteFile P/Invoke count
+    private readonly Utf8Buffer _pendingCursorMoves = new ();
+    private bool _batchMode;
 
     /// <inheritdoc/>
     public Cursor GetCursor () => _currentCursor;
@@ -334,7 +399,17 @@ public class AnsiOutput : OutputBase, IOutput
         // In inline mode, App.Screen.Y is the terminal row where the inline region starts.
         // Adding it shifts rendering down so buffer row 0 maps to the correct terminal row.
         int inlineRowOffset = AppScreenGetter?.Invoke ().Y ?? 0;
-        Write (EscSeqUtils.CSI_SetCursorPosition (row + 1 + inlineRowOffset, col + 1));
+
+        if (_batchMode)
+        {
+            // PERF: Defer cursor-move to _pendingCursorMoves (Utf8Buffer); merges with subsequent cell content
+            // into a single WriteFile P/Invoke instead of one per cursor move.
+            _pendingCursorMoves.AppendAscii (EscSeqUtils.CSI_SetCursorPosition (row + 1 + inlineRowOffset, col + 1));
+        }
+        else
+        {
+            Write (EscSeqUtils.CSI_SetCursorPosition (row + 1 + inlineRowOffset, col + 1));
+        }
 
         return true;
     }

--- a/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
+++ b/Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
@@ -212,6 +212,15 @@ public class AnsiOutput : OutputBase, IOutput
     /// <inheritdoc/>
     protected override void Write (StringBuilder output)
     {
+        // In batch mode, route through the byte-span path to merge with deferred cursor moves.
+        if (_batchMode && _pendingCursorMoves.Length > 0)
+        {
+            byte [] utf8 = Encoding.UTF8.GetBytes (output.ToString ());
+            Write (utf8);
+
+            return;
+        }
+
         base.Write (output);
 
         try
@@ -278,14 +287,21 @@ public class AnsiOutput : OutputBase, IOutput
     {
         _lastBuffer = buffer;
         _batchMode = true;
-        base.Write (buffer);
-        _batchMode = false;
 
-        // Flush any remaining deferred cursor moves
-        if (_pendingCursorMoves.Length > 0)
+        try
         {
-            Write (_pendingCursorMoves.AsSpan ());
-            _pendingCursorMoves.Clear ();
+            base.Write (buffer);
+        }
+        finally
+        {
+            _batchMode = false;
+
+            // Flush any remaining deferred cursor moves
+            if (_pendingCursorMoves.Length > 0)
+            {
+                Write (_pendingCursorMoves.AsSpan ());
+                _pendingCursorMoves.Clear ();
+            }
         }
     }
 

--- a/Terminal.Gui/Drivers/AnsiHandling/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/EscSeqUtils/EscSeqUtils.cs
@@ -816,6 +816,35 @@ public static class EscSeqUtils
             return;
         }
 
+        List<int> sgr = ComputeTextStyleSgrCodes (prev, next);
+
+        output.Append ("\x1b[");
+        output.Append (string.Join (';', sgr));
+        output.Append ('m');
+    }
+
+    /// <summary>
+    ///     Builds the SGR escape sequence for a text style change as a string (ASCII).
+    ///     Used by Utf8Buffer-based output path.
+    /// </summary>
+    internal static string CSI_BuildTextStyleChange (TextStyle prev, TextStyle next)
+    {
+        if (prev == next)
+        {
+            return string.Empty;
+        }
+
+        List<int> sgr = ComputeTextStyleSgrCodes (prev, next);
+
+        return $"\x1b[{string.Join (';', sgr)}m";
+    }
+
+    /// <summary>
+    ///     Computes the SGR parameter codes for a text style change.
+    ///     Shared by <see cref="CSI_AppendTextStyleChange"/> and <see cref="CSI_BuildTextStyleChange"/>.
+    /// </summary>
+    private static List<int> ComputeTextStyleSgrCodes (TextStyle prev, TextStyle next)
+    {
         // Bitwise operations to determine flag changes. A ^ B are the flags different between two flag sets. These different flags that exist in the next flag
         // set (diff & next) are the ones that were enabled in the switch, those that exist in the previous flag set (diff & prev) are the ones that were
         // disabled.
@@ -915,115 +944,7 @@ public static class EscSeqUtils
             }
         }
 
-        output.Append ("\x1b[");
-        output.Append (string.Join (';', sgr));
-        output.Append ('m');
-    }
-
-    /// <summary>
-    ///     Builds the SGR escape sequence for a text style change as a string (ASCII).
-    ///     Used by Utf8Buffer-based output path.
-    /// </summary>
-    internal static string CSI_BuildTextStyleChange (TextStyle prev, TextStyle next)
-    {
-        if (prev == next)
-        {
-            return string.Empty;
-        }
-
-        TextStyle diff = prev ^ next;
-        TextStyle enabled = diff & next;
-        TextStyle disabled = diff & prev;
-
-        List<int> sgr = new ();
-
-        if (disabled != TextStyle.None)
-        {
-            if (disabled.HasFlag (TextStyle.Bold))
-            {
-                sgr.Add (22);
-
-                if ((prev & next).HasFlag (TextStyle.Faint))
-                {
-                    sgr.Add (2);
-                }
-            }
-
-            if (disabled.HasFlag (TextStyle.Faint))
-            {
-                sgr.Add (22);
-
-                if ((prev & next).HasFlag (TextStyle.Bold))
-                {
-                    sgr.Add (1);
-                }
-            }
-
-            if (disabled.HasFlag (TextStyle.Italic))
-            {
-                sgr.Add (23);
-            }
-
-            if (disabled.HasFlag (TextStyle.Underline))
-            {
-                sgr.Add (24);
-            }
-
-            if (disabled.HasFlag (TextStyle.Blink))
-            {
-                sgr.Add (25);
-            }
-
-            if (disabled.HasFlag (TextStyle.Reverse))
-            {
-                sgr.Add (27);
-            }
-
-            if (disabled.HasFlag (TextStyle.Strikethrough))
-            {
-                sgr.Add (29);
-            }
-        }
-
-        if (enabled != TextStyle.None)
-        {
-            if (enabled.HasFlag (TextStyle.Bold))
-            {
-                sgr.Add (1);
-            }
-
-            if (enabled.HasFlag (TextStyle.Faint))
-            {
-                sgr.Add (2);
-            }
-
-            if (enabled.HasFlag (TextStyle.Italic))
-            {
-                sgr.Add (3);
-            }
-
-            if (enabled.HasFlag (TextStyle.Underline))
-            {
-                sgr.Add (4);
-            }
-
-            if (enabled.HasFlag (TextStyle.Blink))
-            {
-                sgr.Add (5);
-            }
-
-            if (enabled.HasFlag (TextStyle.Reverse))
-            {
-                sgr.Add (7);
-            }
-
-            if (enabled.HasFlag (TextStyle.Strikethrough))
-            {
-                sgr.Add (9);
-            }
-        }
-
-        return $"\x1b[{string.Join (';', sgr)}m";
+        return sgr;
     }
 
     #endregion Text Styles

--- a/Terminal.Gui/Drivers/AnsiHandling/EscSeqUtils/EscSeqUtils.cs
+++ b/Terminal.Gui/Drivers/AnsiHandling/EscSeqUtils/EscSeqUtils.cs
@@ -920,6 +920,112 @@ public static class EscSeqUtils
         output.Append ('m');
     }
 
+    /// <summary>
+    ///     Builds the SGR escape sequence for a text style change as a string (ASCII).
+    ///     Used by Utf8Buffer-based output path.
+    /// </summary>
+    internal static string CSI_BuildTextStyleChange (TextStyle prev, TextStyle next)
+    {
+        if (prev == next)
+        {
+            return string.Empty;
+        }
+
+        TextStyle diff = prev ^ next;
+        TextStyle enabled = diff & next;
+        TextStyle disabled = diff & prev;
+
+        List<int> sgr = new ();
+
+        if (disabled != TextStyle.None)
+        {
+            if (disabled.HasFlag (TextStyle.Bold))
+            {
+                sgr.Add (22);
+
+                if ((prev & next).HasFlag (TextStyle.Faint))
+                {
+                    sgr.Add (2);
+                }
+            }
+
+            if (disabled.HasFlag (TextStyle.Faint))
+            {
+                sgr.Add (22);
+
+                if ((prev & next).HasFlag (TextStyle.Bold))
+                {
+                    sgr.Add (1);
+                }
+            }
+
+            if (disabled.HasFlag (TextStyle.Italic))
+            {
+                sgr.Add (23);
+            }
+
+            if (disabled.HasFlag (TextStyle.Underline))
+            {
+                sgr.Add (24);
+            }
+
+            if (disabled.HasFlag (TextStyle.Blink))
+            {
+                sgr.Add (25);
+            }
+
+            if (disabled.HasFlag (TextStyle.Reverse))
+            {
+                sgr.Add (27);
+            }
+
+            if (disabled.HasFlag (TextStyle.Strikethrough))
+            {
+                sgr.Add (29);
+            }
+        }
+
+        if (enabled != TextStyle.None)
+        {
+            if (enabled.HasFlag (TextStyle.Bold))
+            {
+                sgr.Add (1);
+            }
+
+            if (enabled.HasFlag (TextStyle.Faint))
+            {
+                sgr.Add (2);
+            }
+
+            if (enabled.HasFlag (TextStyle.Italic))
+            {
+                sgr.Add (3);
+            }
+
+            if (enabled.HasFlag (TextStyle.Underline))
+            {
+                sgr.Add (4);
+            }
+
+            if (enabled.HasFlag (TextStyle.Blink))
+            {
+                sgr.Add (5);
+            }
+
+            if (enabled.HasFlag (TextStyle.Reverse))
+            {
+                sgr.Add (7);
+            }
+
+            if (enabled.HasFlag (TextStyle.Strikethrough))
+            {
+                sgr.Add (9);
+            }
+        }
+
+        return $"\x1b[{string.Join (';', sgr)}m";
+    }
+
     #endregion Text Styles
 
     #region Requests

--- a/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
+++ b/Terminal.Gui/Drivers/DotNetDriver/NetOutput.cs
@@ -110,6 +110,26 @@ public class NetOutput : OutputBase, IOutput
         }
     }
 
+    /// <inheritdoc/>
+    protected override void Write (ReadOnlySpan<byte> output)
+    {
+        base.Write (output);
+
+        if (!IsAttachedToTerminal)
+        {
+            return;
+        }
+
+        try
+        {
+            Console.Out.Write (Encoding.UTF8.GetString (output));
+        }
+        catch (IOException)
+        {
+            // Not connected to a terminal; do nothing
+        }
+    }
+
     private Cursor _currentCursor = new ();
 
     /// <inheritdoc/>

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -74,8 +74,11 @@ public abstract class OutputBase
     private int _lastTrackedCols;
     private int _lastTrackedUrlVersion;
 
-    private readonly StringBuilder _lastoutputBuffer = new ();
+    private readonly StringBuilder _lastOutputStringBuilder = new ();
     private bool _clearLastOutputPending;
+
+    // Reusable buffer for UTF-8 → UTF-16 decode in Write(ReadOnlySpan<byte>).
+    private char []? _utf16DecodeBuffer;
 
     // Kitty image ids placed on the previous Write, keyed by RasterImageCommand.Id. A single image
     // can occupy more than one placement when its visible region is fragmented by clipping (e.g. a
@@ -318,7 +321,7 @@ public abstract class OutputBase
     }
 
     /// <inheritdoc cref="IOutput.GetLastOutput"/>
-    public virtual string GetLastOutput () => _lastoutputBuffer.ToString ();
+    public virtual string GetLastOutput () => _lastOutputStringBuilder.ToString ();
 
     /// <summary>
     ///     Changes the color and text style of the console to the given <paramref name="attr"/> and
@@ -339,7 +342,8 @@ public abstract class OutputBase
     {
         if (attr.Foreground == Color.None)
         {
-            output.AppendAscii ($"{EscSeqUtils.CSI}39m");
+            output.AppendAscii (EscSeqUtils.CSI);
+            output.AppendAscii ("39m");
         }
         else if (Force16Colors)
         {
@@ -347,12 +351,20 @@ public abstract class OutputBase
         }
         else
         {
-            output.AppendAscii ($"{EscSeqUtils.CSI}38;2;{attr.Foreground.R};{attr.Foreground.G};{attr.Foreground.B}m");
+            output.AppendAscii (EscSeqUtils.CSI);
+            output.AppendAscii ("38;2;");
+            output.AppendInt (attr.Foreground.R);
+            output.AppendByte ((byte)';');
+            output.AppendInt (attr.Foreground.G);
+            output.AppendByte ((byte)';');
+            output.AppendInt (attr.Foreground.B);
+            output.AppendByte ((byte)'m');
         }
 
         if (attr.Background == Color.None)
         {
-            output.AppendAscii ($"{EscSeqUtils.CSI}49m");
+            output.AppendAscii (EscSeqUtils.CSI);
+            output.AppendAscii ("49m");
         }
         else if (Force16Colors)
         {
@@ -360,7 +372,14 @@ public abstract class OutputBase
         }
         else
         {
-            output.AppendAscii ($"{EscSeqUtils.CSI}48;2;{attr.Background.R};{attr.Background.G};{attr.Background.B}m");
+            output.AppendAscii (EscSeqUtils.CSI);
+            output.AppendAscii ("48;2;");
+            output.AppendInt (attr.Background.R);
+            output.AppendByte ((byte)';');
+            output.AppendInt (attr.Background.G);
+            output.AppendByte ((byte)';');
+            output.AppendInt (attr.Background.B);
+            output.AppendByte ((byte)'m');
         }
 
         string styleChange = EscSeqUtils.CSI_BuildTextStyleChange (redrawTextStyle, attr.Style);
@@ -388,11 +407,11 @@ public abstract class OutputBase
     {
         if (_clearLastOutputPending)
         {
-            _lastoutputBuffer.Clear ();
+            _lastOutputStringBuilder.Clear ();
             _clearLastOutputPending = false;
         }
 
-        _lastoutputBuffer.Append (output);
+        _lastOutputStringBuilder.Append (output);
     }
 
     /// <summary>
@@ -404,12 +423,21 @@ public abstract class OutputBase
     {
         if (_clearLastOutputPending)
         {
-            _lastoutputBuffer.Clear ();
+            _lastOutputStringBuilder.Clear ();
             _clearLastOutputPending = false;
         }
 
-        // Decode back to UTF-16 for GetLastOutput() (test/debug only, not hot path)
-        _lastoutputBuffer.Append (Encoding.UTF8.GetString (output));
+        // Decode UTF-8 to UTF-16 for GetLastOutput() using a reusable buffer.
+        // Allocates only when the buffer must grow; stable-state zero-allocation.
+        int maxCharCount = Encoding.UTF8.GetMaxCharCount (output.Length);
+
+        if (_utf16DecodeBuffer is null || _utf16DecodeBuffer.Length < maxCharCount)
+        {
+            _utf16DecodeBuffer = new char [maxCharCount];
+        }
+
+        int charCount = Encoding.UTF8.GetChars (output, _utf16DecodeBuffer);
+        _lastOutputStringBuilder.Append (_utf16DecodeBuffer, 0, charCount);
     }
 
     /// <summary>

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -74,7 +74,7 @@ public abstract class OutputBase
     private int _lastTrackedCols;
     private int _lastTrackedUrlVersion;
 
-    private readonly StringBuilder _lastOutputStringBuilder = new ();
+    private readonly StringBuilder _lastoutputBuffer = new ();
     private bool _clearLastOutputPending;
 
     // Kitty image ids placed on the previous Write, keyed by RasterImageCommand.Id. A single image
@@ -173,92 +173,85 @@ public abstract class OutputBase
                 outputBuffer.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
             }
 
+            lastCol = 0;
+            var outputWidth = 0;
+
             // Process columns in row
             for (int col = left; col < cols; col++)
             {
-                lastCol = -1;
-                var outputWidth = 0;
+                // Skip clean cells, plus blank cells owned by raster images. Raster-owned
+                // blanks must not be emitted because normal text output would erase Sixel
+                // images and is unnecessary over Kitty's transparent-cleared placement.
+                bool skipRasterBlank = IsRasterCoveredBlankCell (buffer, row, col, rasterCellRectangles);
 
-                // Batch consecutive dirty cells
-                for (; col < cols; col++)
+                if (!buffer.Contents! [row, col].IsDirty || skipRasterBlank)
                 {
-                    // Skip clean cells, plus blank cells owned by raster images. Raster-owned
-                    // blanks must not be emitted because normal text output would erase Sixel
-                    // images and is unnecessary over Kitty's transparent-cleared placement.
-                    bool skipRasterBlank = IsRasterCoveredBlankCell (buffer, row, col, rasterCellRectangles);
-
-                    if (!buffer.Contents! [row, col].IsDirty || skipRasterBlank)
+                    if (skipRasterBlank)
                     {
-                        if (skipRasterBlank)
-                        {
-                            buffer.Contents [row, col].IsDirty = false;
-                        }
-
-                        if (outputBuffer.Length > 0)
-                        {
-                            // This clears outputBuffer
-                            WriteToConsole (outputBuffer, ref lastCol, ref outputWidth);
-                        }
-                        else if (lastCol == -1)
-                        {
-                            lastCol = col;
-                        }
-
-                        if (lastCol + 1 < cols)
-                        {
-                            lastCol++;
-                        }
-
-                        SetCursorPositionImpl (lastCol, row);
-
-                        continue;
-                    }
-
-                    if (lastCol == -1)
-                    {
-                        lastCol = col;
-                    }
-
-                    // Handle URL hyperlink state changes
-                    if (!IsLegacyConsole)
-                    {
-                        string? cellUrl = buffer.GetCellUrl (col, row);
-
-                        if (cellUrl != _lastUrl)
-                        {
-                            // If we were in a hyperlink, end it
-                            if (_lastUrl is { })
-                            {
-                                outputBuffer.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
-                            }
-
-                            // If starting a new hyperlink, begin it
-                            if (!string.IsNullOrEmpty (cellUrl))
-                            {
-                                outputBuffer.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
-                            }
-
-                            _lastUrl = cellUrl;
-                        }
-                    }
-
-                    // Append dirty cell as ANSI and mark clean
-                    Cell cell = buffer.Contents [row, col];
-                    buffer.Contents [row, col].IsDirty = false;
-                    AppendCellAnsi (cell, outputBuffer, ref redrawAttr, ref _redrawTextStyle, cols, ref col, ref outputWidth);
-
-                    if (col != lastCol)
-                    {
-                        // Was a wide grapheme so mark clean next cell
-                        // See https://github.com/tui-cs/Terminal.Gui/issues/4466
                         buffer.Contents [row, col].IsDirty = false;
                     }
+
+                    if (outputWidth > 0)
+                    {
+                        // This clears outputBuffer
+                        WriteToConsole (outputBuffer, ref lastCol, ref outputWidth);
+                    }
+
+                    continue;
+                }
+
+                // Position the cursor once at the beginning of each dirty run. Clean gaps
+                // are skipped without emitting one cursor-position sequence per cell.
+                if (outputWidth == 0 && col != lastCol)
+                {
+                    if (!SetCursorPositionImpl (col, row))
+                    {
+                        return;
+                    }
+
+                    lastCol = col;
+                }
+
+                // Handle URL hyperlink state changes
+                if (!IsLegacyConsole)
+                {
+                    string? cellUrl = buffer.GetCellUrl (col, row);
+
+                    if (cellUrl != _lastUrl)
+                    {
+                        // If we were in a hyperlink, end it
+                        if (_lastUrl is { })
+                        {
+                            outputBuffer.Append (EscSeqUtils.OSC_EndHyperlink ());
+                        }
+
+                        // If starting a new hyperlink, begin it
+                        if (!string.IsNullOrEmpty (cellUrl))
+                        {
+                            outputBuffer.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
+                        }
+
+                        _lastUrl = cellUrl;
+                    }
+                }
+
+                // Append dirty cell as ANSI and mark clean
+                int cellCol = col;
+                Cell cell = buffer.Contents [row, col];
+                buffer.Contents [row, col].IsDirty = false;
+                AppendCellAnsi (cell, outputBuffer, ref redrawAttr, ref _redrawTextStyle, cols, ref col, ref outputWidth);
+
+                if (col != cellCol)
+                {
+                    // Was a wide grapheme so mark clean next cell
+                    // See https://github.com/tui-cs/Terminal.Gui/issues/4466
+                    buffer.Contents [row, col].IsDirty = false;
                 }
             }
 
             // Track row's URL status BEFORE the early-exit so _rowsWithUrls stays consistent
             // with the buffer state — even for rows whose cells were all flushed via WriteToConsole
-            // during the inner loop (leaving outputBuffer empty at this point).
+            // during the row scan (leaving outputBuffer empty at this point).
             if (!IsLegacyConsole)
             {
                 if (rowHasUrlsNow)
@@ -270,6 +263,10 @@ public abstract class OutputBase
                     _rowsWithUrls.Remove (row);
                 }
             }
+
+            // Every dirty cell in this row has now been consumed. Drawing operations will
+            // set this flag again when they modify the row in a later frame.
+            buffer.DirtyLines [row] = false;
 
             // Flush buffered output for row. Even when nothing remains buffered, an OSC 8 hyperlink
             // may still be open in the terminal because it was started in a prior batch flushed by
@@ -296,8 +293,6 @@ public abstract class OutputBase
                 _lastUrl = null;
             }
 
-            SetCursorPositionImpl (lastCol, row);
-
             Write (outputBuffer.AsSpan ());
         }
 
@@ -323,7 +318,7 @@ public abstract class OutputBase
     }
 
     /// <inheritdoc cref="IOutput.GetLastOutput"/>
-    public virtual string GetLastOutput () => _lastOutputStringBuilder.ToString ();
+    public virtual string GetLastOutput () => _lastoutputBuffer.ToString ();
 
     /// <summary>
     ///     Changes the color and text style of the console to the given <paramref name="attr"/> and
@@ -393,11 +388,11 @@ public abstract class OutputBase
     {
         if (_clearLastOutputPending)
         {
-            _lastOutputStringBuilder.Clear ();
+            _lastoutputBuffer.Clear ();
             _clearLastOutputPending = false;
         }
 
-        _lastOutputStringBuilder.Append (output);
+        _lastoutputBuffer.Append (output);
     }
 
     /// <summary>
@@ -409,12 +404,12 @@ public abstract class OutputBase
     {
         if (_clearLastOutputPending)
         {
-            _lastOutputStringBuilder.Clear ();
+            _lastoutputBuffer.Clear ();
             _clearLastOutputPending = false;
         }
 
         // Decode back to UTF-16 for GetLastOutput() (test/debug only, not hot path)
-        _lastOutputStringBuilder.Append (Encoding.UTF8.GetString (output));
+        _lastoutputBuffer.Append (Encoding.UTF8.GetString (output));
     }
 
     /// <summary>
@@ -577,9 +572,9 @@ public abstract class OutputBase
             return output.ToString ();
         }
 
-        if (buffer is OutputBufferImpl outputBuffer)
+        if (buffer is OutputBufferImpl outputBuffer2)
         {
-            outputBuffer.SyncAutoUrlsForAllRows ();
+            outputBuffer2.SyncAutoUrlsForAllRows ();
         }
 
         StringBuilder ansiOutput = new ();
@@ -1279,7 +1274,7 @@ public abstract class OutputBase
 
     private void InvalidateRowsWithUrlsIfStale (IOutputBuffer buffer, int rows, int cols)
     {
-        int urlVersion = buffer is OutputBufferImpl outputBuffer ? outputBuffer.UrlStateVersion : 0;
+        int urlVersion = buffer is OutputBufferImpl outputBuffer2 ? outputBuffer2.UrlStateVersion : 0;
 
         if (!ReferenceEquals (_lastTrackedBuffer, buffer)
             || _lastTrackedRows != rows

--- a/Terminal.Gui/Drivers/Output/OutputBase.cs
+++ b/Terminal.Gui/Drivers/Output/OutputBase.cs
@@ -116,7 +116,7 @@ public abstract class OutputBase
     public virtual void Write (IOutputBuffer buffer)
     {
         _clearLastOutputPending = true;
-        StringBuilder outputStringBuilder = new ();
+        Utf8Buffer outputBuffer = new ();
         var top = 0;
         var left = 0;
         int rows = buffer.Rows;
@@ -157,101 +157,108 @@ public abstract class OutputBase
                 return;
             }
 
-            if (!IsLegacyConsole && buffer is OutputBufferImpl outputBuffer)
+            if (!IsLegacyConsole && buffer is OutputBufferImpl outputBuffer2)
             {
-                outputBuffer.SyncAutoUrlsForRow (row);
+                outputBuffer2.SyncAutoUrlsForRow (row);
             }
 
             bool rowHadUrlsPreviously = _rowsWithUrls.Contains (row);
             bool rowHasUrlsNow = !IsLegacyConsole && RowContainsUrls (buffer, row, cols);
 
-            outputStringBuilder.Clear ();
+            outputBuffer.Clear ();
             _lastUrl = null; // Reset URL state at the start of each row
 
             if (!IsLegacyConsole && rowHadUrlsPreviously && !rowHasUrlsNow)
             {
-                outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
+                outputBuffer.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
             }
-
-            lastCol = 0;
-            var outputWidth = 0;
 
             // Process columns in row
             for (int col = left; col < cols; col++)
             {
-                // Skip clean cells, plus blank cells owned by raster images. Raster-owned
-                // blanks must not be emitted because normal text output would erase Sixel
-                // images and is unnecessary over Kitty's transparent-cleared placement.
-                bool skipRasterBlank = IsRasterCoveredBlankCell (buffer, row, col, rasterCellRectangles);
+                lastCol = -1;
+                var outputWidth = 0;
 
-                if (!buffer.Contents! [row, col].IsDirty || skipRasterBlank)
+                // Batch consecutive dirty cells
+                for (; col < cols; col++)
                 {
-                    if (skipRasterBlank)
+                    // Skip clean cells, plus blank cells owned by raster images. Raster-owned
+                    // blanks must not be emitted because normal text output would erase Sixel
+                    // images and is unnecessary over Kitty's transparent-cleared placement.
+                    bool skipRasterBlank = IsRasterCoveredBlankCell (buffer, row, col, rasterCellRectangles);
+
+                    if (!buffer.Contents! [row, col].IsDirty || skipRasterBlank)
                     {
+                        if (skipRasterBlank)
+                        {
+                            buffer.Contents [row, col].IsDirty = false;
+                        }
+
+                        if (outputBuffer.Length > 0)
+                        {
+                            // This clears outputBuffer
+                            WriteToConsole (outputBuffer, ref lastCol, ref outputWidth);
+                        }
+                        else if (lastCol == -1)
+                        {
+                            lastCol = col;
+                        }
+
+                        if (lastCol + 1 < cols)
+                        {
+                            lastCol++;
+                        }
+
+                        SetCursorPositionImpl (lastCol, row);
+
+                        continue;
+                    }
+
+                    if (lastCol == -1)
+                    {
+                        lastCol = col;
+                    }
+
+                    // Handle URL hyperlink state changes
+                    if (!IsLegacyConsole)
+                    {
+                        string? cellUrl = buffer.GetCellUrl (col, row);
+
+                        if (cellUrl != _lastUrl)
+                        {
+                            // If we were in a hyperlink, end it
+                            if (_lastUrl is { })
+                            {
+                                outputBuffer.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
+                            }
+
+                            // If starting a new hyperlink, begin it
+                            if (!string.IsNullOrEmpty (cellUrl))
+                            {
+                                outputBuffer.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
+                            }
+
+                            _lastUrl = cellUrl;
+                        }
+                    }
+
+                    // Append dirty cell as ANSI and mark clean
+                    Cell cell = buffer.Contents [row, col];
+                    buffer.Contents [row, col].IsDirty = false;
+                    AppendCellAnsi (cell, outputBuffer, ref redrawAttr, ref _redrawTextStyle, cols, ref col, ref outputWidth);
+
+                    if (col != lastCol)
+                    {
+                        // Was a wide grapheme so mark clean next cell
+                        // See https://github.com/tui-cs/Terminal.Gui/issues/4466
                         buffer.Contents [row, col].IsDirty = false;
                     }
-
-                    if (outputWidth > 0)
-                    {
-                        // This clears outputStringBuilder
-                        WriteToConsole (outputStringBuilder, ref lastCol, ref outputWidth);
-                    }
-
-                    continue;
-                }
-
-                // Position the cursor once at the beginning of each dirty run. Clean gaps
-                // are skipped without emitting one cursor-position sequence per cell.
-                if (outputWidth == 0 && col != lastCol)
-                {
-                    if (!SetCursorPositionImpl (col, row))
-                    {
-                        return;
-                    }
-
-                    lastCol = col;
-                }
-
-                // Handle URL hyperlink state changes
-                if (!IsLegacyConsole)
-                {
-                    string? cellUrl = buffer.GetCellUrl (col, row);
-
-                    if (cellUrl != _lastUrl)
-                    {
-                        // If we were in a hyperlink, end it
-                        if (_lastUrl is { })
-                        {
-                            outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
-                        }
-
-                        // If starting a new hyperlink, begin it
-                        if (!string.IsNullOrEmpty (cellUrl))
-                        {
-                            outputStringBuilder.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
-                        }
-
-                        _lastUrl = cellUrl;
-                    }
-                }
-
-                // Append dirty cell as ANSI and mark clean
-                int cellCol = col;
-                Cell cell = buffer.Contents [row, col];
-                buffer.Contents [row, col].IsDirty = false;
-                AppendCellAnsi (cell, outputStringBuilder, ref redrawAttr, ref _redrawTextStyle, cols, ref col, ref outputWidth);
-
-                if (col != cellCol)
-                {
-                    // Was a wide grapheme so mark clean next cell
-                    // See https://github.com/tui-cs/Terminal.Gui/issues/4466
-                    buffer.Contents [row, col].IsDirty = false;
                 }
             }
 
             // Track row's URL status BEFORE the early-exit so _rowsWithUrls stays consistent
             // with the buffer state — even for rows whose cells were all flushed via WriteToConsole
-            // during the row scan (leaving outputStringBuilder empty at this point).
+            // during the inner loop (leaving outputBuffer empty at this point).
             if (!IsLegacyConsole)
             {
                 if (rowHasUrlsNow)
@@ -264,24 +271,20 @@ public abstract class OutputBase
                 }
             }
 
-            // Every dirty cell in this row has now been consumed. Drawing operations will
-            // set this flag again when they modify the row in a later frame.
-            buffer.DirtyLines [row] = false;
-
             // Flush buffered output for row. Even when nothing remains buffered, an OSC 8 hyperlink
             // may still be open in the terminal because it was started in a prior batch flushed by
             // WriteToConsole and the row ended (or only clean cells followed) before any cell with
             // a different URL closed it. Emit the close so the link does not bleed into later rows.
-            if (outputStringBuilder.Length <= 0 && _lastUrl is null)
+            if (outputBuffer.Length <= 0 && _lastUrl is null)
             {
                 continue;
             }
 
             if (IsLegacyConsole)
             {
-                if (outputStringBuilder.Length > 0)
+                if (outputBuffer.Length > 0)
                 {
-                    Write (outputStringBuilder);
+                    Write (outputBuffer.AsSpan ());
                 }
 
                 continue;
@@ -289,11 +292,13 @@ public abstract class OutputBase
 
             if (_lastUrl is { })
             {
-                outputStringBuilder.Append (EscSeqUtils.OSC_EndHyperlink ());
+                outputBuffer.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
                 _lastUrl = null;
             }
 
-            Write (outputStringBuilder);
+            SetCursorPositionImpl (lastCol, row);
+
+            Write (outputBuffer.AsSpan ());
         }
 
         if (IsLegacyConsole)
@@ -335,35 +340,40 @@ public abstract class OutputBase
     /// <param name="output"></param>
     /// <param name="attr"></param>
     /// <param name="redrawTextStyle"></param>
-    protected virtual void AppendOrWriteAttribute (StringBuilder output, Attribute attr, TextStyle redrawTextStyle)
+    protected virtual void AppendOrWriteAttribute (Utf8Buffer output, Attribute attr, TextStyle redrawTextStyle)
     {
         if (attr.Foreground == Color.None)
         {
-            EscSeqUtils.CSI_AppendResetForegroundColor (output);
+            output.AppendAscii ($"{EscSeqUtils.CSI}39m");
         }
         else if (Force16Colors)
         {
-            output.Append (EscSeqUtils.CSI_SetForegroundColor (attr.Foreground.GetAnsiColorCode ()));
+            output.AppendAscii (EscSeqUtils.CSI_SetForegroundColor (attr.Foreground.GetAnsiColorCode ()));
         }
         else
         {
-            EscSeqUtils.CSI_AppendForegroundColorRGB (output, attr.Foreground.R, attr.Foreground.G, attr.Foreground.B);
+            output.AppendAscii ($"{EscSeqUtils.CSI}38;2;{attr.Foreground.R};{attr.Foreground.G};{attr.Foreground.B}m");
         }
 
         if (attr.Background == Color.None)
         {
-            EscSeqUtils.CSI_AppendResetBackgroundColor (output);
+            output.AppendAscii ($"{EscSeqUtils.CSI}49m");
         }
         else if (Force16Colors)
         {
-            output.Append (EscSeqUtils.CSI_SetBackgroundColor (attr.Background.GetAnsiColorCode ()));
+            output.AppendAscii (EscSeqUtils.CSI_SetBackgroundColor (attr.Background.GetAnsiColorCode ()));
         }
         else
         {
-            EscSeqUtils.CSI_AppendBackgroundColorRGB (output, attr.Background.R, attr.Background.G, attr.Background.B);
+            output.AppendAscii ($"{EscSeqUtils.CSI}48;2;{attr.Background.R};{attr.Background.G};{attr.Background.B}m");
         }
 
-        EscSeqUtils.CSI_AppendTextStyleChange (output, redrawTextStyle, attr.Style);
+        string styleChange = EscSeqUtils.CSI_BuildTextStyleChange (redrawTextStyle, attr.Style);
+
+        if (styleChange.Length > 0)
+        {
+            output.AppendAscii (styleChange);
+        }
     }
 
     /// <summary>
@@ -391,6 +401,23 @@ public abstract class OutputBase
     }
 
     /// <summary>
+    ///     PERF: Output pre-encoded UTF-8 bytes directly to the console.
+    ///     Bypasses StringBuilder → string → byte[] conversion in the hot path.
+    /// </summary>
+    /// <param name="output">UTF-8 encoded bytes to write.</param>
+    protected virtual void Write (ReadOnlySpan<byte> output)
+    {
+        if (_clearLastOutputPending)
+        {
+            _lastOutputStringBuilder.Clear ();
+            _clearLastOutputPending = false;
+        }
+
+        // Decode back to UTF-16 for GetLastOutput() (test/debug only, not hot path)
+        _lastOutputStringBuilder.Append (Encoding.UTF8.GetString (output));
+    }
+
+    /// <summary>
     ///     Builds ANSI escape sequences for the specified rectangular region of the buffer.
     /// </summary>
     /// <param name="buffer">The output buffer to build ANSI for.</param>
@@ -415,6 +442,9 @@ public abstract class OutputBase
         var redrawTextStyle = TextStyle.None;
         string? lastUrl = null;
 
+        // Use Utf8Buffer for cell rendering, then decode to StringBuilder at the end
+        Utf8Buffer utf8Output = new ();
+
         for (int row = startRow; row < endRow; row++)
         {
             for (int col = startCol; col < endCol; col++)
@@ -431,12 +461,12 @@ public abstract class OutputBase
                 {
                     if (lastUrl is { })
                     {
-                        output.Append (EscSeqUtils.OSC_EndHyperlink ());
+                        utf8Output.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
                     }
 
                     if (!string.IsNullOrEmpty (cellUrl))
                     {
-                        output.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
+                        utf8Output.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
                     }
 
                     lastUrl = cellUrl;
@@ -444,13 +474,13 @@ public abstract class OutputBase
 
                 Cell cell = buffer.Contents! [row, col];
                 int outputWidth = -1;
-                AppendCellAnsi (cell, output, ref lastAttr, ref redrawTextStyle, endCol, ref col, ref outputWidth);
+                AppendCellAnsi (cell, utf8Output, ref lastAttr, ref redrawTextStyle, endCol, ref col, ref outputWidth);
             }
 
             // Close any open hyperlink at end of row
             if (lastUrl is { })
             {
-                output.Append (EscSeqUtils.OSC_EndHyperlink ());
+                utf8Output.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
                 lastUrl = null;
             }
 
@@ -461,9 +491,12 @@ public abstract class OutputBase
             // ONLCR tty discipline, so a '\n' row break still recreates the screen correctly.
             if (addNewlines)
             {
-                output.Append ('\n');
+                utf8Output.AppendByte ((byte)'\n');
             }
         }
+
+        // Decode Utf8Buffer back to StringBuilder for ToAnsi() callers
+        output.Append (Encoding.UTF8.GetString (utf8Output.AsSpan ()));
     }
 
     /// <summary>
@@ -477,7 +510,7 @@ public abstract class OutputBase
     /// <param name="currentCol">The current column, updated for wide characters.</param>
     /// <param name="outputWidth">The current output width, updated for wide characters.</param>
     protected void AppendCellAnsi (Cell cell,
-                                   StringBuilder output,
+                                   Utf8Buffer output,
                                    ref Attribute? lastAttr,
                                    ref TextStyle redrawTextStyle,
                                    int maxCol,
@@ -494,7 +527,7 @@ public abstract class OutputBase
             redrawTextStyle = attribute.Value.Style;
         }
 
-        // Add the grapheme
+        // Add the grapheme (Utf8Buffer.Append auto-detects ASCII vs Unicode)
         string grapheme = cell.Grapheme;
         output.Append (grapheme);
         outputWidth++;
@@ -593,6 +626,9 @@ public abstract class OutputBase
         var redrawTextStyle = TextStyle.None;
         string? lastUrl = null;
 
+        // Use Utf8Buffer for cell rendering, then decode to StringBuilder at the end
+        Utf8Buffer utf8Output = new ();
+
         for (int row = startRow; row < endRow; row++)
         {
             for (int col = startCol; col < endCol; col++)
@@ -601,14 +637,14 @@ public abstract class OutputBase
                 {
                     if (lastUrl is { })
                     {
-                        output.Append (EscSeqUtils.OSC_EndHyperlink ());
+                        utf8Output.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
                         lastUrl = null;
                     }
 
                     continue;
                 }
 
-                output.Append (EscSeqUtils.CSI_SetCursorPosition (row + 1, col + 1));
+                utf8Output.Append (EscSeqUtils.CSI_SetCursorPosition (row + 1, col + 1));
                 lastAttr = null;
                 redrawTextStyle = TextStyle.None;
 
@@ -627,12 +663,12 @@ public abstract class OutputBase
                     {
                         if (lastUrl is { })
                         {
-                            output.Append (EscSeqUtils.OSC_EndHyperlink ());
+                            utf8Output.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
                         }
 
                         if (!string.IsNullOrEmpty (cellUrl))
                         {
-                            output.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
+                            utf8Output.Append (EscSeqUtils.OSC_StartHyperlink (cellUrl));
                         }
 
                         lastUrl = cellUrl;
@@ -640,16 +676,19 @@ public abstract class OutputBase
 
                     Cell cell = buffer.Contents! [row, col];
                     int outputWidth = -1;
-                    AppendCellAnsi (cell, output, ref lastAttr, ref redrawTextStyle, endCol, ref col, ref outputWidth);
+                    AppendCellAnsi (cell, utf8Output, ref lastAttr, ref redrawTextStyle, endCol, ref col, ref outputWidth);
                 }
             }
 
             if (lastUrl is { })
             {
-                output.Append (EscSeqUtils.OSC_EndHyperlink ());
+                utf8Output.AppendAscii (EscSeqUtils.OSC_EndHyperlink ());
                 lastUrl = null;
             }
         }
+
+        // Decode Utf8Buffer back to StringBuilder for ToAnsi() callers
+        output.Append (Encoding.UTF8.GetString (utf8Output.AsSpan ()));
     }
 
     private void ClearKittyRasterBlankCells (IOutputBuffer buffer)
@@ -1216,9 +1255,9 @@ public abstract class OutputBase
     ///     Writes buffered output to console, then clears the buffer and advances
     ///     <paramref name="lastCol"/> by <paramref name="outputWidth"/>.
     /// </summary>
-    private void WriteToConsole (StringBuilder output, ref int lastCol, ref int outputWidth)
+    private void WriteToConsole (Utf8Buffer output, ref int lastCol, ref int outputWidth)
     {
-        Write (output);
+        Write (output.AsSpan ());
 
         output.Clear ();
         lastCol += outputWidth;

--- a/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
+++ b/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
@@ -72,11 +72,10 @@ public sealed class Utf8Buffer
         if (allAscii)
         {
             AppendAscii (text);
+            return;
         }
-        else
-        {
-            Append (text.AsSpan ());
-        }
+
+        Append (text.AsSpan ());
     }
 
     /// <summary>
@@ -102,6 +101,44 @@ public sealed class Utf8Buffer
     {
         EnsureCapacity (1);
         _buffer [_length++] = b;
+    }
+
+    /// <summary>
+    ///     Appends an integer as ASCII digits directly (no string allocation).
+    /// </summary>
+    public void AppendInt (int value)
+    {
+        if (value == 0)
+        {
+            AppendByte ((byte)'0');
+            return;
+        }
+
+        if (value < 0)
+        {
+            AppendByte ((byte)'-');
+            value = -value;
+        }
+
+        int temp = value;
+        int digitCount = 0;
+
+        while (temp > 0)
+        {
+            digitCount++;
+            temp /= 10;
+        }
+
+        EnsureCapacity (digitCount);
+        int start = _length + digitCount;
+
+        while (value > 0)
+        {
+            _buffer [--start] = (byte)('0' + value % 10);
+            value /= 10;
+        }
+
+        _length += digitCount;
     }
 
     /// <summary>

--- a/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
+++ b/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
@@ -181,9 +181,6 @@ public sealed class Utf8Buffer
         // Guard against int overflow: if required size exceeds Array.MaxLength, throw instead of hanging.
         long required = (long)_length + additional;
 
-        // Guard against int overflow: if required size exceeds Array.MaxLength, throw instead of hanging.
-        long required = (long)_length + additional;
-
         if (required > Array.MaxLength)
         {
             throw new OutOfMemoryException ($"Utf8Buffer capacity {required} exceeds Array.MaxLength.");

--- a/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
+++ b/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
@@ -181,6 +181,9 @@ public sealed class Utf8Buffer
         // Guard against int overflow: if required size exceeds Array.MaxLength, throw instead of hanging.
         long required = (long)_length + additional;
 
+        // Guard against int overflow: if required size exceeds Array.MaxLength, throw instead of hanging.
+        long required = (long)_length + additional;
+
         if (required > Array.MaxLength)
         {
             throw new OutOfMemoryException ($"Utf8Buffer capacity {required} exceeds Array.MaxLength.");
@@ -188,6 +191,12 @@ public sealed class Utf8Buffer
 
         // Perform doubling in long to avoid int overflow, then cast back.
         long newSize = _buffer.Length;
+
+        // Guard against zero-length buffer: doubling zero stays zero (infinite loop).
+        if (newSize == 0)
+        {
+            newSize = 1;
+        }
 
         while (newSize < required)
         {

--- a/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
+++ b/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
@@ -178,13 +178,27 @@ public sealed class Utf8Buffer
             return;
         }
 
-        int newSize = _buffer.Length;
+        // Guard against int overflow: if required size exceeds Array.MaxLength, throw instead of hanging.
+        long required = (long)_length + additional;
 
-        while (newSize < _length + additional)
+        if (required > Array.MaxLength)
+        {
+            throw new OutOfMemoryException ($"Utf8Buffer capacity {required} exceeds Array.MaxLength.");
+        }
+
+        // Perform doubling in long to avoid int overflow, then cast back.
+        long newSize = _buffer.Length;
+
+        while (newSize < required)
         {
             newSize *= 2;
         }
 
-        Array.Resize (ref _buffer, newSize);
+        if (newSize > Array.MaxLength)
+        {
+            newSize = Array.MaxLength;
+        }
+
+        Array.Resize (ref _buffer, (int)newSize);
     }
 }

--- a/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
+++ b/Terminal.Gui/Drivers/Output/Utf8Buffer.cs
@@ -1,0 +1,153 @@
+using System.Text;
+
+namespace Terminal.Gui.Drivers;
+
+/// <summary>
+///     PERF: UTF-8 byte buffer — replaces StringBuilder in the output hot path.
+///     ANSI sequences (CSI/SGR/OSC) are pure ASCII and appended via fast path (no encoding).
+///     Unicode graphemes are UTF-8 encoded on append.
+///     Zero allocation in stable state (internal buffer grows as needed).
+/// </summary>
+public sealed class Utf8Buffer
+{
+    private byte [] _buffer = new byte [256];
+    private int _length;
+
+    /// <summary>Gets the number of bytes written.</summary>
+    public int Length => _length;
+
+    /// <summary>Resets the buffer for reuse without releasing the backing array.</summary>
+    public void Clear () => _length = 0;
+
+    /// <summary>Gets a read-only span over the written bytes.</summary>
+    public ReadOnlySpan<byte> AsSpan () => _buffer.AsSpan (0, _length);
+
+    /// <summary>
+    ///     Appends an ASCII string as raw bytes. Caller must ensure <paramref name="text"/> is pure ASCII.
+    ///     No UTF-8 encoding is performed — each char is truncated to byte directly.
+    /// </summary>
+    public void AppendAscii (string text)
+    {
+        int len = text.Length;
+        if (len == 0)
+        {
+            return;
+        }
+
+        EnsureCapacity (len);
+
+        for (int i = 0; i < len; i++)
+        {
+            _buffer [_length + i] = (byte)text [i];
+        }
+
+        _length += len;
+    }
+
+    /// <summary>
+    ///     Appends a string, auto-detecting ASCII vs Unicode.
+    ///     ASCII strings use a fast truncation path; Unicode strings are UTF-8 encoded.
+    /// </summary>
+    public void Append (string text)
+    {
+        int len = text.Length;
+        if (len == 0)
+        {
+            return;
+        }
+
+        // Fast check: if all chars < 0x80, use ASCII path (no encoding)
+        bool allAscii = true;
+
+        for (int i = 0; i < len; i++)
+        {
+            if (text [i] >= 0x80)
+            {
+                allAscii = false;
+
+                break;
+            }
+        }
+
+        if (allAscii)
+        {
+            AppendAscii (text);
+        }
+        else
+        {
+            Append (text.AsSpan ());
+        }
+    }
+
+    /// <summary>
+    ///     Appends a char span as UTF-8 encoded bytes.
+    /// </summary>
+    public void Append (ReadOnlySpan<char> text)
+    {
+        if (text.IsEmpty)
+        {
+            return;
+        }
+
+        int byteCount = Encoding.UTF8.GetByteCount (text);
+        EnsureCapacity (byteCount);
+        Encoding.UTF8.GetBytes (text, _buffer.AsSpan (_length));
+        _length += byteCount;
+    }
+
+    /// <summary>
+    ///     Appends a single ASCII byte directly.
+    /// </summary>
+    public void AppendByte (byte b)
+    {
+        EnsureCapacity (1);
+        _buffer [_length++] = b;
+    }
+
+    /// <summary>
+    ///     Appends the contents of another <see cref="Utf8Buffer"/>.
+    /// </summary>
+    public void Append (Utf8Buffer other)
+    {
+        if (other._length == 0)
+        {
+            return;
+        }
+
+        EnsureCapacity (other._length);
+        other._buffer.AsSpan (0, other._length).CopyTo (_buffer.AsSpan (_length));
+        _length += other._length;
+    }
+
+    /// <summary>
+    ///     Appends raw UTF-8 bytes directly (e.g. from another buffer or pre-encoded span).
+    /// </summary>
+    public void AppendBytes (ReadOnlySpan<byte> bytes)
+    {
+        if (bytes.IsEmpty)
+        {
+            return;
+        }
+
+        EnsureCapacity (bytes.Length);
+        bytes.CopyTo (_buffer.AsSpan (_length));
+        _length += bytes.Length;
+    }
+
+    private void EnsureCapacity (int additional)
+    {
+        if (_length + additional <= _buffer.Length)
+        {
+            return;
+        }
+
+        int newSize = _buffer.Length;
+
+        while (newSize < _length + additional)
+        {
+            newSize *= 2;
+        }
+
+        Array.Resize (ref _buffer, newSize);
+    }
+}

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -331,6 +331,12 @@ internal static class UnixIOHelper
                 return false;
             }
 
+            // Guard against out-of-range count to prevent native read beyond buffer bounds.
+            if (count < 0 || count > buffer.Length)
+            {
+                return false;
+            }
+
             return TryWriteAll (fd, buffer, count, write);
         }
         catch

--- a/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
+++ b/Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
@@ -305,7 +305,7 @@ internal static class UnixIOHelper
                 return false;
             }
 
-            return TryWriteAll (fd, buffer, write);
+            return TryWriteAll (fd, buffer, buffer.Length, write);
         }
         catch
         {
@@ -313,10 +313,36 @@ internal static class UnixIOHelper
         }
     }
 
-    internal static bool TryWriteAll (int fd, byte [] buffer, Func<int, byte [], int, int> writeFunc)
+    /// <summary>
+    ///     Writes <paramref name="count"/> bytes from <paramref name="buffer"/> to stdout.
+    ///     Avoids allocating a new array when the caller already has a reusable buffer.
+    /// </summary>
+    /// <param name="buffer">Buffer containing data to write.</param>
+    /// <param name="count">Number of bytes to write (starting from index 0).</param>
+    /// <returns>True if write was successful, false otherwise.</returns>
+    public static bool TryWriteStdout (byte [] buffer, int count)
+    {
+        try
+        {
+            int fd = TerminalDevice.OutputFd;
+
+            if (fd < 0)
+            {
+                return false;
+            }
+
+            return TryWriteAll (fd, buffer, count, write);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    internal static bool TryWriteAll (int fd, byte [] buffer, int count, Func<int, byte [], int, int> writeFunc)
     {
         int offset = 0;
-        int remaining = buffer.Length;
+        int remaining = count;
 
         while (remaining > 0)
         {

--- a/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
@@ -464,12 +464,12 @@ internal partial class WindowsOutput : OutputBase, IOutput
     }
 
     /// <inheritdoc/>
-    protected override void AppendOrWriteAttribute (StringBuilder output, Attribute attr, TextStyle redrawTextStyle)
+    protected override void AppendOrWriteAttribute (Utf8Buffer output, Attribute attr, TextStyle redrawTextStyle)
     {
         if (Force16Colors && IsLegacyConsole)
         {
             // Legacy Windows console doesn't support ANSI — use Win32 API directly
-            Write (output);
+            Write (output.AsSpan ());
             output.Clear ();
             var as16ColorInt = (ushort)((int)attr.Foreground.GetClosestNamedColor16 () | ((int)attr.Background.GetClosestNamedColor16 () << 4));
             SetConsoleTextAttribute (_screenBuffer, as16ColorInt);

--- a/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
+++ b/Terminal.Gui/Drivers/WindowsDriver/WindowsOutput.cs
@@ -90,6 +90,9 @@ internal partial class WindowsOutput : OutputBase, IOutput
     private readonly ConsoleColor _foreground;
     private readonly ConsoleColor _background;
 
+    // Reusable buffer for UTF-8 → UTF-16 decode in Write(ReadOnlySpan<byte>).
+    private char []? _utf16DecodeBuffer;
+
     public WindowsOutput ()
     {
         //Logging.Information ($"Creating {nameof (WindowsOutput)}");
@@ -460,6 +463,39 @@ internal partial class WindowsOutput : OutputBase, IOutput
                     throw;
                 }
             }
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Write (ReadOnlySpan<byte> output)
+    {
+        base.Write (output);
+
+        if (!IsAttachedToTerminal || output.IsEmpty)
+        {
+            return;
+        }
+
+        if (!OperatingSystem.IsWindows ())
+        {
+            return;
+        }
+
+        // Decode UTF-8 to UTF-16 using a reusable buffer, then write via WriteConsole.
+        int maxCharCount = Encoding.UTF8.GetMaxCharCount (output.Length);
+
+        if (_utf16DecodeBuffer is null || _utf16DecodeBuffer.Length < maxCharCount)
+        {
+            _utf16DecodeBuffer = new char [maxCharCount];
+        }
+
+        int charCount = Encoding.UTF8.GetChars (output, _utf16DecodeBuffer);
+        ReadOnlySpan<char> charSpan = _utf16DecodeBuffer.AsSpan (0, charCount);
+        nint handle = !IsLegacyConsole ? _outputHandle : _screenBuffer;
+
+        if (!WriteConsole (handle, charSpan, (uint)charCount, out _, nint.Zero))
+        {
+            // Don't throw in unit tests
         }
     }
 

--- a/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTOutputHelper.cs
+++ b/Terminal.Gui/Drivers/WindowsHelpers/WindowsVTOutputHelper.cs
@@ -42,6 +42,11 @@ internal sealed class WindowsVTOutputHelper : IDisposable
     private uint _originalConsoleMode;
     private bool _disposed;
 
+    // PERF: Reusable buffers to avoid per-write allocations (string + byte[]).
+    // Grows as needed; stable-state zero-allocation writes.
+    private char []? _charBuffer;
+    private byte []? _byteBuffer;
+
     /// <summary>
     ///     Gets whether VTS output mode was successfully enabled.
     /// </summary>
@@ -169,10 +174,53 @@ internal sealed class WindowsVTOutputHelper : IDisposable
 
     public void Write (StringBuilder output)
     {
-        // Convert StringBuilder to string and then to byte array
-        byte [] byteArray = Encoding.UTF8.GetBytes (output.ToString ());
+        int charLen = output.Length;
+        if (charLen == 0) return;
 
-        WriteFile (OutputHandle, byteArray, (uint)byteArray.Length, out _, nint.Zero);
+        // Ensure char buffer is large enough
+        if (_charBuffer is null || _charBuffer.Length < charLen)
+        {
+            _charBuffer = new char [charLen];
+        }
+
+        // Copy StringBuilder contents to reusable char[] — avoids allocating a string
+        output.CopyTo (0, _charBuffer, 0, charLen);
+
+        // Calculate UTF-8 byte count
+        int byteLen = Encoding.UTF8.GetByteCount (_charBuffer, 0, charLen);
+
+        // Ensure byte buffer is large enough
+        if (_byteBuffer is null || _byteBuffer.Length < byteLen)
+        {
+            _byteBuffer = new byte [byteLen];
+        }
+
+        // Encode to reusable byte[] — avoids allocating a new byte[] each call
+        Encoding.UTF8.GetBytes (_charBuffer, 0, charLen, _byteBuffer, 0);
+
+        WriteFile (OutputHandle, _byteBuffer, (uint)byteLen, out _, nint.Zero);
+    }
+
+    /// <summary>
+    ///     PERF: Writes pre-encoded UTF-8 bytes directly to the console via WriteFile.
+    ///     Zero conversion — bytes are written as-is.
+    /// </summary>
+    public void Write (ReadOnlySpan<byte> utf8)
+    {
+        if (utf8.IsEmpty)
+        {
+            return;
+        }
+
+        // Ensure byte buffer is large enough
+        if (_byteBuffer is null || _byteBuffer.Length < utf8.Length)
+        {
+            _byteBuffer = new byte [utf8.Length];
+        }
+
+        utf8.CopyTo (_byteBuffer);
+
+        WriteFile (OutputHandle, _byteBuffer, (uint)utf8.Length, out _, nint.Zero);
     }
 
     /// <summary>

--- a/Terminal.Gui/ViewBase/View.Drawing.cs
+++ b/Terminal.Gui/ViewBase/View.Drawing.cs
@@ -807,7 +807,7 @@ public partial class View // Drawing APIs
     /// <remarks>
     ///     <para>
     ///         The cull path skips <see cref="Draw(DrawContext?)"/>, hence <see cref="DoDrawComplete"/>, which
-    ///         repopulates the <see cref="CachedDrawnRegion"/> that <see cref="GetViewsUnderLocation"/> consults
+    ///         repopulates the <see cref="CachedDrawnRegion"/> that <see cref="GetViewsUnderLocation(in Point, ViewportSettingsFlags)"/> consults
     ///         for <see cref="ViewportSettingsFlags.TransparentMouse"/> layers. A view's own
     ///         <see cref="CachedDrawnRegion"/> is invalidated by <see cref="SetNeedsDraw()"/>, so a
     ///         <see cref="ViewportSettingsFlags.TransparentMouse"/> view that is culled would be left with a null

--- a/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/OutputBaseTests.cs
@@ -2047,6 +2047,8 @@ public class OutputBaseTests
         }
 
         protected override void Write (StringBuilder output) => Writes++;
+
+        protected override void Write (ReadOnlySpan<byte> output) => Writes++;
     }
 
     // Copilot - Claude Sonnet 4.6

--- a/Tests/UnitTestsParallelizable/Drivers/Output/Utf8BufferTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/Output/Utf8BufferTests.cs
@@ -1,0 +1,314 @@
+using System.Text;
+
+namespace DriverTests.Output;
+
+/// <summary>
+///     Focused tests for <see cref="Utf8Buffer"/> encoding, reuse, and capacity behavior.
+/// </summary>
+[Collection ("Driver Tests")]
+public class Utf8BufferTests
+{
+    [Fact]
+    public void AppendAscii_EmptyString_DoesNothing ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendAscii (string.Empty);
+
+        Assert.Equal (0, buffer.Length);
+    }
+
+    [Fact]
+    public void AppendAscii_PureAscii_StoresRawBytes ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendAscii ("Hello");
+
+        Assert.Equal (5, buffer.Length);
+        Assert.Equal ("Hello", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void AppendAscii_CsiEscapeSequence_StoresExactBytes ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendAscii ("\x1b[38;2;1;2;3m");
+
+        ReadOnlySpan<byte> span = buffer.AsSpan ();
+        Assert.Equal ((byte)0x1b, span [0]);
+        Assert.Equal ((byte)'[', span [1]);
+        Assert.Equal ("38;2;1;2;3m", Encoding.UTF8.GetString (span [2..]));
+    }
+
+    [Fact]
+    public void Append_AsciiString_UsesFastPath ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.Append ("ABC");
+
+        Assert.Equal (3, buffer.Length);
+        Assert.Equal ("ABC", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void Append_MultibyteUtf8_EncodesCorrectly ()
+    {
+        Utf8Buffer buffer = new ();
+        // "héllo" — 'é' is U+00E9, 2 bytes in UTF-8 (0xC3 0xA9)
+        buffer.Append ("héllo");
+
+        Assert.Equal (6, buffer.Length);
+        Assert.Equal ("héllo", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void Append_CjkCharacters_EncodesMultibyte ()
+    {
+        Utf8Buffer buffer = new ();
+        // Chinese "你好" — each char is 3 bytes in UTF-8
+        buffer.Append ("你好");
+
+        Assert.Equal (6, buffer.Length);
+        Assert.Equal ("你好", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void Append_SurrogatePair_Emoji_EncodesAs4Bytes ()
+    {
+        Utf8Buffer buffer = new ();
+        // U+1F600 (😀) is a surrogate pair in UTF-16, 4 bytes in UTF-8
+        buffer.Append ("😀");
+
+        Assert.Equal (4, buffer.Length);
+        Assert.Equal ("😀", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void Append_MixedAsciiAndUnicode_EncodesCorrectly ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.Append ("A你B😀C");
+
+        Assert.Equal ("A你B😀C", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void Append_EmptyString_DoesNothing ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.Append (string.Empty);
+
+        Assert.Equal (0, buffer.Length);
+    }
+
+    [Fact]
+    public void Append_CharSpan_Empty_DoesNothing ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.Append (ReadOnlySpan<char>.Empty);
+
+        Assert.Equal (0, buffer.Length);
+    }
+
+    [Fact]
+    public void AppendByte_SingleByte_StoresAtCorrectPosition ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendByte (0x41);
+        buffer.AppendByte (0x42);
+
+        Assert.Equal (2, buffer.Length);
+        Assert.Equal ("AB", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void AppendInt_Zero_AppendsDigitZero ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendInt (0);
+
+        Assert.Equal ("0", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void AppendInt_Positive_AppendsDigits ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendInt (255);
+
+        Assert.Equal ("255", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void AppendInt_Negative_AppendsMinusAndDigits ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendInt (-42);
+
+        Assert.Equal ("-42", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Theory]
+    [InlineData (1)]
+    [InlineData (9)]
+    [InlineData (10)]
+    [InlineData (99)]
+    [InlineData (100)]
+    [InlineData (999)]
+    [InlineData (1000)]
+    [InlineData (int.MaxValue)]
+    public void AppendInt_VariousValues_MatchesToString (int value)
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendInt (value);
+
+        Assert.Equal (value.ToString (), Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void AppendBytes_RawBytes_StoresExactContent ()
+    {
+        Utf8Buffer buffer = new ();
+        byte [] data = [0x1b, (byte)'[', (byte)'m'];
+
+        buffer.AppendBytes (data);
+
+        Assert.Equal (3, buffer.Length);
+        Assert.Equal ("\x1b[m", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void AppendBytes_EmptySpan_DoesNothing ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendBytes (ReadOnlySpan<byte>.Empty);
+
+        Assert.Equal (0, buffer.Length);
+    }
+
+    [Fact]
+    public void Append_OtherBuffer_CopiesContent ()
+    {
+        Utf8Buffer source = new ();
+        source.AppendAscii ("Hello");
+        source.Append ("世界");
+
+        Utf8Buffer dest = new ();
+        dest.Append (source);
+
+        Assert.Equal (source.Length, dest.Length);
+        Assert.Equal (Encoding.UTF8.GetString (source.AsSpan ()), Encoding.UTF8.GetString (dest.AsSpan ()));
+    }
+
+    [Fact]
+    public void Append_OtherEmptyBuffer_DoesNothing ()
+    {
+        Utf8Buffer source = new ();
+        Utf8Buffer dest = new ();
+        dest.Append (source);
+
+        Assert.Equal (0, dest.Length);
+    }
+
+    [Fact]
+    public void Clear_ResetsLength_KeepsCapacity ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendAscii ("Hello");
+
+        buffer.Clear ();
+
+        Assert.Equal (0, buffer.Length);
+        Assert.True (buffer.AsSpan ().IsEmpty);
+    }
+
+    [Fact]
+    public void Clear_ThenAppend_WorksCorrectly ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendAscii ("First");
+        buffer.Clear ();
+        buffer.AppendAscii ("Second");
+
+        Assert.Equal (6, buffer.Length);
+        Assert.Equal ("Second", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void AsSpan_ReturnsWrittenBytesOnly ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendAscii ("AB");
+
+        ReadOnlySpan<byte> span = buffer.AsSpan ();
+
+        Assert.Equal (2, span.Length);
+        Assert.Equal ((byte)'A', span [0]);
+        Assert.Equal ((byte)'B', span [1]);
+    }
+
+    [Fact]
+    public void Capacity_GrowsAutomatically_WhenExceeded ()
+    {
+        Utf8Buffer buffer = new ();
+
+        // Append a large string that exceeds the initial 256-byte capacity.
+        string large = new ('x', 1000);
+        buffer.Append (large);
+
+        Assert.Equal (1000, buffer.Length);
+        Assert.Equal (large, Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void Capacity_GrowsForMultibyteContent ()
+    {
+        Utf8Buffer buffer = new ();
+
+        // Append 500 CJK chars (3 bytes each = 1500 bytes, exceeds initial 256).
+        string large = new ('你', 500);
+        buffer.Append (large);
+
+        Assert.Equal (1500, buffer.Length);
+        Assert.Equal (large, Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void MultipleAppends_AccumulateCorrectly ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.AppendAscii ("\x1b[");
+        buffer.AppendAscii ("38;2;");
+        buffer.AppendInt (255);
+        buffer.AppendByte ((byte)';');
+        buffer.AppendInt (128);
+        buffer.AppendByte ((byte)';');
+        buffer.AppendInt (0);
+        buffer.AppendByte ((byte)'m');
+        buffer.Append ("X");
+
+        Assert.Equal ("\x1b[38;2;255;128;0mX", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+
+    [Fact]
+    public void ReuseAfterClear_DoesNotCorruptData ()
+    {
+        Utf8Buffer buffer = new ();
+
+        for (int i = 0; i < 10; i++)
+        {
+            buffer.Clear ();
+            buffer.AppendAscii ($"Iter{i}");
+            Assert.Equal ($"Iter{i}", Encoding.UTF8.GetString (buffer.AsSpan ()));
+        }
+    }
+
+    [Fact]
+    public void Append_CharSpan_Unicode_EncodesCorrectly ()
+    {
+        Utf8Buffer buffer = new ();
+        buffer.Append ("héllo".AsSpan ());
+
+        Assert.Equal (6, buffer.Length);
+        Assert.Equal ("héllo", Encoding.UTF8.GetString (buffer.AsSpan ()));
+    }
+}

--- a/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTests.cs
+++ b/Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTests.cs
@@ -23,6 +23,7 @@ public class UnixIOHelperTests
 
         bool result = UnixIOHelper.TryWriteAll (1,
                                                 payload,
+                                                payload.Length,
                                                 (_, _, _) =>
                                                 {
                                                     calls++;
@@ -43,6 +44,7 @@ public class UnixIOHelperTests
 
         bool result = UnixIOHelper.TryWriteAll (1,
                                                 payload,
+                                                payload.Length,
                                                 (_, buffer, count) =>
                                                 {
                                                     counts.Add (count);


### PR DESCRIPTION
## Summary

- 	ry/finally protects _batchMode reset even if ase.Write throws
- Unix path reuses yte[] for zero-allocation writes (WriteUnix)
- EnsureCapacity guards against zero-length buffer infinite loop
- catch adds Trace diagnostics for production

## Files Changed (4)
- Terminal.Gui/Drivers/AnsiDriver/AnsiOutput.cs
- Terminal.Gui/Drivers/Output/Utf8Buffer.cs
- Terminal.Gui/Drivers/UnixHelpers/UnixIOHelper.cs
- Tests/UnitTestsParallelizable/Drivers/UnixIOHelperTests.cs

## Depends on
- #5650 (perf: UTF-8 batch mode + Utf8Buffer) — must merge first

## CI
All checks passed on fork (liuqihonggit/Terminal.Gui#4).