### PR TITLE
Fixes #5652. Execute timeout callbacks outside the queue lock

### DIFF
--- a/Terminal.Gui/App/IApplication.cs
+++ b/Terminal.Gui/App/IApplication.cs
@@ -790,11 +790,15 @@ public interface IApplication : IDisposable
     /// </remarks>
     object? AddTimeout (TimeSpan time, Func<bool> callback);
 
-    /// <summary>Removes a previously scheduled timeout.</summary>
+    /// <summary>Cancels all timeout occurrences associated with a previously returned token.</summary>
     /// <param name="token">The token returned by <see cref="AddTimeout"/>.</param>
+    /// <remarks>
+    ///     A matching callback that is already executing is not interrupted, but it will not be rescheduled if it returns
+    ///     <see langword="true"/>.
+    /// </remarks>
     /// <returns>
-    ///     <see langword="true"/> if the timeout is successfully removed; otherwise, <see langword="false"/>.
-    ///     This method also returns <see langword="false"/> if the timeout is not found.
+    ///     <see langword="true"/> if at least one queued occurrence was removed or a cancellation request was recorded for
+    ///     at least one active occurrence; otherwise, <see langword="false"/>.
     /// </returns>
     bool RemoveTimeout (object token);
 

--- a/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
+++ b/Terminal.Gui/App/MainLoop/MainLoopSyncContext.cs
@@ -27,6 +27,10 @@ internal sealed class MainLoopSyncContext : SynchronizationContext
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    ///     A call from outside the main-loop thread blocks until the main loop executes the callback. As with other
+    ///     synchronous UI dispatch APIs, this can deadlock if the main-loop thread is waiting for the calling thread.
+    /// </remarks>
     public override void Send (SendOrPostCallback d, object? state)
     {
         ArgumentNullException.ThrowIfNull (d);

--- a/Terminal.Gui/App/Timeout/ITimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/ITimedEvents.cs
@@ -18,29 +18,53 @@ public interface ITimedEvents
     object Add (TimeSpan time, Func<bool> callback);
 
     /// <inheritdoc cref="Add(System.TimeSpan,System.Func{bool})"/>
+    /// <remarks>
+    ///     Adding the same <see cref="Timeout"/> instance more than once creates multiple occurrences that share one
+    ///     cancellation token. Calling <see cref="Remove"/> with that token cancels all matching occurrences that precede
+    ///     the removal operation's synchronization point.
+    /// </remarks>
     object Add (Timeout timeout);
 
     /// <summary>
     ///     Invoked when a new timeout is added. To be used in the case when
     ///     <see cref="IApplication.StopAfterFirstIteration"/> is <see langword="true"/>.
     /// </summary>
+    /// <remarks>
+    ///     The event is raised after the timeout is added and after the timeout queue lock is released. A concurrent
+    ///     <see cref="RunTimers"/> call can execute a due timeout before its <see cref="Added"/> handler runs.
+    /// </remarks>
     event EventHandler<TimeoutEventArgs>? Added;
 
     /// <summary>
-    ///     Removes a previously scheduled timeout.
+    ///     Cancels all timeout occurrences associated with a previously returned token.
     /// </summary>
     /// <remarks>
-    ///     The token parameter is the value returned by <see cref="Add(TimeSpan, Func{bool})"/> or <see cref="Add(Timeout)"/>.
+    ///     <para>
+    ///         The token parameter is the value returned by <see cref="Add(TimeSpan, Func{bool})"/> or
+    ///         <see cref="Add(Timeout)"/>. All matching queued occurrences are removed.
+    ///     </para>
+    ///     <para>
+    ///         A matching callback that is already executing is not interrupted, but it will not be rescheduled if it
+    ///         returns <see langword="true"/>. Occurrences registered after the cancellation takes effect are not affected,
+    ///         including occurrences created by adding the same <see cref="Timeout"/> instance again. A concurrent
+    ///         <see cref="Add(TimeSpan, Func{bool})"/> or <see cref="Add(Timeout)"/> call can be ordered before or after the
+    ///         cancellation.
+    ///     </para>
     /// </remarks>
     /// <returns>
-    ///     <see langword="true"/> if the timeout is successfully removed; otherwise, <see langword="false"/>.
-    ///     This method also returns <see langword="false"/> if the timeout is not found.
+    ///     <see langword="true"/> if at least one queued occurrence was removed or a cancellation request was recorded for
+    ///     at least one active occurrence; otherwise, <see langword="false"/>.
     /// </returns>
     bool Remove (object token);
 
     /// <summary>
-    ///     Runs all timeouts that are due.
+    ///     Runs timeouts that are due.
     /// </summary>
+    /// <remarks>
+    ///     Timeout callbacks are serialized. A nested call on the active runner thread is supported. A call from a
+    ///     competing thread returns without running callbacks; remaining due timeouts are processed by a later successful
+    ///     call. A callback exception propagates directly from the call that executes it and ends that timer pass.
+    /// </remarks>
     void RunTimers ();
 
     /// <summary>
@@ -50,12 +74,23 @@ public interface ITimedEvents
     SortedList<long, Timeout> Timeouts { get; }
 
     /// <summary>
-    ///     Gets the timeout for the specified event.
+    ///     Gets the configured interval for a queued timeout occurrence associated with the specified token.
     /// </summary>
     /// <param name="token">The token of the event.</param>
-    /// <returns>The <see cref="TimeSpan"/> for the event, or <see lang="null"/> if the event is not found.</returns>
+    /// <returns>
+    ///     The <see cref="TimeSpan"/> for a queued occurrence, or <see langword="null"/> if no queued occurrence is found.
+    ///     A callback can be actively executing when this method returns <see langword="null"/>; use <see cref="Remove"/>
+    ///     to prevent an active repeating callback from rescheduling.
+    /// </returns>
     TimeSpan? GetTimeout (object token);
 
     /// <summary>Stops and removes all timed events.</summary>
+    /// <remarks>
+    ///     Removes all queued timeout occurrences and prevents callbacks that are active when this method is called from
+    ///     rescheduling. It does not interrupt callbacks already executing. Timeouts added after the cancellation takes
+    ///     effect are unaffected, including a reused <see cref="Timeout"/> instance. A concurrent
+    ///     <see cref="Add(TimeSpan, Func{bool})"/> or <see cref="Add(Timeout)"/> call can be ordered before or after the
+    ///     cancellation.
+    /// </remarks>
     void StopAll ();
 }

--- a/Terminal.Gui/App/Timeout/ITimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/ITimedEvents.cs
@@ -34,8 +34,15 @@ public interface ITimedEvents
     ///     <see cref="IApplication.StopAfterFirstIteration"/> is <see langword="true"/>.
     /// </summary>
     /// <remarks>
-    ///     The event is raised after the timeout is added and after the timeout queue lock is released. A concurrent
-    ///     <see cref="RunTimers"/> call can execute a due timeout before its <see cref="Added"/> handler runs.
+    ///     <para>
+    ///         The event is raised after the timeout is added and after the timeout queue lock is released. A concurrent
+    ///         <see cref="RunTimers"/> call can execute a due timeout before its <see cref="Added"/> handler runs.
+    ///     </para>
+    ///     <para>
+    ///         A handler exception propagates to whatever caused the timeout to be scheduled. For a repeating timeout that
+    ///         is being rescheduled, that is the <see cref="RunTimers"/> call, and it ends that timer pass. The timeout
+    ///         remains scheduled, so a handler that throws on every reschedule ends every subsequent pass as well.
+    ///     </para>
     /// </remarks>
     event EventHandler<TimeoutEventArgs>? Added;
 

--- a/Terminal.Gui/App/Timeout/ITimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/ITimedEvents.cs
@@ -67,10 +67,10 @@ public interface ITimedEvents
     /// <remarks>
     ///     Timeout callbacks are serialized. A nested call on the active runner thread is supported. A call from a
     ///     competing thread returns without running callbacks; remaining due timeouts are processed by a later successful
-    ///     call. Each pass executes at most the number of callbacks that were due when it started, so a repeating callback
-    ///     that reschedules as already due is deferred to a later pass rather than starving the main loop. Concurrent queue
-    ///     changes can alter which due occurrences consume that budget. A callback exception propagates directly from the
-    ///     call that executes it and ends that timer pass.
+    ///     call. Each pass executes only queue occurrences that were due when it started. An occurrence added or rescheduled
+    ///     after the pass starts is deferred to a later pass, preventing an immediately repeating callback from starving
+    ///     already-due peers. A callback exception propagates directly from the call that executes it and ends that timer
+    ///     pass.
     /// </remarks>
     void RunTimers ();
 

--- a/Terminal.Gui/App/Timeout/ITimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/ITimedEvents.cs
@@ -15,6 +15,7 @@ public interface ITimedEvents
     ///     returned value is a
     ///     token that can be used to stop the timeout by calling <see cref="Remove"/>.
     /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="callback"/> is <see langword="null"/>.</exception>
     object Add (TimeSpan time, Func<bool> callback);
 
     /// <inheritdoc cref="Add(System.TimeSpan,System.Func{bool})"/>
@@ -23,6 +24,9 @@ public interface ITimedEvents
     ///     cancellation token. Calling <see cref="Remove"/> with that token cancels all matching occurrences that precede
     ///     the removal operation's synchronization point.
     /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="timeout"/> or its <see cref="Timeout.Callback"/> is <see langword="null"/>.
+    /// </exception>
     object Add (Timeout timeout);
 
     /// <summary>
@@ -63,13 +67,16 @@ public interface ITimedEvents
     /// <remarks>
     ///     Timeout callbacks are serialized. A nested call on the active runner thread is supported. A call from a
     ///     competing thread returns without running callbacks; remaining due timeouts are processed by a later successful
-    ///     call. A callback exception propagates directly from the call that executes it and ends that timer pass.
+    ///     call. Each pass executes at most the number of callbacks that were due when it started, so a repeating callback
+    ///     that reschedules as already due is deferred to a later pass rather than starving the main loop. Concurrent queue
+    ///     changes can alter which due occurrences consume that budget. A callback exception propagates directly from the
+    ///     call that executes it and ends that timer pass.
     /// </remarks>
     void RunTimers ();
 
     /// <summary>
-    ///     Returns the next planned execution time (key - UTC ticks)
-    ///     for each timeout that is not actively executing.
+    ///     Returns a snapshot containing the next planned execution timestamp, in 100-nanosecond units, for each timeout
+    ///     that is not actively executing. Mutating the returned list does not change the scheduled timeouts.
     /// </summary>
     SortedList<long, Timeout> Timeouts { get; }
 

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -40,8 +40,7 @@ namespace Terminal.Gui.App;
 public class TimedEvents : ITimedEvents
 {
     internal SortedList<long, Timeout> _timeouts = new ();
-    private readonly Dictionary<Timeout, int> _activeTimeouts = new (ReferenceEqualityComparer.Instance);
-    private readonly Dictionary<Timeout, int> _cancelledTimeouts = new (ReferenceEqualityComparer.Instance);
+    private readonly List<ActiveTimeoutOccurrence> _activeTimeoutOccurrences = [];
     private readonly object _runTimersLockToken = new ();
     private readonly object _timeoutsLockToken = new ();
     private readonly ITimeProvider? _timeProvider;
@@ -168,21 +167,19 @@ public class TimedEvents : ITimedEvents
                 return true;
             }
 
-            if (!_activeTimeouts.TryGetValue (timeout, out int activeCount))
+            foreach (ActiveTimeoutOccurrence occurrence in _activeTimeoutOccurrences)
             {
-                return false;
+                if (!ReferenceEquals (occurrence.Timeout, timeout) || occurrence.IsCancelled)
+                {
+                    continue;
+                }
+
+                occurrence.IsCancelled = true;
+
+                return true;
             }
 
-            _cancelledTimeouts.TryGetValue (timeout, out int cancelledCount);
-
-            if (cancelledCount >= activeCount)
-            {
-                return false;
-            }
-
-            _cancelledTimeouts [timeout] = cancelledCount + 1;
-
-            return true;
+            return false;
         }
     }
 
@@ -303,7 +300,7 @@ public class TimedEvents : ITimedEvents
         // Process due timeouts one at a time, without blocking the entire queue
         while (true)
         {
-            Timeout timeoutToExecute;
+            ActiveTimeoutOccurrence occurrence;
 
             // Find the next due timeout
             lock (_timeoutsLockToken)
@@ -325,10 +322,10 @@ public class TimedEvents : ITimedEvents
                 }
 
                 // This timeout is due - remove it from the queue
-                timeoutToExecute = _timeouts.Values [0];
+                Timeout timeoutToExecute = _timeouts.Values [0];
                 _timeouts.RemoveAt (0);
-                _activeTimeouts.TryGetValue (timeoutToExecute, out int activeCount);
-                _activeTimeouts [timeoutToExecute] = activeCount + 1;
+                occurrence = new (timeoutToExecute);
+                _activeTimeoutOccurrences.Add (occurrence);
             }
 
             // Execute the callback outside the lock
@@ -337,59 +334,33 @@ public class TimedEvents : ITimedEvents
 
             try
             {
-                repeat = timeoutToExecute.Callback! ();
+                repeat = occurrence.Timeout.Callback! ();
             }
             finally
             {
-                CompleteTimeout (timeoutToExecute, repeat);
+                CompleteTimeout (occurrence, repeat);
             }
         }
     }
 
-    private void CompleteTimeout (Timeout timeout, bool repeat)
+    private void CompleteTimeout (ActiveTimeoutOccurrence occurrence, bool repeat)
     {
         long k;
 
         lock (_timeoutsLockToken)
         {
-            int activeCount = _activeTimeouts [timeout];
-            int remainingActiveCount = activeCount - 1;
+            bool removed = _activeTimeoutOccurrences.Remove (occurrence);
+            Debug.Assert (removed);
 
-            if (remainingActiveCount == 0)
-            {
-                _activeTimeouts.Remove (timeout);
-            }
-            else
-            {
-                _activeTimeouts [timeout] = remainingActiveCount;
-            }
-
-            _cancelledTimeouts.TryGetValue (timeout, out int cancelledCount);
-            bool cancelled = repeat && cancelledCount > 0;
-
-            if (cancelled && cancelledCount == 1)
-            {
-                _cancelledTimeouts.Remove (timeout);
-            }
-            else if (cancelled && cancelledCount > 1)
-            {
-                _cancelledTimeouts [timeout] = cancelledCount - 1;
-            }
-
-            if (remainingActiveCount == 0)
-            {
-                _cancelledTimeouts.Remove (timeout);
-            }
-
-            if (!repeat || cancelled)
+            if (!repeat || occurrence.IsCancelled)
             {
                 return;
             }
 
-            k = AddTimeoutCore (timeout.Span, timeout);
+            k = AddTimeoutCore (occurrence.Timeout.Span, occurrence.Timeout);
         }
 
-        Added?.Invoke (this, new (timeout, k));
+        Added?.Invoke (this, new (occurrence.Timeout, k));
     }
 
     /// <inheritdoc/>
@@ -399,10 +370,22 @@ public class TimedEvents : ITimedEvents
         {
             _timeouts.Clear ();
 
-            foreach (KeyValuePair<Timeout, int> activeTimeout in _activeTimeouts)
+            foreach (ActiveTimeoutOccurrence occurrence in _activeTimeoutOccurrences)
             {
-                _cancelledTimeouts [activeTimeout.Key] = activeTimeout.Value;
+                occurrence.IsCancelled = true;
             }
         }
+    }
+
+    private sealed class ActiveTimeoutOccurrence
+    {
+        public ActiveTimeoutOccurrence (Timeout timeout)
+        {
+            Timeout = timeout;
+        }
+
+        public bool IsCancelled { get; set; }
+
+        public Timeout Timeout { get; }
     }
 }

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -30,8 +30,9 @@ namespace Terminal.Gui.App;
 ///     <para>
 ///         <see cref="Add(TimeSpan, Func{bool})"/>, <see cref="Add(Timeout)"/>, <see cref="Remove"/>,
 ///         <see cref="StopAll"/>, <see cref="GetTimeout"/>, <see cref="CheckTimers"/>, and <see cref="RunTimers"/> are
-///         safe to call concurrently from any thread. Callbacks are invoked outside the timeout queue lock, so a
-///         callback can schedule or cancel timeouts without deadlocking.
+///         safe to call concurrently from any thread. Timeout callbacks, <see cref="Timeout.Span"/> access,
+///         <see cref="Added"/> handlers, and time-provider reads occur outside the timeout queue lock, so user code can
+///         schedule or cancel timeouts without deadlocking.
 ///     </para>
 ///     <para>
 ///         <see cref="Timeouts"/> returns a snapshot so the queue can be inspected safely while another thread schedules
@@ -266,38 +267,45 @@ public class TimedEvents : ITimedEvents
             return null;
         }
 
+        var found = false;
+
         lock (_timeoutsLockToken)
         {
             foreach (Timeout queuedTimeout in _timeouts.Values)
             {
-                if (ReferenceEquals (queuedTimeout, timeout))
+                if (!ReferenceEquals (queuedTimeout, timeout))
                 {
-                    return timeout.Span;
+                    continue;
                 }
-            }
 
-            return null;
+                found = true;
+
+                break;
+            }
         }
+
+        return found ? timeout.Span : null;
     }
 
     private void AddTimeout (TimeSpan time, Timeout timeout)
     {
+        long timestampTicks = GetTimestampTicks ();
         long k;
 
         lock (_timeoutsLockToken)
         {
-            k = AddTimeoutCore (time, timeout);
+            k = AddTimeoutCore (timestampTicks, time, timeout);
         }
 
         Added?.Invoke (this, new (timeout, k));
     }
 
-    private long AddTimeoutCore (TimeSpan time, Timeout timeout)
+    private long AddTimeoutCore (long timestampTicks, TimeSpan time, Timeout timeout)
     {
         // Caller must hold _timeoutsLockToken.
         Debug.Assert (Monitor.IsEntered (_timeoutsLockToken));
 
-        long k = GetTimestampTicks () + time.Ticks;
+        long k = timestampTicks + time.Ticks;
 
         // if user wants to run as soon as possible set timer such that it expires right away (no race conditions)
         if (time == TimeSpan.Zero)
@@ -335,14 +343,14 @@ public class TimedEvents : ITimedEvents
 
     private void RunTimersImpl ()
     {
-        long passStart;
         long occurrenceIdCutoff;
 
         lock (_timeoutsLockToken)
         {
-            passStart = GetTimestampTicks ();
             occurrenceIdCutoff = _nextTimeoutOccurrenceId;
         }
+
+        long passStart = GetTimestampTicks ();
 
         // Execute only queue occurrences that were due when this pass started. A repeating timeout with a zero or
         // negative span reschedules as already due, but receives a new occurrence ID and is deferred to a later pass.
@@ -423,6 +431,51 @@ public class TimedEvents : ITimedEvents
 
     private void CompleteTimeout (ActiveTimeoutOccurrence occurrence, bool repeat)
     {
+        if (!repeat || !CanReschedule (occurrence))
+        {
+            CompleteTimeoutCore (occurrence, false, default, 0);
+
+            return;
+        }
+
+        TimeSpan repeatInterval = default;
+        long timestampTicks = 0;
+        var rescheduleInputsRead = false;
+
+        try
+        {
+            repeatInterval = occurrence.Timeout.Span;
+            timestampTicks = GetTimestampTicks ();
+            rescheduleInputsRead = true;
+        }
+        finally
+        {
+            // Span and the time provider are user-overridable. Read them without the queue lock, then revalidate the
+            // occurrence in CompleteTimeoutCore before enqueueing it. The finally also releases active-state bookkeeping
+            // if either read throws.
+            CompleteTimeoutCore (occurrence, rescheduleInputsRead, repeatInterval, timestampTicks);
+        }
+    }
+
+    private bool CanReschedule (ActiveTimeoutOccurrence occurrence)
+    {
+        lock (_timeoutsLockToken)
+        {
+            bool found = _activeTimeoutStates.TryGetValue (occurrence.Timeout, out ActiveTimeoutState state);
+            Debug.Assert (found);
+
+            return found
+                   && occurrence.StopAllEpoch == _stopAllEpoch
+                   && occurrence.RemovalGeneration == state.RemovalGeneration;
+        }
+    }
+
+    private void CompleteTimeoutCore (
+        ActiveTimeoutOccurrence occurrence,
+        bool repeat,
+        TimeSpan repeatInterval,
+        long timestampTicks)
+    {
         long k;
 
         lock (_timeoutsLockToken)
@@ -459,7 +512,7 @@ public class TimedEvents : ITimedEvents
                 return;
             }
 
-            k = AddTimeoutCore (occurrence.Timeout.Span, occurrence.Timeout);
+            k = AddTimeoutCore (timestampTicks, repeatInterval, occurrence.Timeout);
         }
 
         Added?.Invoke (this, new (occurrence.Timeout, k));

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -382,6 +382,8 @@ public class TimedEvents : ITimedEvents
             // Execute the callback outside the lock
             // This allows nested RunTimers() calls to access the timeout queue
             bool repeat = false;
+            bool rescheduled;
+            long rescheduledKey;
 
             try
             {
@@ -389,7 +391,14 @@ public class TimedEvents : ITimedEvents
             }
             finally
             {
-                CompleteTimeout (occurrence, repeat);
+                // Bookkeeping and rescheduling only. Added is raised below rather than here so that a
+                // subscriber cannot throw out of this finally and replace an exception from the callback.
+                rescheduled = CompleteTimeout (occurrence, repeat, out rescheduledKey);
+            }
+
+            if (rescheduled)
+            {
+                Added?.Invoke (this, new (occurrence.Timeout, rescheduledKey));
             }
         }
     }
@@ -421,9 +430,15 @@ public class TimedEvents : ITimedEvents
         return -1;
     }
 
-    private void CompleteTimeout (ActiveTimeoutOccurrence occurrence, bool repeat)
+    /// <summary>
+    ///     Releases the cancellation bookkeeping for a completed occurrence and reschedules it when it repeats and was
+    ///     not cancelled. Called from a <see langword="finally"/>, so it must not raise <see cref="Added"/>: the caller
+    ///     raises it after the callback has returned normally.
+    /// </summary>
+    /// <returns><see langword="true"/> if the timeout was rescheduled; otherwise, <see langword="false"/>.</returns>
+    private bool CompleteTimeout (ActiveTimeoutOccurrence occurrence, bool repeat, out long rescheduledKey)
     {
-        long k;
+        rescheduledKey = 0;
 
         lock (_timeoutsLockToken)
         {
@@ -432,7 +447,7 @@ public class TimedEvents : ITimedEvents
 
             if (!found)
             {
-                return;
+                return false;
             }
 
             state.ActiveCount--;
@@ -456,13 +471,13 @@ public class TimedEvents : ITimedEvents
 
             if (!repeat || !canReschedule)
             {
-                return;
+                return false;
             }
 
-            k = AddTimeoutCore (occurrence.Timeout.Span, occurrence.Timeout);
-        }
+            rescheduledKey = AddTimeoutCore (occurrence.Timeout.Span, occurrence.Timeout);
 
-        Added?.Invoke (this, new (occurrence.Timeout, k));
+            return true;
+        }
     }
 
     /// <inheritdoc/>

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 
 namespace Terminal.Gui.App;
 
@@ -106,7 +107,7 @@ public class TimedEvents : ITimedEvents
     public void RunTimers ()
     {
         Interlocked.Exchange (ref _runTimersPending, 1);
-        System.Runtime.ExceptionServices.ExceptionDispatchInfo? error = null;
+        List<ExceptionDispatchInfo>? errors = null;
 
         while (true)
         {
@@ -114,7 +115,7 @@ public class TimedEvents : ITimedEvents
             // the active runner drains the due timeouts.
             if (!Monitor.TryEnter (_runTimersLockToken))
             {
-                error?.Throw ();
+                ThrowErrors (errors);
 
                 return;
             }
@@ -129,7 +130,8 @@ public class TimedEvents : ITimedEvents
                 }
                 catch (Exception ex)
                 {
-                    error ??= System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture (ex);
+                    errors ??= [];
+                    errors.Add (ExceptionDispatchInfo.Capture (ex));
                 }
             }
             finally
@@ -139,11 +141,28 @@ public class TimedEvents : ITimedEvents
 
             if (Interlocked.Exchange (ref _runTimersPending, 0) == 0)
             {
-                error?.Throw ();
+                ThrowErrors (errors);
 
                 return;
             }
         }
+    }
+
+    private static void ThrowErrors (List<ExceptionDispatchInfo>? errors)
+    {
+        if (errors is null)
+        {
+            return;
+        }
+
+        if (errors.Count == 1)
+        {
+            errors [0].Throw ();
+
+            return;
+        }
+
+        throw new AggregateException (errors.ConvertAll (error => error.SourceException));
     }
 
     /// <inheritdoc/>

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.ExceptionServices;
 
 namespace Terminal.Gui.App;
 
@@ -41,11 +40,11 @@ namespace Terminal.Gui.App;
 public class TimedEvents : ITimedEvents
 {
     internal SortedList<long, Timeout> _timeouts = new ();
-    private readonly List<ActiveTimeoutOccurrence> _activeTimeoutOccurrences = [];
+    private readonly Dictionary<Timeout, ActiveTimeoutState> _activeTimeoutStates = new (ReferenceEqualityComparer.Instance);
     private readonly object _runTimersLockToken = new ();
     private readonly object _timeoutsLockToken = new ();
     private readonly ITimeProvider? _timeProvider;
-    private int _runTimersPending;
+    private long _stopAllEpoch;
 
     /// <summary>
     ///     Initializes a new instance of <see cref="TimedEvents"/> with the default system time provider.
@@ -106,63 +105,21 @@ public class TimedEvents : ITimedEvents
     /// <inheritdoc/>
     public void RunTimers ()
     {
-        Interlocked.Exchange (ref _runTimersPending, 1);
-        List<ExceptionDispatchInfo>? errors = null;
-
-        while (true)
-        {
-            // A monitor is reentrant, so nested runs on this thread remain supported. A competing thread returns while
-            // the active runner drains the due timeouts.
-            if (!Monitor.TryEnter (_runTimersLockToken))
-            {
-                ThrowErrors (errors);
-
-                return;
-            }
-
-            try
-            {
-                Interlocked.Exchange (ref _runTimersPending, 0);
-
-                try
-                {
-                    RunTimersImpl ();
-                }
-                catch (Exception ex)
-                {
-                    errors ??= [];
-                    errors.Add (ExceptionDispatchInfo.Capture (ex));
-                }
-            }
-            finally
-            {
-                Monitor.Exit (_runTimersLockToken);
-            }
-
-            if (Interlocked.Exchange (ref _runTimersPending, 0) == 0)
-            {
-                ThrowErrors (errors);
-
-                return;
-            }
-        }
-    }
-
-    private static void ThrowErrors (List<ExceptionDispatchInfo>? errors)
-    {
-        if (errors is null)
+        // A monitor is reentrant, so nested runs on this thread remain supported. A competing caller returns while the
+        // active runner drains the due timeouts.
+        if (!Monitor.TryEnter (_runTimersLockToken))
         {
             return;
         }
 
-        if (errors.Count == 1)
+        try
         {
-            errors [0].Throw ();
-
-            return;
+            RunTimersImpl ();
         }
-
-        throw new AggregateException (errors.ConvertAll (error => error.SourceException));
+        finally
+        {
+            Monitor.Exit (_runTimersLockToken);
+        }
     }
 
     /// <inheritdoc/>
@@ -177,28 +134,30 @@ public class TimedEvents : ITimedEvents
 
         lock (_timeoutsLockToken)
         {
-            int idx = _timeouts.IndexOfValue (timeout);
+            var found = false;
 
-            if (idx >= 0)
+            for (var i = _timeouts.Count - 1; i >= 0; i--)
             {
-                _timeouts.RemoveAt (idx);
-
-                return true;
-            }
-
-            foreach (ActiveTimeoutOccurrence occurrence in _activeTimeoutOccurrences)
-            {
-                if (!ReferenceEquals (occurrence.Timeout, timeout) || occurrence.IsCancelled)
+                if (!ReferenceEquals (_timeouts.Values [i], timeout))
                 {
                     continue;
                 }
 
-                occurrence.IsCancelled = true;
-
-                return true;
+                _timeouts.RemoveAt (i);
+                found = true;
             }
 
-            return false;
+            if (_activeTimeoutStates.TryGetValue (timeout, out ActiveTimeoutState state)
+                && state.StopAllEpoch == _stopAllEpoch
+                && state.UncancelledActiveCount > 0)
+            {
+                state.RemovalGeneration++;
+                state.UncancelledActiveCount = 0;
+                _activeTimeoutStates [timeout] = state;
+                found = true;
+            }
+
+            return found;
         }
     }
 
@@ -256,16 +215,22 @@ public class TimedEvents : ITimedEvents
     /// <inheritdoc/>
     public TimeSpan? GetTimeout (object token)
     {
+        if (token is not Timeout timeout)
+        {
+            return null;
+        }
+
         lock (_timeoutsLockToken)
         {
-            int idx = _timeouts.IndexOfValue ((token as Timeout)!);
-
-            if (idx == -1)
+            foreach (Timeout queuedTimeout in _timeouts.Values)
             {
-                return null;
+                if (ReferenceEquals (queuedTimeout, timeout))
+                {
+                    return timeout.Span;
+                }
             }
 
-            return _timeouts.Values [idx].Span;
+            return null;
         }
     }
 
@@ -283,6 +248,9 @@ public class TimedEvents : ITimedEvents
 
     private long AddTimeoutCore (TimeSpan time, Timeout timeout)
     {
+        // Caller must hold _timeoutsLockToken.
+        Debug.Assert (Monitor.IsEntered (_timeoutsLockToken));
+
         long k = GetTimestampTicks () + time.Ticks;
 
         // if user wants to run as soon as possible set timer such that it expires right away (no race conditions)
@@ -306,6 +274,9 @@ public class TimedEvents : ITimedEvents
     /// <returns></returns>
     private long NudgeToUniqueKey (long k)
     {
+        // Caller must hold _timeoutsLockToken.
+        Debug.Assert (Monitor.IsEntered (_timeoutsLockToken));
+
         while (_timeouts.ContainsKey (k))
         {
             k++;
@@ -343,12 +314,22 @@ public class TimedEvents : ITimedEvents
                 // This timeout is due - remove it from the queue
                 Timeout timeoutToExecute = _timeouts.Values [0];
                 _timeouts.RemoveAt (0);
-                occurrence = new (timeoutToExecute);
-                _activeTimeoutOccurrences.Add (occurrence);
+                _activeTimeoutStates.TryGetValue (timeoutToExecute, out ActiveTimeoutState state);
+
+                if (state.StopAllEpoch != _stopAllEpoch)
+                {
+                    state.StopAllEpoch = _stopAllEpoch;
+                    state.UncancelledActiveCount = 0;
+                }
+
+                occurrence = new (timeoutToExecute, _stopAllEpoch, state.RemovalGeneration);
+                state.ActiveCount++;
+                state.UncancelledActiveCount++;
+                _activeTimeoutStates [timeoutToExecute] = state;
             }
 
             // Execute the callback outside the lock
-            // This allows nested Run() calls to access the timeout queue
+            // This allows nested RunTimers() calls to access the timeout queue
             bool repeat = false;
 
             try
@@ -368,10 +349,34 @@ public class TimedEvents : ITimedEvents
 
         lock (_timeoutsLockToken)
         {
-            bool removed = _activeTimeoutOccurrences.Remove (occurrence);
-            Debug.Assert (removed);
+            bool found = _activeTimeoutStates.TryGetValue (occurrence.Timeout, out ActiveTimeoutState state);
+            Debug.Assert (found);
 
-            if (!repeat || occurrence.IsCancelled)
+            if (!found)
+            {
+                return;
+            }
+
+            state.ActiveCount--;
+            bool canReschedule = occurrence.StopAllEpoch == _stopAllEpoch
+                                 && occurrence.RemovalGeneration == state.RemovalGeneration;
+
+            if (canReschedule)
+            {
+                state.UncancelledActiveCount--;
+                Debug.Assert (state.UncancelledActiveCount >= 0);
+            }
+
+            if (state.ActiveCount == 0)
+            {
+                _activeTimeoutStates.Remove (occurrence.Timeout);
+            }
+            else
+            {
+                _activeTimeoutStates [occurrence.Timeout] = state;
+            }
+
+            if (!repeat || !canReschedule)
             {
                 return;
             }
@@ -388,23 +393,17 @@ public class TimedEvents : ITimedEvents
         lock (_timeoutsLockToken)
         {
             _timeouts.Clear ();
-
-            foreach (ActiveTimeoutOccurrence occurrence in _activeTimeoutOccurrences)
-            {
-                occurrence.IsCancelled = true;
-            }
+            _stopAllEpoch++;
         }
     }
 
-    private sealed class ActiveTimeoutOccurrence
+    private readonly record struct ActiveTimeoutOccurrence (Timeout Timeout, long StopAllEpoch, long RemovalGeneration);
+
+    private struct ActiveTimeoutState
     {
-        public ActiveTimeoutOccurrence (Timeout timeout)
-        {
-            Timeout = timeout;
-        }
-
-        public bool IsCancelled { get; set; }
-
-        public Timeout Timeout { get; }
+        public int ActiveCount { get; set; }
+        public long RemovalGeneration { get; set; }
+        public long StopAllEpoch { get; set; }
+        public int UncancelledActiveCount { get; set; }
     }
 }

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -382,8 +382,6 @@ public class TimedEvents : ITimedEvents
             // Execute the callback outside the lock
             // This allows nested RunTimers() calls to access the timeout queue
             bool repeat = false;
-            bool rescheduled;
-            long rescheduledKey;
 
             try
             {
@@ -391,14 +389,7 @@ public class TimedEvents : ITimedEvents
             }
             finally
             {
-                // Bookkeeping and rescheduling only. Added is raised below rather than here so that a
-                // subscriber cannot throw out of this finally and replace an exception from the callback.
-                rescheduled = CompleteTimeout (occurrence, repeat, out rescheduledKey);
-            }
-
-            if (rescheduled)
-            {
-                Added?.Invoke (this, new (occurrence.Timeout, rescheduledKey));
+                CompleteTimeout (occurrence, repeat);
             }
         }
     }
@@ -430,15 +421,9 @@ public class TimedEvents : ITimedEvents
         return -1;
     }
 
-    /// <summary>
-    ///     Releases the cancellation bookkeeping for a completed occurrence and reschedules it when it repeats and was
-    ///     not cancelled. Called from a <see langword="finally"/>, so it must not raise <see cref="Added"/>: the caller
-    ///     raises it after the callback has returned normally.
-    /// </summary>
-    /// <returns><see langword="true"/> if the timeout was rescheduled; otherwise, <see langword="false"/>.</returns>
-    private bool CompleteTimeout (ActiveTimeoutOccurrence occurrence, bool repeat, out long rescheduledKey)
+    private void CompleteTimeout (ActiveTimeoutOccurrence occurrence, bool repeat)
     {
-        rescheduledKey = 0;
+        long k;
 
         lock (_timeoutsLockToken)
         {
@@ -447,7 +432,7 @@ public class TimedEvents : ITimedEvents
 
             if (!found)
             {
-                return false;
+                return;
             }
 
             state.ActiveCount--;
@@ -471,13 +456,13 @@ public class TimedEvents : ITimedEvents
 
             if (!repeat || !canReschedule)
             {
-                return false;
+                return;
             }
 
-            rescheduledKey = AddTimeoutCore (occurrence.Timeout.Span, occurrence.Timeout);
-
-            return true;
+            k = AddTimeoutCore (occurrence.Timeout.Span, occurrence.Timeout);
         }
+
+        Added?.Invoke (this, new (occurrence.Timeout, k));
     }
 
     /// <inheritdoc/>

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -7,7 +7,6 @@ namespace Terminal.Gui.App;
 ///     <para>
 ///         Allows scheduling of callbacks to be invoked after a specified delay, with optional repetition.
 ///         Timeouts are stored in a sorted list by their scheduled execution time (high-resolution ticks).
-///         Thread-safe for concurrent access.
 ///     </para>
 ///     <para>
 ///         Typical usage:
@@ -29,6 +28,16 @@ namespace Terminal.Gui.App;
 /// </summary>
 /// <remarks>
 ///     <para>
+///         <see cref="Add(TimeSpan, Func{bool})"/>, <see cref="Add(Timeout)"/>, <see cref="Remove"/>,
+///         <see cref="StopAll"/>, <see cref="GetTimeout"/>, <see cref="CheckTimers"/>, and <see cref="RunTimers"/> are
+///         safe to call concurrently from any thread. Callbacks are invoked outside the timeout queue lock, so a
+///         callback can schedule or cancel timeouts without deadlocking.
+///     </para>
+///     <para>
+///         <see cref="Timeouts"/> is the exception: it returns the live queue rather than a snapshot, so reading or
+///         mutating it while another thread schedules timeouts is not synchronized.
+///     </para>
+///     <para>
 ///         By default, uses <see cref="Stopwatch.GetTimestamp"/> for high-resolution timing to provide microsecond-level
 ///         precision and eliminate race conditions from timer resolution issues.
 ///     </para>
@@ -40,6 +49,9 @@ namespace Terminal.Gui.App;
 public class TimedEvents : ITimedEvents
 {
     internal SortedList<long, Timeout> _timeouts = new ();
+
+    // ActiveTimeoutState is a mutable struct, so TryGetValue hands back a copy. Every mutation must be written back
+    // with _activeTimeoutStates [timeout] = state (or the entry removed) before _timeoutsLockToken is released.
     private readonly Dictionary<Timeout, ActiveTimeoutState> _activeTimeoutStates = new (ReferenceEqualityComparer.Instance);
     private readonly object _runTimersLockToken = new ();
     private readonly object _timeoutsLockToken = new ();
@@ -71,6 +83,10 @@ public class TimedEvents : ITimedEvents
     ///     Gets the list of all timeouts sorted by the <see cref="TimeSpan"/> time ticks. A shorter limit time can be
     ///     added at the end, but it will be called before an earlier addition that has a longer limit time.
     /// </summary>
+    /// <remarks>
+    ///     Returns the live queue, not a snapshot, and access to it is not synchronized. A timeout whose callback is
+    ///     currently executing has already been dequeued and is not present.
+    /// </remarks>
     public SortedList<long, Timeout> Timeouts => _timeouts;
 
     /// <inheritdoc/>
@@ -136,6 +152,8 @@ public class TimedEvents : ITimedEvents
         {
             var found = false;
 
+            // The same Timeout instance can be queued more than once, so the whole queue is scanned. Do not replace
+            // this with an early-exiting lookup such as IndexOfValue.
             for (var i = _timeouts.Count - 1; i >= 0; i--)
             {
                 if (!ReferenceEquals (_timeouts.Values [i], timeout))
@@ -180,7 +198,18 @@ public class TimedEvents : ITimedEvents
         return timeout;
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    ///     Determines whether any timeout is queued and calculates how long the caller may wait before the earliest one
+    ///     is due.
+    /// </summary>
+    /// <param name="waitTimeout">
+    ///     The number of milliseconds until the earliest queued timeout is due, <c>0</c> if one is already due, or
+    ///     <c>-1</c> if no timeout is queued. <c>-1</c> indicates the caller may wait indefinitely.
+    /// </param>
+    /// <returns><see langword="true"/> if at least one timeout is queued; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    ///     A timeout whose callback is currently executing has been dequeued and is therefore not counted.
+    /// </remarks>
     public bool CheckTimers (out int waitTimeout)
     {
         long now = GetTimestampTicks ();
@@ -397,13 +426,33 @@ public class TimedEvents : ITimedEvents
         }
     }
 
+    /// <summary>
+    ///     Identifies a single in-flight execution of a <see cref="Timeout"/>, capturing the cancellation state that was
+    ///     current when the occurrence was dequeued. <see cref="CompleteTimeout"/> reschedules only if both values still
+    ///     match, which is how <see cref="Remove"/> and <see cref="StopAll"/> cancel an active occurrence without
+    ///     affecting occurrences created after them.
+    /// </summary>
     private readonly record struct ActiveTimeoutOccurrence (Timeout Timeout, long StopAllEpoch, long RemovalGeneration);
 
+    /// <summary>
+    ///     Per-<see cref="Timeout"/> cancellation bookkeeping. Mutable; see the comment on
+    ///     <see cref="_activeTimeoutStates"/> for the write-back requirement.
+    /// </summary>
     private struct ActiveTimeoutState
     {
+        /// <summary>Number of occurrences of this timeout that are currently executing.</summary>
         public int ActiveCount { get; set; }
+
+        /// <summary>Incremented by <see cref="Remove"/> to invalidate every occurrence dequeued before it.</summary>
         public long RemovalGeneration { get; set; }
+
+        /// <summary>The <see cref="_stopAllEpoch"/> value that <see cref="UncancelledActiveCount"/> is scoped to.</summary>
         public long StopAllEpoch { get; set; }
+
+        /// <summary>
+        ///     Number of active occurrences still matching <see cref="StopAllEpoch"/> and <see cref="RemovalGeneration"/>,
+        ///     used so <see cref="Remove"/> can report whether it actually cancelled anything.
+        /// </summary>
         public int UncancelledActiveCount { get; set; }
     }
 }

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -53,9 +53,11 @@ public class TimedEvents : ITimedEvents
     // ActiveTimeoutState is a mutable struct, so TryGetValue hands back a copy. Every mutation must be written back
     // with _activeTimeoutStates [timeout] = state (or the entry removed) before _timeoutsLockToken is released.
     private readonly Dictionary<Timeout, ActiveTimeoutState> _activeTimeoutStates = new (ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<long, long> _queuedTimeoutOccurrenceIds = [];
     private readonly object _runTimersLockToken = new ();
     private readonly object _timeoutsLockToken = new ();
     private readonly ITimeProvider? _timeProvider;
+    private long _nextTimeoutOccurrenceId;
     private long _stopAllEpoch;
 
     /// <summary>
@@ -170,6 +172,9 @@ public class TimedEvents : ITimedEvents
                     continue;
                 }
 
+                long key = _timeouts.Keys [i];
+                bool occurrenceRemoved = _queuedTimeoutOccurrenceIds.Remove (key);
+                Debug.Assert (occurrenceRemoved);
                 _timeouts.RemoveAt (i);
                 found = true;
             }
@@ -304,6 +309,7 @@ public class TimedEvents : ITimedEvents
 
         k = NudgeToUniqueKey (k);
         _timeouts.Add (k, timeout);
+        _queuedTimeoutOccurrenceIds.Add (k, _nextTimeoutOccurrenceId++);
 
         return k;
     }
@@ -329,48 +335,36 @@ public class TimedEvents : ITimedEvents
 
     private void RunTimersImpl ()
     {
-        int remainingCallbacks;
+        long passStart;
+        long occurrenceIdCutoff;
 
         lock (_timeoutsLockToken)
         {
-            long passStart = GetTimestampTicks ();
-            remainingCallbacks = 0;
-
-            while (remainingCallbacks < _timeouts.Count && _timeouts.Keys [remainingCallbacks] <= passStart)
-            {
-                remainingCallbacks++;
-            }
+            passStart = GetTimestampTicks ();
+            occurrenceIdCutoff = _nextTimeoutOccurrenceId;
         }
 
-        // Bound each pass to the number of callbacks that were due when it started. A repeating timeout with a zero or
-        // negative span reschedules as already due; without this budget it can run forever in one pass and starve the
-        // rest of the main loop. Concurrent queue changes can alter which due occurrences consume the budget.
-        while (remainingCallbacks > 0)
+        // Execute only queue occurrences that were due when this pass started. A repeating timeout with a zero or
+        // negative span reschedules as already due, but receives a new occurrence ID and is deferred to a later pass.
+        // Without occurrence identity, it can reuse its freed queue key and starve an already-due peer indefinitely.
+        while (true)
         {
             ActiveTimeoutOccurrence occurrence;
 
-            // Find the next due timeout
             lock (_timeoutsLockToken)
             {
-                if (_timeouts.Count == 0)
+                int timeoutIndex = GetNextDueTimeoutIndex (passStart, occurrenceIdCutoff);
+
+                if (timeoutIndex == -1)
                 {
                     return;
                 }
 
-                // Re-evaluate current time for each iteration
-                long now = GetTimestampTicks ();
-
-                // Check if the earliest timeout is due
-                long scheduledTime = _timeouts.Keys [0];
-
-                if (scheduledTime > now)
-                {
-                    return;
-                }
-
-                // This timeout is due - remove it from the queue
-                Timeout timeoutToExecute = _timeouts.Values [0];
-                _timeouts.RemoveAt (0);
+                long scheduledTime = _timeouts.Keys [timeoutIndex];
+                Timeout timeoutToExecute = _timeouts.Values [timeoutIndex];
+                bool occurrenceRemoved = _queuedTimeoutOccurrenceIds.Remove (scheduledTime);
+                Debug.Assert (occurrenceRemoved);
+                _timeouts.RemoveAt (timeoutIndex);
                 _activeTimeoutStates.TryGetValue (timeoutToExecute, out ActiveTimeoutState state);
 
                 if (state.StopAllEpoch != _stopAllEpoch)
@@ -385,8 +379,6 @@ public class TimedEvents : ITimedEvents
                 _activeTimeoutStates [timeoutToExecute] = state;
             }
 
-            remainingCallbacks--;
-
             // Execute the callback outside the lock
             // This allows nested RunTimers() calls to access the timeout queue
             bool repeat = false;
@@ -400,6 +392,33 @@ public class TimedEvents : ITimedEvents
                 CompleteTimeout (occurrence, repeat);
             }
         }
+    }
+
+    private int GetNextDueTimeoutIndex (long passStart, long occurrenceIdCutoff)
+    {
+        // Caller must hold _timeoutsLockToken.
+        Debug.Assert (Monitor.IsEntered (_timeoutsLockToken));
+        Debug.Assert (_timeouts.Count == _queuedTimeoutOccurrenceIds.Count);
+
+        for (var i = 0; i < _timeouts.Count; i++)
+        {
+            long scheduledTime = _timeouts.Keys [i];
+
+            if (scheduledTime > passStart)
+            {
+                return -1;
+            }
+
+            bool found = _queuedTimeoutOccurrenceIds.TryGetValue (scheduledTime, out long occurrenceId);
+            Debug.Assert (found);
+
+            if (found && occurrenceId < occurrenceIdCutoff)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     private void CompleteTimeout (ActiveTimeoutOccurrence occurrence, bool repeat)
@@ -452,6 +471,7 @@ public class TimedEvents : ITimedEvents
         lock (_timeoutsLockToken)
         {
             _timeouts.Clear ();
+            _queuedTimeoutOccurrenceIds.Clear ();
             _stopAllEpoch++;
         }
     }

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -40,8 +40,12 @@ namespace Terminal.Gui.App;
 public class TimedEvents : ITimedEvents
 {
     internal SortedList<long, Timeout> _timeouts = new ();
+    private readonly Dictionary<Timeout, int> _activeTimeouts = new (ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Timeout, int> _cancelledTimeouts = new (ReferenceEqualityComparer.Instance);
+    private readonly object _runTimersLockToken = new ();
     private readonly object _timeoutsLockToken = new ();
     private readonly ITimeProvider? _timeProvider;
+    private int _runTimersPending;
 
     /// <summary>
     ///     Initializes a new instance of <see cref="TimedEvents"/> with the default system time provider.
@@ -102,11 +106,43 @@ public class TimedEvents : ITimedEvents
     /// <inheritdoc/>
     public void RunTimers ()
     {
-        lock (_timeoutsLockToken)
+        Interlocked.Exchange (ref _runTimersPending, 1);
+        System.Runtime.ExceptionServices.ExceptionDispatchInfo? error = null;
+
+        while (true)
         {
-            if (_timeouts.Count > 0)
+            // A monitor is reentrant, so nested runs on this thread remain supported. A competing thread returns while
+            // the active runner drains the due timeouts.
+            if (!Monitor.TryEnter (_runTimersLockToken))
             {
-                RunTimersImpl ();
+                error?.Throw ();
+
+                return;
+            }
+
+            try
+            {
+                Interlocked.Exchange (ref _runTimersPending, 0);
+
+                try
+                {
+                    RunTimersImpl ();
+                }
+                catch (Exception ex)
+                {
+                    error ??= System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture (ex);
+                }
+            }
+            finally
+            {
+                Monitor.Exit (_runTimersLockToken);
+            }
+
+            if (Interlocked.Exchange (ref _runTimersPending, 0) == 0)
+            {
+                error?.Throw ();
+
+                return;
             }
         }
     }
@@ -114,19 +150,40 @@ public class TimedEvents : ITimedEvents
     /// <inheritdoc/>
     public bool Remove (object token)
     {
+        Timeout? timeout = token as Timeout;
+
+        if (timeout is null)
+        {
+            return false;
+        }
+
         lock (_timeoutsLockToken)
         {
-            int idx = _timeouts.IndexOfValue ((token as Timeout)!);
+            int idx = _timeouts.IndexOfValue (timeout);
 
-            if (idx == -1)
+            if (idx >= 0)
+            {
+                _timeouts.RemoveAt (idx);
+
+                return true;
+            }
+
+            if (!_activeTimeouts.TryGetValue (timeout, out int activeCount))
             {
                 return false;
             }
 
-            _timeouts.RemoveAt (idx);
-        }
+            _cancelledTimeouts.TryGetValue (timeout, out int cancelledCount);
 
-        return true;
+            if (cancelledCount >= activeCount)
+            {
+                return false;
+            }
+
+            _cancelledTimeouts [timeout] = cancelledCount + 1;
+
+            return true;
+        }
     }
 
     /// <inheritdoc/>
@@ -198,21 +255,31 @@ public class TimedEvents : ITimedEvents
 
     private void AddTimeout (TimeSpan time, Timeout timeout)
     {
+        long k;
+
         lock (_timeoutsLockToken)
         {
-            long k = GetTimestampTicks () + time.Ticks;
-
-            // if user wants to run as soon as possible set timer such that it expires right away (no race conditions)
-            if (time == TimeSpan.Zero)
-            {
-                // Use a more substantial buffer (1ms) to ensure it's truly in the past
-                // even under debugger overhead and extreme timing variations
-                k -= TimeSpan.TicksPerMillisecond;
-            }
-
-            _timeouts.Add (NudgeToUniqueKey (k), timeout);
-            Added?.Invoke (this, new (timeout, k));
+            k = AddTimeoutCore (time, timeout);
         }
+
+        Added?.Invoke (this, new (timeout, k));
+    }
+
+    private long AddTimeoutCore (TimeSpan time, Timeout timeout)
+    {
+        long k = GetTimestampTicks () + time.Ticks;
+
+        // if user wants to run as soon as possible set timer such that it expires right away (no race conditions)
+        if (time == TimeSpan.Zero)
+        {
+            // Use a more substantial buffer (1ms) to ensure it's truly in the past
+            // even under debugger overhead and extreme timing variations
+            k -= TimeSpan.TicksPerMillisecond;
+        }
+
+        _timeouts.Add (NudgeToUniqueKey (k), timeout);
+
+        return k;
     }
 
     /// <summary>
@@ -223,12 +290,9 @@ public class TimedEvents : ITimedEvents
     /// <returns></returns>
     private long NudgeToUniqueKey (long k)
     {
-        lock (_timeoutsLockToken)
+        while (_timeouts.ContainsKey (k))
         {
-            while (_timeouts.ContainsKey (k))
-            {
-                k++;
-            }
+            k++;
         }
 
         return k;
@@ -236,51 +300,96 @@ public class TimedEvents : ITimedEvents
 
     private void RunTimersImpl ()
     {
-        long now = GetTimestampTicks ();
-
         // Process due timeouts one at a time, without blocking the entire queue
         while (true)
         {
-            Timeout? timeoutToExecute = null;
-            long scheduledTime = 0;
+            Timeout timeoutToExecute;
 
             // Find the next due timeout
             lock (_timeoutsLockToken)
             {
                 if (_timeouts.Count == 0)
                 {
-                    break; // No more timeouts
+                    return;
                 }
 
                 // Re-evaluate current time for each iteration
-                now = GetTimestampTicks ();
+                long now = GetTimestampTicks ();
 
                 // Check if the earliest timeout is due
-                scheduledTime = _timeouts.Keys [0];
+                long scheduledTime = _timeouts.Keys [0];
 
                 if (scheduledTime > now)
                 {
-                    // Earliest timeout is not yet due, we're done
-                    break;
+                    return;
                 }
 
                 // This timeout is due - remove it from the queue
                 timeoutToExecute = _timeouts.Values [0];
                 _timeouts.RemoveAt (0);
+                _activeTimeouts.TryGetValue (timeoutToExecute, out int activeCount);
+                _activeTimeouts [timeoutToExecute] = activeCount + 1;
             }
 
             // Execute the callback outside the lock
             // This allows nested Run() calls to access the timeout queue
-            if (timeoutToExecute != null)
-            {
-                bool repeat = timeoutToExecute.Callback! ();
+            bool repeat = false;
 
-                if (repeat)
-                {
-                    AddTimeout (timeoutToExecute.Span, timeoutToExecute);
-                }
+            try
+            {
+                repeat = timeoutToExecute.Callback! ();
+            }
+            finally
+            {
+                CompleteTimeout (timeoutToExecute, repeat);
             }
         }
+    }
+
+    private void CompleteTimeout (Timeout timeout, bool repeat)
+    {
+        long k;
+
+        lock (_timeoutsLockToken)
+        {
+            int activeCount = _activeTimeouts [timeout];
+            int remainingActiveCount = activeCount - 1;
+
+            if (remainingActiveCount == 0)
+            {
+                _activeTimeouts.Remove (timeout);
+            }
+            else
+            {
+                _activeTimeouts [timeout] = remainingActiveCount;
+            }
+
+            _cancelledTimeouts.TryGetValue (timeout, out int cancelledCount);
+            bool cancelled = repeat && cancelledCount > 0;
+
+            if (cancelled && cancelledCount == 1)
+            {
+                _cancelledTimeouts.Remove (timeout);
+            }
+            else if (cancelled && cancelledCount > 1)
+            {
+                _cancelledTimeouts [timeout] = cancelledCount - 1;
+            }
+
+            if (remainingActiveCount == 0)
+            {
+                _cancelledTimeouts.Remove (timeout);
+            }
+
+            if (!repeat || cancelled)
+            {
+                return;
+            }
+
+            k = AddTimeoutCore (timeout.Span, timeout);
+        }
+
+        Added?.Invoke (this, new (timeout, k));
     }
 
     /// <inheritdoc/>
@@ -289,6 +398,11 @@ public class TimedEvents : ITimedEvents
         lock (_timeoutsLockToken)
         {
             _timeouts.Clear ();
+
+            foreach (KeyValuePair<Timeout, int> activeTimeout in _activeTimeouts)
+            {
+                _cancelledTimeouts [activeTimeout.Key] = activeTimeout.Value;
+            }
         }
     }
 }

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -34,8 +34,8 @@ namespace Terminal.Gui.App;
 ///         callback can schedule or cancel timeouts without deadlocking.
 ///     </para>
 ///     <para>
-///         <see cref="Timeouts"/> is the exception: it returns the live queue rather than a snapshot, so reading or
-///         mutating it while another thread schedules timeouts is not synchronized.
+///         <see cref="Timeouts"/> returns a snapshot so the queue can be inspected safely while another thread schedules
+///         or cancels timeouts.
 ///     </para>
 ///     <para>
 ///         By default, uses <see cref="Stopwatch.GetTimestamp"/> for high-resolution timing to provide microsecond-level
@@ -84,10 +84,19 @@ public class TimedEvents : ITimedEvents
     ///     added at the end, but it will be called before an earlier addition that has a longer limit time.
     /// </summary>
     /// <remarks>
-    ///     Returns the live queue, not a snapshot, and access to it is not synchronized. A timeout whose callback is
-    ///     currently executing has already been dequeued and is not present.
+    ///     Returns a snapshot. Mutating the returned list does not change the scheduled timeouts. A timeout whose
+    ///     callback is currently executing has already been dequeued and is not present.
     /// </remarks>
-    public SortedList<long, Timeout> Timeouts => _timeouts;
+    public SortedList<long, Timeout> Timeouts
+    {
+        get
+        {
+            lock (_timeoutsLockToken)
+            {
+                return new (_timeouts);
+            }
+        }
+    }
 
     /// <inheritdoc/>
     public event EventHandler<TimeoutEventArgs>? Added;
@@ -193,6 +202,9 @@ public class TimedEvents : ITimedEvents
     /// <inheritdoc/>
     public object Add (Timeout timeout)
     {
+        ArgumentNullException.ThrowIfNull (timeout);
+        ArgumentNullException.ThrowIfNull (timeout.Callback);
+
         AddTimeout (timeout.Span, timeout);
 
         return timeout;
@@ -290,7 +302,8 @@ public class TimedEvents : ITimedEvents
             k -= TimeSpan.TicksPerMillisecond;
         }
 
-        _timeouts.Add (NudgeToUniqueKey (k), timeout);
+        k = NudgeToUniqueKey (k);
+        _timeouts.Add (k, timeout);
 
         return k;
     }
@@ -316,8 +329,23 @@ public class TimedEvents : ITimedEvents
 
     private void RunTimersImpl ()
     {
-        // Process due timeouts one at a time, without blocking the entire queue
-        while (true)
+        int remainingCallbacks;
+
+        lock (_timeoutsLockToken)
+        {
+            long passStart = GetTimestampTicks ();
+            remainingCallbacks = 0;
+
+            while (remainingCallbacks < _timeouts.Count && _timeouts.Keys [remainingCallbacks] <= passStart)
+            {
+                remainingCallbacks++;
+            }
+        }
+
+        // Bound each pass to the number of callbacks that were due when it started. A repeating timeout with a zero or
+        // negative span reschedules as already due; without this budget it can run forever in one pass and starve the
+        // rest of the main loop. Concurrent queue changes can alter which due occurrences consume the budget.
+        while (remainingCallbacks > 0)
         {
             ActiveTimeoutOccurrence occurrence;
 
@@ -356,6 +384,8 @@ public class TimedEvents : ITimedEvents
                 state.UncancelledActiveCount++;
                 _activeTimeoutStates [timeoutToExecute] = state;
             }
+
+            remainingCallbacks--;
 
             // Execute the callback outside the lock
             // This allows nested RunTimers() calls to access the timeout queue

--- a/Terminal.Gui/App/Timeout/TimedEvents.cs
+++ b/Terminal.Gui/App/Timeout/TimedEvents.cs
@@ -347,6 +347,11 @@ public class TimedEvents : ITimedEvents
 
         lock (_timeoutsLockToken)
         {
+            if (_timeouts.Count == 0)
+            {
+                return;
+            }
+
             occurrenceIdCutoff = _nextTimeoutOccurrenceId;
         }
 

--- a/Terminal.Gui/App/Timeout/TimeoutEventArgs.cs
+++ b/Terminal.Gui/App/Timeout/TimeoutEventArgs.cs
@@ -12,7 +12,9 @@ public class TimeoutEventArgs : EventArgs
         Ticks = ticks;
     }
 
-    /// <summary>Gets the <see cref="DateTime.Ticks"/> in UTC time when the <see cref="Timeout"/> will next execute after.</summary>
+    /// <summary>
+    ///     Gets the actual queue key, as a timestamp in 100-nanosecond units, after collision nudging has been applied.
+    /// </summary>
     public long Ticks { get; }
 
     /// <summary>Gets the timeout callback handler</summary>

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/NestedRunTimeoutTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/NestedRunTimeoutTests.cs
@@ -8,6 +8,85 @@ namespace ApplicationTests.Timeout;
 [Collection("Application Tests")]
 public class NestedRunTimeoutTests (ITestOutputHelper output)
 {
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task CrossThread_Invoke_Executes_During_Nested_Run_Started_From_Timeout ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim nestedRunStarted = new ();
+        Window mainWindow = new () { Title = "Main Window" };
+        Dialog dialog = new () { Title = "Nested Dialog", Buttons = [new () { Text = "Ok" }] };
+        Task? invokeTask = null;
+        Exception? invokeError = null;
+        var invokedDuringNestedRun = false;
+        var nestedRunCompleted = false;
+        var safetyTimeoutFired = false;
+
+        object safetyTimeout = app.AddTimeout (
+                                                   TimeSpan.FromSeconds (5),
+                                                   () =>
+                                                   {
+                                                       safetyTimeoutFired = true;
+                                                       app.RequestStop (dialog);
+
+                                                       return false;
+                                                   })!;
+
+        app.AddTimeout (
+                        TimeSpan.Zero,
+                        () =>
+                        {
+                            invokeTask = Task.Factory.StartNew (
+                                                                () =>
+                                                                {
+                                                                    try
+                                                                    {
+                                                                        nestedRunStarted.Wait (cancellationToken);
+                                                                        app.Invoke (
+                                                                                    () =>
+                                                                                    {
+                                                                                        invokedDuringNestedRun = app.TopRunnableView == dialog;
+                                                                                        app.RequestStop (dialog);
+                                                                                    });
+                                                                    }
+                                                                    catch (Exception ex)
+                                                                    {
+                                                                        invokeError = ex;
+                                                                    }
+                                                                },
+                                                                CancellationToken.None,
+                                                                TaskCreationOptions.LongRunning,
+                                                                TaskScheduler.Default);
+
+                            nestedRunStarted.Set ();
+                            app.Run (dialog);
+                            nestedRunCompleted = true;
+                            app.RemoveTimeout (safetyTimeout);
+                            app.RequestStop (mainWindow);
+
+                            return false;
+                        });
+
+        try
+        {
+            app.Run (mainWindow);
+            Assert.NotNull (invokeTask);
+            await invokeTask.WaitAsync (TimeSpan.FromSeconds (5), cancellationToken);
+        }
+        finally
+        {
+            dialog.Dispose ();
+            mainWindow.Dispose ();
+        }
+
+        Assert.Null (invokeError);
+        Assert.False (safetyTimeoutFired, "The cross-thread Invoke should close the dialog before the safety timeout.");
+        Assert.True (invokedDuringNestedRun, "Invoke should execute while the nested dialog is the top runnable.");
+        Assert.True (nestedRunCompleted);
+    }
+
     [Fact]
     public void Multiple_Timeouts_Fire_In_Correct_Order_With_Nested_Run ()
     {

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -744,6 +744,61 @@ public class TimedEventsTests
         Assert.Empty (timedEvents.Timeouts);
     }
 
+    // Claude - Opus 5
+    [Fact]
+    public void RunTimers_Added_Handler_Exception_Does_Not_Replace_Callback_Exception ()
+    {
+        TimedEvents timedEvents = new ();
+        InvalidOperationException expectedException = new ("Expected callback failure.");
+
+        // A repeating timeout that throws. Added is raised outside the finally that completes the
+        // occurrence, so a throwing subscriber must not be able to displace the callback's exception.
+        timedEvents.Add (TimeSpan.FromMilliseconds (1), () => throw expectedException);
+        timedEvents.Added += (_, _) => throw new NotSupportedException ("Added handler failure.");
+
+        Thread.Sleep (5);
+
+        InvalidOperationException actualException = Assert.Throws<InvalidOperationException> (timedEvents.RunTimers);
+
+        Assert.Same (expectedException, actualException);
+
+        // A throwing callback is not rescheduled, so the queue drains.
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // Claude - Opus 5
+    [Fact]
+    public void RunTimers_Added_Handler_Exception_During_Reschedule_Leaves_Timeout_Scheduled ()
+    {
+        TimedEvents timedEvents = new ();
+        var callbackCount = 0;
+
+        timedEvents.Add (
+                         TimeSpan.FromMilliseconds (1),
+                         () =>
+                         {
+                             Interlocked.Increment (ref callbackCount);
+
+                             return true;
+                         });
+
+        timedEvents.Added += (_, _) => throw new InvalidOperationException ("Added handler failure.");
+
+        Thread.Sleep (5);
+
+        // The reschedule succeeds before Added is raised, so the timeout survives the handler exception
+        // and later passes keep running it rather than losing it.
+        Assert.Throws<InvalidOperationException> (timedEvents.RunTimers);
+        Assert.Equal (1, callbackCount);
+        Assert.Single (timedEvents.Timeouts);
+
+        Thread.Sleep (5);
+
+        Assert.Throws<InvalidOperationException> (timedEvents.RunTimers);
+        Assert.Equal (2, callbackCount);
+        Assert.Single (timedEvents.Timeouts);
+    }
+
     // CoPilot - GPT-5
     [Fact]
     public void RunTimers_StopAll_Cancels_Duplicate_Active_Timeout_Occurrences ()

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -514,6 +514,70 @@ public class TimedEventsTests
         Assert.Empty (timedEvents.Timeouts);
     }
 
+    // CoPilot - Claude Opus 5
+    [Fact]
+    public async Task Remove_Returns_True_For_Active_Occurrence_And_Does_Not_Interrupt_It ()
+    {
+        // Pins the documented contract: Remove reports true when the only match is an occurrence that has already been
+        // dequeued and is executing, and it neither waits for nor interrupts that callback.
+        TimedEvents timedEvents = new ();
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim callbackStarted = new ();
+        using ManualResetEventSlim releaseCallback = new ();
+        var callbackReleased = false;
+        var callbackCompleted = false;
+
+        object timeout = timedEvents.Add (
+                                          TimeSpan.Zero,
+                                          () =>
+                                          {
+                                              callbackStarted.Set ();
+                                              callbackReleased = releaseCallback.Wait (
+                                                                                       TimeSpan.FromSeconds (5),
+                                                                                       cancellationToken);
+                                              callbackCompleted = true;
+
+                                              return false;
+                                          });
+
+        Task runnerTask = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task<bool>? removeTask = null;
+        var callbackStartedBeforeTimeout = false;
+        var removeReturnedBeforeCallback = false;
+        var queueWasEmptyWhenRemoveRan = false;
+        var callbackStillActiveWhenRemoveReturned = false;
+
+        try
+        {
+            callbackStartedBeforeTimeout = callbackStarted.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+            if (callbackStartedBeforeTimeout)
+            {
+                // The occurrence was dequeued before the callback ran, so nothing is left for Remove to unqueue.
+                queueWasEmptyWhenRemoveRan = timedEvents.Timeouts.Count == 0;
+                removeTask = RunOnDedicatedThread (() => timedEvents.Remove (timeout));
+                removeReturnedBeforeCallback = await CompletesWithinAsync (removeTask, cancellationToken);
+                callbackStillActiveWhenRemoveReturned = !callbackCompleted;
+            }
+        }
+        finally
+        {
+            releaseCallback.Set ();
+        }
+
+        await runnerTask;
+        bool removed = removeTask is not null && await removeTask;
+
+        Assert.True (callbackStartedBeforeTimeout, "The callback should start.");
+        Assert.True (queueWasEmptyWhenRemoveRan, "The active occurrence should already be dequeued.");
+        Assert.True (removeReturnedBeforeCallback, "Remove should return while the callback is active.");
+        Assert.True (callbackStillActiveWhenRemoveReturned, "Remove should not wait for the active callback to finish.");
+        Assert.True (removed, "Remove should report true for the cancelled active occurrence.");
+        Assert.True (callbackReleased, "The callback should be released before its wait times out.");
+        Assert.True (callbackCompleted, "Remove should not interrupt the active callback.");
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
     // CoPilot - GPT-5
     [Fact]
     public async Task RunTimers_StopAll_During_Active_Repeating_Timeout_Prevents_Reschedule ()

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -236,6 +236,26 @@ public class TimedEventsTests
 
     // CoPilot - GPT-5
     [Fact]
+    public void RunTimers_Empty_Queue_Does_Not_Read_TimeProvider ()
+    {
+        var timeReadCount = 0;
+
+        DateTime GetCurrentTime ()
+        {
+            timeReadCount++;
+
+            return DateTime.UnixEpoch;
+        }
+
+        TimedEvents timedEvents = new (new FuncTimeProvider (GetCurrentTime));
+
+        timedEvents.RunTimers ();
+
+        Assert.Equal (0, timeReadCount);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
     public async Task RunTimers_Callback_Does_Not_Block_Add_From_Other_Thread ()
     {
         TimedEvents timedEvents = new ();

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -9,6 +9,233 @@ public class TimedEventsTests
 {
     // CoPilot - GPT-5
     [Fact]
+    public async Task RunTimers_Repeating_Timeout_Span_Does_Not_Block_Remove ()
+    {
+        TimedEvents timedEvents = new (new VirtualTimeProvider ());
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim spanGetStarted = new ();
+        using ManualResetEventSlim releaseSpanGet = new ();
+        BlockingSpanTimeout timeout = new () { Span = TimeSpan.Zero, Callback = () => true };
+        timedEvents.Add (timeout);
+        timeout.BlockNextGet (spanGetStarted, releaseSpanGet, cancellationToken);
+        Task runnerTask = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task<bool>? removeTask = null;
+        var spanGetStartedBeforeTimeout = false;
+        var removeReturnedBeforeSpanGet = false;
+
+        try
+        {
+            spanGetStartedBeforeTimeout = spanGetStarted.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+            if (spanGetStartedBeforeTimeout)
+            {
+                removeTask = RunOnDedicatedThread (() => timedEvents.Remove (timeout));
+                removeReturnedBeforeSpanGet = await CompletesWithinAsync (removeTask, cancellationToken);
+            }
+        }
+        finally
+        {
+            releaseSpanGet.Set ();
+        }
+
+        await runnerTask;
+        bool removed = removeTask is not null && await removeTask;
+
+        Assert.True (spanGetStartedBeforeTimeout, "The repeat interval should be read after the callback returns true.");
+        Assert.True (removeReturnedBeforeSpanGet, "Remove should not wait for an overridden Span getter.");
+        Assert.True (removed);
+        Assert.True (timeout.BlockedGetReleased, "The Span getter should be released before its wait times out.");
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void RunTimers_Throwing_Repeat_Span_Cleans_Active_Occurrence ()
+    {
+        TimedEvents timedEvents = new (new VirtualTimeProvider ());
+        InvalidOperationException expectedException = new ("Expected Span failure.");
+        BlockingSpanTimeout timeout = new () { Span = TimeSpan.Zero, Callback = () => true };
+        timedEvents.Add (timeout);
+        timeout.ThrowOnNextGet (expectedException);
+
+        InvalidOperationException actualException = Assert.Throws<InvalidOperationException> (timedEvents.RunTimers);
+
+        Assert.Same (expectedException, actualException);
+        Assert.False (timedEvents.Remove (timeout));
+        Assert.Empty (timedEvents.Timeouts);
+
+        timeout.Callback = () => false;
+        timedEvents.Add (timeout);
+        timedEvents.RunTimers ();
+
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task GetTimeout_Overridden_Span_Does_Not_Block_Add ()
+    {
+        TimedEvents timedEvents = new (new VirtualTimeProvider ());
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim spanGetStarted = new ();
+        using ManualResetEventSlim releaseSpanGet = new ();
+        BlockingSpanTimeout timeout = new () { Span = TimeSpan.FromHours (1), Callback = () => false };
+        timedEvents.Add (timeout);
+        timeout.BlockNextGet (spanGetStarted, releaseSpanGet, cancellationToken);
+        Task<TimeSpan?> getTimeoutTask = RunOnDedicatedThread (() => timedEvents.GetTimeout (timeout));
+        Task? addTask = null;
+        var spanGetStartedBeforeTimeout = false;
+        var addReturnedBeforeSpanGet = false;
+
+        try
+        {
+            spanGetStartedBeforeTimeout = spanGetStarted.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+            if (spanGetStartedBeforeTimeout)
+            {
+                addTask = RunOnDedicatedThread (() => timedEvents.Add (TimeSpan.FromHours (2), () => false));
+                addReturnedBeforeSpanGet = await CompletesWithinAsync (addTask, cancellationToken);
+            }
+        }
+        finally
+        {
+            releaseSpanGet.Set ();
+        }
+
+        TimeSpan? span = await getTimeoutTask;
+
+        if (addTask is not null)
+        {
+            await addTask;
+        }
+
+        Assert.True (spanGetStartedBeforeTimeout, "GetTimeout should read Span for the queued timeout.");
+        Assert.True (addReturnedBeforeSpanGet, "Add should not wait for an overridden Span getter.");
+        Assert.True (timeout.BlockedGetReleased, "The Span getter should be released before its wait times out.");
+        Assert.Equal (TimeSpan.FromHours (1), span);
+        Assert.Equal (2, timedEvents.Timeouts.Count);
+        timedEvents.StopAll ();
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task Add_TimeProvider_Does_Not_Block_Remove ()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim timeReadStarted = new ();
+        using ManualResetEventSlim releaseTimeRead = new ();
+        var timeReadCount = 0;
+        var timeReadReleased = false;
+
+        DateTime GetCurrentTime ()
+        {
+            if (Interlocked.Increment (ref timeReadCount) == 2)
+            {
+                timeReadStarted.Set ();
+                timeReadReleased = releaseTimeRead.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+            }
+
+            return DateTime.UnixEpoch;
+        }
+
+        TimedEvents timedEvents = new (new FuncTimeProvider (GetCurrentTime));
+        object firstTimeout = timedEvents.Add (TimeSpan.FromHours (1), () => false);
+        Task<object> addTask = RunOnDedicatedThread (
+                                                         () => timedEvents.Add (TimeSpan.FromHours (2), () => false));
+        Task<bool>? removeTask = null;
+        var timeReadStartedBeforeTimeout = false;
+        var removeReturnedBeforeTimeRead = false;
+
+        try
+        {
+            timeReadStartedBeforeTimeout = timeReadStarted.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+            if (timeReadStartedBeforeTimeout)
+            {
+                removeTask = RunOnDedicatedThread (() => timedEvents.Remove (firstTimeout));
+                removeReturnedBeforeTimeRead = await CompletesWithinAsync (removeTask, cancellationToken);
+            }
+        }
+        finally
+        {
+            releaseTimeRead.Set ();
+        }
+
+        await addTask;
+        bool removed = removeTask is not null && await removeTask;
+
+        Assert.True (timeReadStartedBeforeTimeout, "The second Add should read the time provider.");
+        Assert.True (removeReturnedBeforeTimeRead, "Remove should not wait for a time-provider read.");
+        Assert.True (removed);
+        Assert.True (timeReadReleased, "The time-provider read should be released before its wait times out.");
+        Assert.Single (timedEvents.Timeouts);
+        timedEvents.StopAll ();
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_TimeProvider_Does_Not_Block_Remove ()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim timeReadStarted = new ();
+        using ManualResetEventSlim releaseTimeRead = new ();
+        var timeReadCount = 0;
+        var timeReadReleased = false;
+        var callbackCount = 0;
+
+        DateTime GetCurrentTime ()
+        {
+            if (Interlocked.Increment (ref timeReadCount) == 2)
+            {
+                timeReadStarted.Set ();
+                timeReadReleased = releaseTimeRead.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+            }
+
+            return DateTime.UnixEpoch;
+        }
+
+        TimedEvents timedEvents = new (new FuncTimeProvider (GetCurrentTime));
+        object timeout = timedEvents.Add (
+                                          TimeSpan.Zero,
+                                          () =>
+                                          {
+                                              callbackCount++;
+
+                                              return false;
+                                          });
+        Task runnerTask = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task<bool>? removeTask = null;
+        var timeReadStartedBeforeTimeout = false;
+        var removeReturnedBeforeTimeRead = false;
+
+        try
+        {
+            timeReadStartedBeforeTimeout = timeReadStarted.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+            if (timeReadStartedBeforeTimeout)
+            {
+                removeTask = RunOnDedicatedThread (() => timedEvents.Remove (timeout));
+                removeReturnedBeforeTimeRead = await CompletesWithinAsync (removeTask, cancellationToken);
+            }
+        }
+        finally
+        {
+            releaseTimeRead.Set ();
+        }
+
+        await runnerTask;
+        bool removed = removeTask is not null && await removeTask;
+
+        Assert.True (timeReadStartedBeforeTimeout, "RunTimers should read the time provider.");
+        Assert.True (removeReturnedBeforeTimeRead, "Remove should not wait for a time-provider read.");
+        Assert.True (removed);
+        Assert.True (timeReadReleased, "The time-provider read should be released before its wait times out.");
+        Assert.Equal (0, callbackCount);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
     public async Task RunTimers_Callback_Does_Not_Block_Add_From_Other_Thread ()
     {
         TimedEvents timedEvents = new ();
@@ -1430,4 +1657,53 @@ public class TimedEventsTests
                                TaskScheduler.Default);
 
     private static bool WaitForCleanup (ManualResetEventSlim waitHandle) => waitHandle.Wait (TimeSpan.FromSeconds (5));
+
+    private sealed class BlockingSpanTimeout : Terminal.Gui.App.Timeout
+    {
+        private CancellationToken _cancellationToken;
+        private ManualResetEventSlim? _getStarted;
+        private Exception? _nextException;
+        private ManualResetEventSlim? _releaseGet;
+        private TimeSpan _span;
+
+        public bool BlockedGetReleased { get; private set; }
+
+        public override TimeSpan Span
+        {
+            get
+            {
+                Exception? exception = Interlocked.Exchange (ref _nextException, null);
+
+                if (exception is not null)
+                {
+                    throw exception;
+                }
+
+                ManualResetEventSlim? getStarted = Interlocked.Exchange (ref _getStarted, null);
+
+                if (getStarted is null)
+                {
+                    return _span;
+                }
+
+                getStarted.Set ();
+                BlockedGetReleased = _releaseGet!.Wait (TimeSpan.FromSeconds (5), _cancellationToken);
+
+                return _span;
+            }
+            set => _span = value;
+        }
+
+        public void BlockNextGet (
+            ManualResetEventSlim getStarted,
+            ManualResetEventSlim releaseGet,
+            CancellationToken cancellationToken)
+        {
+            _releaseGet = releaseGet;
+            _cancellationToken = cancellationToken;
+            Interlocked.Exchange (ref _getStarted, getStarted);
+        }
+
+        public void ThrowOnNextGet (Exception exception) { Interlocked.Exchange (ref _nextException, exception); }
+    }
 }

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -748,6 +748,51 @@ public class TimedEventsTests
 
     // CoPilot - GPT-5
     [Fact]
+    public void RunTimers_StopAll_Cancels_Active_Occurrence_Not_Later_Same_Timeout_Occurrence ()
+    {
+        VirtualTimeProvider timeProvider = new ();
+        TimedEvents timedEvents = new (timeProvider);
+        var callbackCount = 0;
+        Terminal.Gui.App.Timeout timeout = new () { Span = TimeSpan.FromSeconds (1) };
+
+        timeout.Callback = () =>
+                           {
+                               callbackCount++;
+
+                               if (callbackCount == 1)
+                               {
+                                   timedEvents.StopAll ();
+                                   timeout.Span = TimeSpan.FromSeconds (1);
+                                   timedEvents.Add (timeout);
+                                   timeProvider.Advance (TimeSpan.FromSeconds (2));
+                                   timedEvents.RunTimers ();
+
+                                   // Distinguish an incorrect reschedule of this pre-StopAll occurrence.
+                                   timeout.Span = TimeSpan.FromSeconds (10);
+
+                                   return true;
+                               }
+
+                               return callbackCount == 2;
+                           };
+
+        timedEvents.Add (timeout);
+        timeProvider.Advance (TimeSpan.FromSeconds (2));
+
+        timedEvents.RunTimers ();
+
+        Assert.Equal (2, callbackCount);
+        Assert.Single (timedEvents.Timeouts);
+
+        timeProvider.Advance (TimeSpan.FromSeconds (2));
+        timedEvents.RunTimers ();
+
+        Assert.Equal (3, callbackCount);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
     public async Task RunTimers_Remove_Cancels_Repeating_Duplicate_Active_Timeout_Occurrence ()
     {
         VirtualTimeProvider timeProvider = new ();

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -1503,13 +1503,14 @@ public class TimedEventsTests
     {
         TimedEvents timedEvents = new (new VirtualTimeProvider ());
         var callbackCount = 0;
+        var stopRepeating = 0;
         object token = timedEvents.Add (
                                         TimeSpan.Zero,
                                         () =>
                                         {
                                             Interlocked.Increment (ref callbackCount);
 
-                                            return true;
+                                            return Volatile.Read (ref stopRepeating) == 0;
                                         });
         Task runner = RunOnDedicatedThread (timedEvents.RunTimers);
         Task completedTask = await Task.WhenAny (
@@ -1526,8 +1527,9 @@ public class TimedEventsTests
             countAfterNextPass = Volatile.Read (ref callbackCount);
         }
 
-        timedEvents.Remove (token);
+        Volatile.Write (ref stopRepeating, 1);
         await runner.WaitAsync (TimeSpan.FromSeconds (5), TestContext.Current.CancellationToken);
+        timedEvents.Remove (token);
 
         Assert.True (returned, "RunTimers should return after the callbacks that were due when the pass started.");
         Assert.Equal (1, countAfterPass);
@@ -1537,35 +1539,47 @@ public class TimedEventsTests
 
     // CoPilot - GPT-5
     [Fact]
-    public void RunTimers_Repeating_Zero_Timeout_Does_Not_Starve_Due_Peer ()
+    public async Task RunTimers_Repeating_Zero_Timeout_Does_Not_Starve_Due_Peer ()
     {
         TimedEvents timedEvents = new (new VirtualTimeProvider ());
         var repeatingCallbackCount = 0;
         var peerCallbackCount = 0;
+        var stopRepeating = 0;
         object repeatingToken = timedEvents.Add (
                                                  TimeSpan.Zero,
                                                  () =>
                                                  {
-                                                     repeatingCallbackCount++;
+                                                     Interlocked.Increment (ref repeatingCallbackCount);
 
-                                                     return true;
+                                                     return Volatile.Read (ref stopRepeating) == 0;
                                                  });
         timedEvents.Add (
                          TimeSpan.Zero,
                          () =>
                          {
-                             peerCallbackCount++;
+                             Interlocked.Increment (ref peerCallbackCount);
 
                              return false;
                          });
 
-        timedEvents.RunTimers ();
+        Task runner = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task completedTask = await Task.WhenAny (
+                                                 runner,
+                                                 Task.Delay (TimeSpan.FromSeconds (1), TestContext.Current.CancellationToken));
+        var returned = ReferenceEquals (completedTask, runner);
+        int repeatingCountAfterPass = Volatile.Read (ref repeatingCallbackCount);
+        int peerCountAfterPass = Volatile.Read (ref peerCallbackCount);
+        SortedList<long, Terminal.Gui.App.Timeout> queuedAfterPass = returned ? timedEvents.Timeouts : [];
+        Terminal.Gui.App.Timeout? queuedTimeoutAfterPass = queuedAfterPass.Count == 1 ? queuedAfterPass.Values [0] : null;
 
-        Assert.Equal (1, repeatingCallbackCount);
-        Assert.Equal (1, peerCallbackCount);
-        Assert.Same (repeatingToken, Assert.Single (timedEvents.Timeouts).Value);
-
+        Volatile.Write (ref stopRepeating, 1);
+        await runner.WaitAsync (TimeSpan.FromSeconds (5), TestContext.Current.CancellationToken);
         timedEvents.Remove (repeatingToken);
+
+        Assert.True (returned, "RunTimers should return after the callbacks that were due when the pass started.");
+        Assert.Equal (1, repeatingCountAfterPass);
+        Assert.Equal (1, peerCountAfterPass);
+        Assert.Same (repeatingToken, queuedTimeoutAfterPass);
     }
 
     [Fact]

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -1166,7 +1166,7 @@ public class TimedEventsTests
                      $"Expected more unique timestamps. Got {uniqueTimestamps} unique out of {timestamps.Count} total");
     }
 
-    // Claude Opus 5
+    // Claude - Opus 5
     [Fact]
     public void Add_Timeout_Throws_For_Null_Timeout ()
     {
@@ -1175,7 +1175,7 @@ public class TimedEventsTests
         Assert.Throws<ArgumentNullException> (() => timedEvents.Add ((Terminal.Gui.App.Timeout)null!));
     }
 
-    // Claude Opus 5
+    // Claude - Opus 5
     [Fact]
     public void Add_Timeout_Throws_For_Null_Callback ()
     {
@@ -1186,7 +1186,7 @@ public class TimedEventsTests
         Assert.Empty (timedEvents.Timeouts);
     }
 
-    // Claude Opus 5
+    // Claude - Opus 5
     [Fact]
     public void Added_Reports_Actual_Queue_Key_After_Collision ()
     {
@@ -1202,7 +1202,7 @@ public class TimedEventsTests
         Assert.Equal (2, addedTicks.Distinct ().Count ());
     }
 
-    // Claude Opus 5
+    // Claude - Opus 5
     [Fact]
     public void Timeouts_Returns_Snapshot ()
     {
@@ -1217,7 +1217,7 @@ public class TimedEventsTests
         Assert.Equal (2, timedEvents.Timeouts.Count);
     }
 
-    // Claude Opus 5
+    // Claude - Opus 5
     [Fact]
     public async Task RunTimers_Defers_Repeating_Zero_Timeout_Until_Next_Pass ()
     {
@@ -1253,6 +1253,39 @@ public class TimedEventsTests
         Assert.Equal (1, countAfterPass);
         Assert.Equal (1, queuedAfterPass);
         Assert.Equal (2, countAfterNextPass);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void RunTimers_Repeating_Zero_Timeout_Does_Not_Starve_Due_Peer ()
+    {
+        TimedEvents timedEvents = new (new VirtualTimeProvider ());
+        var repeatingCallbackCount = 0;
+        var peerCallbackCount = 0;
+        object repeatingToken = timedEvents.Add (
+                                                 TimeSpan.Zero,
+                                                 () =>
+                                                 {
+                                                     repeatingCallbackCount++;
+
+                                                     return true;
+                                                 });
+        timedEvents.Add (
+                         TimeSpan.Zero,
+                         () =>
+                         {
+                             peerCallbackCount++;
+
+                             return false;
+                         });
+
+        timedEvents.RunTimers ();
+
+        Assert.Equal (1, repeatingCallbackCount);
+        Assert.Equal (1, peerCallbackCount);
+        Assert.Same (repeatingToken, Assert.Single (timedEvents.Timeouts).Value);
+
+        timedEvents.Remove (repeatingToken);
     }
 
     [Fact]

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -713,6 +713,67 @@ public class TimedEventsTests
 
     // CoPilot - GPT-5
     [Fact]
+    public async Task RunTimers_Competing_Caller_Aggregates_Follow_Up_Callback_Exception ()
+    {
+        TimedEvents timedEvents = new ();
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim callbackStarted = new ();
+        using ManualResetEventSlim releaseCallback = new ();
+        InvalidOperationException firstException = new ("Expected first callback failure.");
+        ArgumentException followUpException = new ("Expected follow-up callback failure.");
+        var callbackReleased = false;
+
+        timedEvents.Add (
+                         TimeSpan.Zero,
+                         () =>
+                         {
+                             callbackStarted.Set ();
+                             callbackReleased = releaseCallback.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+                             throw firstException;
+                         });
+        timedEvents.Add (TimeSpan.Zero, () => throw followUpException);
+
+        Task firstRunner = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task? secondRunner = null;
+        var callbackStartedBeforeTimeout = false;
+        var secondRunnerReturned = false;
+
+        try
+        {
+            callbackStartedBeforeTimeout = callbackStarted.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+            if (callbackStartedBeforeTimeout)
+            {
+                secondRunner = RunOnDedicatedThread (timedEvents.RunTimers);
+                secondRunnerReturned = await CompletesWithinAsync (secondRunner, cancellationToken);
+            }
+        }
+        finally
+        {
+            releaseCallback.Set ();
+        }
+
+        AggregateException actualException = await Assert.ThrowsAsync<AggregateException> (
+            async () => await firstRunner);
+
+        if (secondRunner is not null)
+        {
+            await secondRunner;
+        }
+
+        Assert.True (callbackStartedBeforeTimeout, "The first throwing callback should start.");
+        Assert.True (callbackReleased, "The first throwing callback should be released before its wait times out.");
+        Assert.True (secondRunnerReturned, "The competing RunTimers call should request the follow-up pass.");
+        Assert.Collection (
+                           actualException.InnerExceptions,
+                           exception => Assert.Same (firstException, exception),
+                           exception => Assert.Same (followUpException, exception));
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
     public void RunTimers_StopAll_Cancels_Duplicate_Active_Timeout_Occurrences ()
     {
         VirtualTimeProvider timeProvider = new ();

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -573,7 +573,7 @@ public class TimedEventsTests
 
     // CoPilot - GPT-5
     [Fact]
-    public async Task RunTimers_Competing_Caller_Requests_Follow_Up_Run ()
+    public async Task RunTimers_Competing_Caller_Returns_Without_Running_Newly_Due_Timeout ()
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         long currentTicks = DateTime.UnixEpoch.Ticks;
@@ -641,31 +641,24 @@ public class TimedEventsTests
         Assert.True (dueCheckStartedBeforeTimeout, "The first runner should reach the due-time check.");
         Assert.True (dueCheckReleased, "The due-time check should be released before its wait times out.");
         Assert.True (secondRunnerReturned, "The competing RunTimers call should return while the runner is active.");
+        Assert.Equal (0, callbackCount);
+        Assert.Single (timedEvents.Timeouts);
+
+        timedEvents.RunTimers ();
+
         Assert.Equal (1, callbackCount);
         Assert.Empty (timedEvents.Timeouts);
     }
 
     // CoPilot - GPT-5
     [Fact]
-    public async Task RunTimers_Competing_Caller_Requests_Follow_Up_Run_When_Callback_Throws ()
+    public void RunTimers_Callback_Exception_Propagates_And_Ends_Pass ()
     {
         TimedEvents timedEvents = new ();
-        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
-        using ManualResetEventSlim callbackStarted = new ();
-        using ManualResetEventSlim releaseCallback = new ();
         InvalidOperationException expectedException = new ("Expected callback failure.");
         var followUpCallbackCount = 0;
-        var callbackReleased = false;
 
-        timedEvents.Add (
-                         TimeSpan.Zero,
-                         () =>
-                         {
-                             callbackStarted.Set ();
-                             callbackReleased = releaseCallback.Wait (TimeSpan.FromSeconds (5), cancellationToken);
-
-                             throw expectedException;
-                         });
+        timedEvents.Add (TimeSpan.Zero, () => throw expectedException);
         timedEvents.Add (
                          TimeSpan.Zero,
                          () =>
@@ -675,100 +668,15 @@ public class TimedEventsTests
                              return false;
                          });
 
-        Task firstRunner = RunOnDedicatedThread (timedEvents.RunTimers);
-        Task? secondRunner = null;
-        var callbackStartedBeforeTimeout = false;
-        var secondRunnerReturned = false;
+        InvalidOperationException actualException = Assert.Throws<InvalidOperationException> (timedEvents.RunTimers);
 
-        try
-        {
-            callbackStartedBeforeTimeout = callbackStarted.Wait (TimeSpan.FromSeconds (5), cancellationToken);
-
-            if (callbackStartedBeforeTimeout)
-            {
-                secondRunner = RunOnDedicatedThread (timedEvents.RunTimers);
-                secondRunnerReturned = await CompletesWithinAsync (secondRunner, cancellationToken);
-            }
-        }
-        finally
-        {
-            releaseCallback.Set ();
-        }
-
-        InvalidOperationException actualException = await Assert.ThrowsAsync<InvalidOperationException> (
-            async () => await firstRunner);
-
-        if (secondRunner is not null)
-        {
-            await secondRunner;
-        }
-
-        Assert.True (callbackStartedBeforeTimeout, "The throwing callback should start.");
-        Assert.True (callbackReleased, "The throwing callback should be released before its wait times out.");
-        Assert.True (secondRunnerReturned, "The competing RunTimers call should return while the runner is active.");
         Assert.Same (expectedException, actualException);
+        Assert.Equal (0, followUpCallbackCount);
+        Assert.Single (timedEvents.Timeouts);
+
+        timedEvents.RunTimers ();
+
         Assert.Equal (1, followUpCallbackCount);
-        Assert.Empty (timedEvents.Timeouts);
-    }
-
-    // CoPilot - GPT-5
-    [Fact]
-    public async Task RunTimers_Competing_Caller_Aggregates_Follow_Up_Callback_Exception ()
-    {
-        TimedEvents timedEvents = new ();
-        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
-        using ManualResetEventSlim callbackStarted = new ();
-        using ManualResetEventSlim releaseCallback = new ();
-        InvalidOperationException firstException = new ("Expected first callback failure.");
-        ArgumentException followUpException = new ("Expected follow-up callback failure.");
-        var callbackReleased = false;
-
-        timedEvents.Add (
-                         TimeSpan.Zero,
-                         () =>
-                         {
-                             callbackStarted.Set ();
-                             callbackReleased = releaseCallback.Wait (TimeSpan.FromSeconds (5), cancellationToken);
-
-                             throw firstException;
-                         });
-        timedEvents.Add (TimeSpan.Zero, () => throw followUpException);
-
-        Task firstRunner = RunOnDedicatedThread (timedEvents.RunTimers);
-        Task? secondRunner = null;
-        var callbackStartedBeforeTimeout = false;
-        var secondRunnerReturned = false;
-
-        try
-        {
-            callbackStartedBeforeTimeout = callbackStarted.Wait (TimeSpan.FromSeconds (5), cancellationToken);
-
-            if (callbackStartedBeforeTimeout)
-            {
-                secondRunner = RunOnDedicatedThread (timedEvents.RunTimers);
-                secondRunnerReturned = await CompletesWithinAsync (secondRunner, cancellationToken);
-            }
-        }
-        finally
-        {
-            releaseCallback.Set ();
-        }
-
-        AggregateException actualException = await Assert.ThrowsAsync<AggregateException> (
-            async () => await firstRunner);
-
-        if (secondRunner is not null)
-        {
-            await secondRunner;
-        }
-
-        Assert.True (callbackStartedBeforeTimeout, "The first throwing callback should start.");
-        Assert.True (callbackReleased, "The first throwing callback should be released before its wait times out.");
-        Assert.True (secondRunnerReturned, "The competing RunTimers call should request the follow-up pass.");
-        Assert.Collection (
-                           actualException.InnerExceptions,
-                           exception => Assert.Same (firstException, exception),
-                           exception => Assert.Same (followUpException, exception));
         Assert.Empty (timedEvents.Timeouts);
     }
 
@@ -905,6 +813,212 @@ public class TimedEventsTests
         Assert.Equal (2, callbackCount);
         Assert.True (removeCompletedBeforeCallbackReturned, "Remove should return while both occurrences are active.");
         Assert.True (removed);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void Remove_Cancels_Queued_And_Active_Occurrences_With_Same_Token ()
+    {
+        VirtualTimeProvider timeProvider = new ();
+        TimedEvents timedEvents = new (timeProvider);
+        var callbackCount = 0;
+        var removed = false;
+        Terminal.Gui.App.Timeout timeout = new () { Span = TimeSpan.FromSeconds (1) };
+
+        timeout.Callback = () =>
+                           {
+                               callbackCount++;
+                               timedEvents.Add (timeout);
+                               removed = timedEvents.Remove (timeout);
+
+                               return true;
+                           };
+
+        timedEvents.Add (timeout);
+        timeProvider.Advance (TimeSpan.FromSeconds (2));
+
+        timedEvents.RunTimers ();
+
+        Assert.True (removed);
+        Assert.Equal (1, callbackCount);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void Remove_Cancels_All_Queued_Occurrences_With_Same_Token ()
+    {
+        TimedEvents timedEvents = new ();
+        Terminal.Gui.App.Timeout timeout = new ()
+        {
+            Span = TimeSpan.FromHours (1),
+            Callback = () => false
+        };
+
+        timedEvents.Add (timeout);
+        timedEvents.Add (timeout);
+
+        bool removed = timedEvents.Remove (timeout);
+
+        Assert.True (removed);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void GetTimeout_Returns_Null_For_Active_Occurrence_That_Remove_Can_Cancel ()
+    {
+        TimedEvents timedEvents = new ();
+        TimeSpan? actualSpan = TimeSpan.MaxValue;
+        var removed = false;
+        object? token = null;
+
+        token = timedEvents.Add (
+                                 TimeSpan.Zero,
+                                 () =>
+                                 {
+                                     actualSpan = timedEvents.GetTimeout (token!);
+                                     removed = timedEvents.Remove (token!);
+
+                                     return true;
+                                 });
+
+        timedEvents.RunTimers ();
+
+        Assert.Null (actualSpan);
+        Assert.True (removed);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void Remove_Does_Not_Cancel_Same_Timeout_Added_After_Remove ()
+    {
+        VirtualTimeProvider timeProvider = new ();
+        TimedEvents timedEvents = new (timeProvider);
+        var callbackCount = 0;
+        var removed = false;
+        Terminal.Gui.App.Timeout timeout = new () { Span = TimeSpan.FromSeconds (1) };
+
+        timeout.Callback = () =>
+                           {
+                               callbackCount++;
+
+                               if (callbackCount > 1)
+                               {
+                                   return false;
+                               }
+
+                               removed = timedEvents.Remove (timeout);
+                               timedEvents.Add (timeout);
+
+                               return true;
+                           };
+
+        timedEvents.Add (timeout);
+        timeProvider.Advance (TimeSpan.FromSeconds (2));
+        timedEvents.RunTimers ();
+
+        Assert.True (removed);
+        Assert.Single (timedEvents.Timeouts);
+
+        timeProvider.Advance (TimeSpan.FromSeconds (2));
+        timedEvents.RunTimers ();
+
+        Assert.Equal (2, callbackCount);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void Remove_Does_Not_Cancel_Nested_Active_Occurrence_Added_After_Remove ()
+    {
+        VirtualTimeProvider timeProvider = new ();
+        TimedEvents timedEvents = new (timeProvider);
+        var callbackCount = 0;
+        var removed = false;
+        Terminal.Gui.App.Timeout timeout = new () { Span = TimeSpan.FromSeconds (1) };
+
+        timeout.Callback = () =>
+                           {
+                               callbackCount++;
+
+                               if (callbackCount == 1)
+                               {
+                                   removed = timedEvents.Remove (timeout);
+                                   timedEvents.Add (timeout);
+                                   timeProvider.Advance (TimeSpan.FromSeconds (2));
+                                   timedEvents.RunTimers ();
+
+                                   return true;
+                               }
+
+                               return callbackCount == 2;
+                           };
+
+        timedEvents.Add (timeout);
+        timeProvider.Advance (TimeSpan.FromSeconds (2));
+        timedEvents.RunTimers ();
+
+        Assert.True (removed);
+        Assert.Equal (2, callbackCount);
+        Assert.Single (timedEvents.Timeouts);
+
+        timeProvider.Advance (TimeSpan.FromSeconds (2));
+        timedEvents.RunTimers ();
+
+        Assert.Equal (3, callbackCount);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void Remove_Returns_False_When_Active_Occurrence_Is_Already_Cancelled ()
+    {
+        TimedEvents timedEvents = new ();
+        var firstRemove = false;
+        var secondRemove = true;
+        object? token = null;
+
+        token = timedEvents.Add (
+                                 TimeSpan.Zero,
+                                 () =>
+                                 {
+                                     firstRemove = timedEvents.Remove (token!);
+                                     secondRemove = timedEvents.Remove (token!);
+
+                                     return true;
+                                 });
+
+        timedEvents.RunTimers ();
+
+        Assert.True (firstRemove);
+        Assert.False (secondRemove);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void Remove_Returns_False_When_StopAll_Already_Cancelled_Active_Occurrence ()
+    {
+        TimedEvents timedEvents = new ();
+        var removed = true;
+        object? token = null;
+
+        token = timedEvents.Add (
+                                 TimeSpan.Zero,
+                                 () =>
+                                 {
+                                     timedEvents.StopAll ();
+                                     removed = timedEvents.Remove (token!);
+
+                                     return true;
+                                 });
+
+        timedEvents.RunTimers ();
+
+        Assert.False (removed);
         Assert.Empty (timedEvents.Timeouts);
     }
 

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -1166,6 +1166,95 @@ public class TimedEventsTests
                      $"Expected more unique timestamps. Got {uniqueTimestamps} unique out of {timestamps.Count} total");
     }
 
+    // Claude Opus 5
+    [Fact]
+    public void Add_Timeout_Throws_For_Null_Timeout ()
+    {
+        TimedEvents timedEvents = new ();
+
+        Assert.Throws<ArgumentNullException> (() => timedEvents.Add ((Terminal.Gui.App.Timeout)null!));
+    }
+
+    // Claude Opus 5
+    [Fact]
+    public void Add_Timeout_Throws_For_Null_Callback ()
+    {
+        TimedEvents timedEvents = new ();
+        Terminal.Gui.App.Timeout timeout = new () { Span = TimeSpan.Zero };
+
+        Assert.Throws<ArgumentNullException> (() => timedEvents.Add (timeout));
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // Claude Opus 5
+    [Fact]
+    public void Added_Reports_Actual_Queue_Key_After_Collision ()
+    {
+        VirtualTimeProvider timeProvider = new ();
+        TimedEvents timedEvents = new (timeProvider);
+        List<long> addedTicks = [];
+        timedEvents.Added += (_, e) => addedTicks.Add (e.Ticks);
+
+        timedEvents.Add (TimeSpan.Zero, () => false);
+        timedEvents.Add (TimeSpan.Zero, () => false);
+
+        Assert.Equal (timedEvents.Timeouts.Keys, addedTicks);
+        Assert.Equal (2, addedTicks.Distinct ().Count ());
+    }
+
+    // Claude Opus 5
+    [Fact]
+    public void Timeouts_Returns_Snapshot ()
+    {
+        TimedEvents timedEvents = new ();
+        timedEvents.Add (TimeSpan.FromHours (1), () => false);
+
+        SortedList<long, Terminal.Gui.App.Timeout> snapshot = timedEvents.Timeouts;
+
+        timedEvents.Add (TimeSpan.FromHours (2), () => false);
+        snapshot.Clear ();
+
+        Assert.Equal (2, timedEvents.Timeouts.Count);
+    }
+
+    // Claude Opus 5
+    [Fact]
+    public async Task RunTimers_Defers_Repeating_Zero_Timeout_Until_Next_Pass ()
+    {
+        TimedEvents timedEvents = new (new VirtualTimeProvider ());
+        var callbackCount = 0;
+        object token = timedEvents.Add (
+                                        TimeSpan.Zero,
+                                        () =>
+                                        {
+                                            Interlocked.Increment (ref callbackCount);
+
+                                            return true;
+                                        });
+        Task runner = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task completedTask = await Task.WhenAny (
+                                                 runner,
+                                                 Task.Delay (TimeSpan.FromSeconds (1), TestContext.Current.CancellationToken));
+        var returned = ReferenceEquals (completedTask, runner);
+        int countAfterPass = Volatile.Read (ref callbackCount);
+        int queuedAfterPass = returned ? timedEvents.Timeouts.Count : 0;
+        int countAfterNextPass = countAfterPass;
+
+        if (returned)
+        {
+            timedEvents.RunTimers ();
+            countAfterNextPass = Volatile.Read (ref callbackCount);
+        }
+
+        timedEvents.Remove (token);
+        await runner.WaitAsync (TimeSpan.FromSeconds (5), TestContext.Current.CancellationToken);
+
+        Assert.True (returned, "RunTimers should return after the callbacks that were due when the pass started.");
+        Assert.Equal (1, countAfterPass);
+        Assert.Equal (1, queuedAfterPass);
+        Assert.Equal (2, countAfterNextPass);
+    }
+
     [Fact]
     public void TimeSpan_Zero_Executes_Immediately ()
     {

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -7,6 +7,801 @@ namespace ApplicationTests.TimedEventTests;
 [Collection("Application Timer Tests")]
 public class TimedEventsTests
 {
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Callback_Does_Not_Block_Add_From_Other_Thread ()
+    {
+        TimedEvents timedEvents = new ();
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim addStarted = new ();
+        using ManualResetEventSlim addCompleted = new ();
+        Task? addTask = null;
+        var addStartedBeforeCallbackReturned = false;
+        var addCompletedBeforeCallbackReturned = false;
+
+        timedEvents.Add (
+                         TimeSpan.Zero,
+                         () =>
+                         {
+                             addTask = RunOnDedicatedThread (
+                                                             () =>
+                                                             {
+                                                                 try
+                                                                 {
+                                                                     addStarted.Set ();
+                                                                     timedEvents.Add (TimeSpan.FromHours (1), () => false);
+                                                                 }
+                                                                 finally
+                                                                 {
+                                                                     addCompleted.Set ();
+                                                                 }
+                                                             });
+                             addStartedBeforeCallbackReturned = addStarted.Wait (
+                                                                                 TimeSpan.FromSeconds (5),
+                                                                                 cancellationToken);
+                             addCompletedBeforeCallbackReturned = addCompleted.Wait (
+                                                                                     TimeSpan.FromSeconds (5),
+                                                                                     cancellationToken);
+
+                             return false;
+                         });
+
+        timedEvents.RunTimers ();
+        await addTask!;
+
+        Assert.True (addStartedBeforeCallbackReturned, "The Add task should start before the callback returns.");
+        Assert.True (addCompletedBeforeCallbackReturned, "Add should complete before the callback returns.");
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Callback_Does_Not_Block_Invoke_From_Other_Thread ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim invokeStarted = new ();
+        using ManualResetEventSlim invokeCompleted = new ();
+        Task? invokeTask = null;
+        Exception? invokeError = null;
+        var invokeStartedBeforeCallbackCompleted = false;
+        var invokeReturnedBeforeCallbackCompleted = false;
+        var invoked = false;
+
+        app.AddTimeout (
+                        TimeSpan.Zero,
+                        () =>
+                        {
+                            invokeTask = RunOnDedicatedThread (
+                                                                () =>
+                                                                {
+                                                                    try
+                                                                    {
+                                                                        invokeStarted.Set ();
+                                                                        app.Invoke (() => invoked = true);
+                                                                    }
+                                                                    catch (Exception ex)
+                                                                    {
+                                                                        invokeError = ex;
+                                                                    }
+                                                                    finally
+                                                                    {
+                                                                        invokeCompleted.Set ();
+                                                                    }
+                                                                });
+                            invokeStartedBeforeCallbackCompleted = invokeStarted.Wait (
+                                                                                       TimeSpan.FromSeconds (5),
+                                                                                       cancellationToken);
+                            invokeReturnedBeforeCallbackCompleted = invokeCompleted.Wait (
+                                                                                           TimeSpan.FromSeconds (5),
+                                                                                           cancellationToken);
+
+                            return false;
+                        });
+
+        try
+        {
+            app.TimedEvents!.RunTimers ();
+
+            if (invokeCompleted.Wait (TimeSpan.FromSeconds (5), cancellationToken))
+            {
+                app.TimedEvents.RunTimers ();
+            }
+        }
+        finally
+        {
+            app.Dispose ();
+        }
+
+        await invokeTask!;
+
+        Assert.NotNull (invokeTask);
+        Assert.Null (invokeError);
+        Assert.True (invokeStartedBeforeCallbackCompleted, "The Invoke task should start before the callback returns.");
+        Assert.True (invokeReturnedBeforeCallbackCompleted, "Invoke should enqueue before the callback returns.");
+        Assert.True (invoked);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Callback_Does_Not_Block_SynchronizationContext_Post ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SynchronizationContext context = new MainLoopSyncContext (app);
+        using ManualResetEventSlim postStarted = new ();
+        using ManualResetEventSlim postCompleted = new ();
+        Task? postTask = null;
+        Exception? postError = null;
+        var postStartedBeforeCallbackCompleted = false;
+        var postReturnedBeforeCallbackCompleted = false;
+        var posted = false;
+
+        app.AddTimeout (
+                        TimeSpan.Zero,
+                        () =>
+                        {
+                            postTask = RunOnDedicatedThread (
+                                                              () =>
+                                                              {
+                                                                  try
+                                                                  {
+                                                                      postStarted.Set ();
+                                                                      context.Post (_ => posted = true, null);
+                                                                  }
+                                                                  catch (Exception ex)
+                                                                  {
+                                                                      postError = ex;
+                                                                  }
+                                                                  finally
+                                                                  {
+                                                                      postCompleted.Set ();
+                                                                  }
+                                                              });
+                            postStartedBeforeCallbackCompleted = postStarted.Wait (
+                                                                                   TimeSpan.FromSeconds (5),
+                                                                                   cancellationToken);
+                            postReturnedBeforeCallbackCompleted = postCompleted.Wait (
+                                                                                       TimeSpan.FromSeconds (5),
+                                                                                       cancellationToken);
+
+                            return false;
+                        });
+
+        try
+        {
+            app.TimedEvents!.RunTimers ();
+
+            if (postCompleted.Wait (TimeSpan.FromSeconds (5), cancellationToken))
+            {
+                app.TimedEvents.RunTimers ();
+            }
+        }
+        finally
+        {
+            app.Dispose ();
+        }
+
+        await postTask!;
+
+        Assert.NotNull (postTask);
+        Assert.Null (postError);
+        Assert.True (postStartedBeforeCallbackCompleted, "The Post task should start before the callback returns.");
+        Assert.True (postReturnedBeforeCallbackCompleted, "Post should enqueue before the callback returns.");
+        Assert.True (posted);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Callback_Does_Not_Block_SynchronizationContext_Send_Enqueue ()
+    {
+        IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SynchronizationContext context = new MainLoopSyncContext (app);
+        using ManualResetEventSlim sendStarted = new ();
+        using ManualResetEventSlim sendQueued = new ();
+        using ManualResetEventSlim sendReturned = new ();
+        Task? sendTask = null;
+        Exception? sendError = null;
+        var sendStartedBeforeCallbackCompleted = false;
+        var sendQueuedBeforeCallbackCompleted = false;
+        var sendQueuedAfterCallbackCompleted = false;
+        var sendReturnedAfterCallback = false;
+        var sent = false;
+        EventHandler<TimeoutEventArgs> handler = (_, _) => sendQueued.Set ();
+
+        app.AddTimeout (
+                        TimeSpan.Zero,
+                        () =>
+                        {
+                            sendTask = RunOnDedicatedThread (
+                                                              () =>
+                                                              {
+                                                                  try
+                                                                  {
+                                                                      sendStarted.Set ();
+                                                                      context.Send (_ => sent = true, null);
+                                                                  }
+                                                                  catch (Exception ex)
+                                                                  {
+                                                                      sendError = ex;
+                                                                  }
+                                                                  finally
+                                                                  {
+                                                                      sendReturned.Set ();
+                                                                  }
+                                                              });
+                            sendStartedBeforeCallbackCompleted = sendStarted.Wait (
+                                                                                   TimeSpan.FromSeconds (5),
+                                                                                   cancellationToken);
+                            sendQueuedBeforeCallbackCompleted = sendQueued.Wait (
+                                                                                 TimeSpan.FromSeconds (5),
+                                                                                 cancellationToken);
+
+                            return false;
+                        });
+
+        app.TimedEvents!.Added += handler;
+
+        try
+        {
+            app.TimedEvents.RunTimers ();
+            sendQueuedAfterCallbackCompleted = sendQueued.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+            if (sendQueuedAfterCallbackCompleted && !sendReturned.IsSet)
+            {
+                app.TimedEvents.RunTimers ();
+            }
+
+            sendReturnedAfterCallback = sendReturned.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+        }
+        finally
+        {
+            if (sendTask is not null && !sendReturned.IsSet)
+            {
+                sendQueuedAfterCallbackCompleted = WaitForCleanup (sendQueued);
+
+                if (sendQueuedAfterCallbackCompleted)
+                {
+                    app.TimedEvents.RunTimers ();
+                    sendReturnedAfterCallback = WaitForCleanup (sendReturned);
+                }
+            }
+
+            app.TimedEvents.Added -= handler;
+            app.Dispose ();
+
+            if (sendTask is not null)
+            {
+                await sendTask;
+            }
+        }
+
+        Assert.NotNull (sendTask);
+        Assert.Null (sendError);
+        Assert.True (sendStartedBeforeCallbackCompleted, "The Send task should start before the callback returns.");
+        Assert.True (sendQueuedBeforeCallbackCompleted, "Send should enqueue before the callback returns.");
+        Assert.True (sendQueuedAfterCallbackCompleted, "Send should enqueue before cleanup times out.");
+        Assert.True (sendReturnedAfterCallback, "Send should return after its callback runs on the timer runner.");
+        Assert.True (sent);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Callback_Does_Not_Block_Remove_From_Other_Thread ()
+    {
+        TimedEvents timedEvents = new ();
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        object timeoutToRemove = timedEvents.Add (TimeSpan.FromHours (1), () => false);
+        using ManualResetEventSlim removeStarted = new ();
+        using ManualResetEventSlim removeCompleted = new ();
+        Task<bool>? removeTask = null;
+        var removeStartedBeforeCallbackReturned = false;
+        var removeCompletedBeforeCallbackReturned = false;
+
+        timedEvents.Add (
+                         TimeSpan.Zero,
+                         () =>
+                         {
+                             removeTask = RunOnDedicatedThread (
+                                                                () =>
+                                                                {
+                                                                    try
+                                                                    {
+                                                                        removeStarted.Set ();
+
+                                                                        return timedEvents.Remove (timeoutToRemove);
+                                                                    }
+                                                                    finally
+                                                                    {
+                                                                        removeCompleted.Set ();
+                                                                    }
+                                                                });
+                             removeStartedBeforeCallbackReturned = removeStarted.Wait (
+                                                                                       TimeSpan.FromSeconds (5),
+                                                                                       cancellationToken);
+                             removeCompletedBeforeCallbackReturned = removeCompleted.Wait (
+                                                                                           TimeSpan.FromSeconds (5),
+                                                                                           cancellationToken);
+
+                             return false;
+                         });
+
+        timedEvents.RunTimers ();
+        bool removed = await removeTask!;
+
+        Assert.True (removeStartedBeforeCallbackReturned, "The Remove task should start before the callback returns.");
+        Assert.True (removeCompletedBeforeCallbackReturned, "Remove should complete before the callback returns.");
+        Assert.True (removed);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Concurrent_Callers_Do_Not_Execute_Callbacks_Concurrently ()
+    {
+        TimedEvents timedEvents = new ();
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim firstCallbackStarted = new ();
+        using ManualResetEventSlim releaseFirstCallback = new ();
+        using ManualResetEventSlim concurrentCallbackStarted = new ();
+        var activeCallbacks = 0;
+        var callbackCount = 0;
+        var firstCallbackReleased = false;
+
+        Func<bool> callback = () =>
+                              {
+                                  if (Interlocked.Increment (ref activeCallbacks) > 1)
+                                  {
+                                      concurrentCallbackStarted.Set ();
+                                  }
+
+                                  int currentCallback = Interlocked.Increment (ref callbackCount);
+
+                                  if (currentCallback == 1)
+                                  {
+                                      firstCallbackStarted.Set ();
+                                      firstCallbackReleased = releaseFirstCallback.Wait (
+                                                                                         TimeSpan.FromSeconds (5),
+                                                                                         cancellationToken);
+                                  }
+
+                                  Interlocked.Decrement (ref activeCallbacks);
+
+                                  return false;
+                              };
+
+        timedEvents.Add (TimeSpan.Zero, callback);
+        timedEvents.Add (TimeSpan.Zero, callback);
+
+        Task firstRunner = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task? secondRunner = null;
+        var firstCallbackStartedBeforeTimeout = false;
+        var secondRunnerReturned = false;
+        var callbacksRanConcurrently = false;
+
+        try
+        {
+            firstCallbackStartedBeforeTimeout = firstCallbackStarted.Wait (
+                                                                            TimeSpan.FromSeconds (5),
+                                                                            cancellationToken);
+
+            if (firstCallbackStartedBeforeTimeout)
+            {
+                secondRunner = RunOnDedicatedThread (timedEvents.RunTimers);
+                secondRunnerReturned = await CompletesWithinAsync (
+                                                                    secondRunner,
+                                                                    cancellationToken);
+                callbacksRanConcurrently = concurrentCallbackStarted.IsSet;
+            }
+        }
+        finally
+        {
+            releaseFirstCallback.Set ();
+        }
+
+        await firstRunner;
+
+        if (secondRunner is not null)
+        {
+            await secondRunner;
+        }
+
+        Assert.True (firstCallbackStartedBeforeTimeout, "The first callback should start.");
+        Assert.True (firstCallbackReleased, "The first callback should be released before its wait times out.");
+        Assert.True (secondRunnerReturned, "A competing RunTimers caller should return while another runner is active.");
+        Assert.False (callbacksRanConcurrently);
+        Assert.Equal (2, callbackCount);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task Added_Handler_Does_Not_Block_Add_From_Other_Thread ()
+    {
+        TimedEvents timedEvents = new ();
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim addStarted = new ();
+        using ManualResetEventSlim addCompleted = new ();
+        Task? addTask = null;
+        var addStartedBeforeHandlerReturned = false;
+        var addCompletedBeforeHandlerReturned = false;
+        EventHandler<TimeoutEventArgs>? handler = null;
+
+        handler = (_, _) =>
+                  {
+                      timedEvents.Added -= handler;
+                      addTask = RunOnDedicatedThread (
+                                                        () =>
+                                                        {
+                                                            try
+                                                            {
+                                                                addStarted.Set ();
+                                                                timedEvents.Add (TimeSpan.FromHours (1), () => false);
+                                                            }
+                                                            finally
+                                                            {
+                                                                addCompleted.Set ();
+                                                            }
+                                                        });
+                      addStartedBeforeHandlerReturned = addStarted.Wait (
+                                                                         TimeSpan.FromSeconds (5),
+                                                                         cancellationToken);
+                      addCompletedBeforeHandlerReturned = addCompleted.Wait (
+                                                                             TimeSpan.FromSeconds (5),
+                                                                             cancellationToken);
+                  };
+        timedEvents.Added += handler;
+
+        timedEvents.Add (TimeSpan.FromHours (1), () => false);
+        await addTask!;
+
+        Assert.True (addStartedBeforeHandlerReturned, "The Add task should start before the Added handler returns.");
+        Assert.True (addCompletedBeforeHandlerReturned, "Add should complete before the Added handler returns.");
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Remove_Active_Repeating_Timeout_Prevents_Reschedule ()
+    {
+        TimedEvents timedEvents = new ();
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim callbackStarted = new ();
+        using ManualResetEventSlim releaseCallback = new ();
+        var callbackReleased = false;
+        object timeout = timedEvents.Add (
+                                                 TimeSpan.Zero,
+                                                 () =>
+                                                 {
+                                                     callbackStarted.Set ();
+                                                     callbackReleased = releaseCallback.Wait (
+                                                                                              TimeSpan.FromSeconds (5),
+                                                                                              cancellationToken);
+
+                                                     return true;
+                                                 });
+        Task runnerTask = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task<bool>? removeTask = null;
+        var callbackStartedBeforeTimeout = false;
+        var removeReturnedBeforeCallback = false;
+
+        try
+        {
+            callbackStartedBeforeTimeout = callbackStarted.Wait (
+                                                                 TimeSpan.FromSeconds (5),
+                                                                 cancellationToken);
+
+            if (callbackStartedBeforeTimeout)
+            {
+                removeTask = RunOnDedicatedThread (() => timedEvents.Remove (timeout));
+                removeReturnedBeforeCallback = await CompletesWithinAsync (
+                                                                           removeTask,
+                                                                           cancellationToken);
+            }
+        }
+        finally
+        {
+            releaseCallback.Set ();
+        }
+
+        await runnerTask;
+        bool removed = removeTask is not null && await removeTask;
+
+        Assert.True (callbackStartedBeforeTimeout, "The repeating callback should start.");
+        Assert.True (callbackReleased, "The repeating callback should be released before its wait times out.");
+        Assert.True (removeReturnedBeforeCallback, "Remove should return while the callback is active.");
+        Assert.True (removed);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_StopAll_During_Active_Repeating_Timeout_Prevents_Reschedule ()
+    {
+        TimedEvents timedEvents = new ();
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim callbackStarted = new ();
+        using ManualResetEventSlim releaseCallback = new ();
+        var callbackReleased = false;
+
+        timedEvents.Add (
+                         TimeSpan.Zero,
+                         () =>
+                         {
+                             callbackStarted.Set ();
+                             callbackReleased = releaseCallback.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+                             return true;
+                         });
+
+        Task runnerTask = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task? stopAllTask = null;
+        var callbackStartedBeforeTimeout = false;
+        var stopAllReturnedBeforeCallback = false;
+
+        try
+        {
+            callbackStartedBeforeTimeout = callbackStarted.Wait (
+                                                                 TimeSpan.FromSeconds (5),
+                                                                 cancellationToken);
+
+            if (callbackStartedBeforeTimeout)
+            {
+                stopAllTask = RunOnDedicatedThread (timedEvents.StopAll);
+                stopAllReturnedBeforeCallback = await CompletesWithinAsync (
+                                                                            stopAllTask,
+                                                                            cancellationToken);
+            }
+        }
+        finally
+        {
+            releaseCallback.Set ();
+        }
+
+        await runnerTask;
+
+        if (stopAllTask is not null)
+        {
+            await stopAllTask;
+        }
+
+        Assert.True (callbackStartedBeforeTimeout, "The repeating callback should start.");
+        Assert.True (callbackReleased, "The repeating callback should be released before its wait times out.");
+        Assert.True (stopAllReturnedBeforeCallback, "StopAll should return while the callback is active.");
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Competing_Caller_Requests_Follow_Up_Run ()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        long currentTicks = DateTime.UnixEpoch.Ticks;
+        var timeReadCount = 0;
+        var callbackCount = 0;
+        using ManualResetEventSlim dueCheckStarted = new ();
+        using ManualResetEventSlim releaseDueCheck = new ();
+        var dueCheckReleased = false;
+
+        DateTime GetCurrentTime ()
+        {
+            long capturedTicks = Interlocked.Read (ref currentTicks);
+
+            if (Interlocked.Increment (ref timeReadCount) == 2)
+            {
+                dueCheckStarted.Set ();
+                dueCheckReleased = releaseDueCheck.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+            }
+
+            return new (capturedTicks, DateTimeKind.Utc);
+        }
+
+        TimedEvents timedEvents = new (new FuncTimeProvider (GetCurrentTime));
+        timedEvents.Add (
+                         TimeSpan.FromSeconds (1),
+                         () =>
+                         {
+                             Interlocked.Increment (ref callbackCount);
+
+                             return false;
+                         });
+
+        Task firstRunner = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task? secondRunner = null;
+        var dueCheckStartedBeforeTimeout = false;
+        var secondRunnerReturned = false;
+
+        try
+        {
+            dueCheckStartedBeforeTimeout = dueCheckStarted.Wait (
+                                                                 TimeSpan.FromSeconds (5),
+                                                                 cancellationToken);
+
+            if (dueCheckStartedBeforeTimeout)
+            {
+                Interlocked.Exchange (ref currentTicks, DateTime.UnixEpoch.AddSeconds (2).Ticks);
+                secondRunner = RunOnDedicatedThread (timedEvents.RunTimers);
+                secondRunnerReturned = await CompletesWithinAsync (
+                                                                    secondRunner,
+                                                                    cancellationToken);
+            }
+        }
+        finally
+        {
+            releaseDueCheck.Set ();
+        }
+
+        await firstRunner;
+
+        if (secondRunner is not null)
+        {
+            await secondRunner;
+        }
+
+        Assert.True (dueCheckStartedBeforeTimeout, "The first runner should reach the due-time check.");
+        Assert.True (dueCheckReleased, "The due-time check should be released before its wait times out.");
+        Assert.True (secondRunnerReturned, "The competing RunTimers call should return while the runner is active.");
+        Assert.Equal (1, callbackCount);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Competing_Caller_Requests_Follow_Up_Run_When_Callback_Throws ()
+    {
+        TimedEvents timedEvents = new ();
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim callbackStarted = new ();
+        using ManualResetEventSlim releaseCallback = new ();
+        InvalidOperationException expectedException = new ("Expected callback failure.");
+        var followUpCallbackCount = 0;
+        var callbackReleased = false;
+
+        timedEvents.Add (
+                         TimeSpan.Zero,
+                         () =>
+                         {
+                             callbackStarted.Set ();
+                             callbackReleased = releaseCallback.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+                             throw expectedException;
+                         });
+        timedEvents.Add (
+                         TimeSpan.Zero,
+                         () =>
+                         {
+                             Interlocked.Increment (ref followUpCallbackCount);
+
+                             return false;
+                         });
+
+        Task firstRunner = RunOnDedicatedThread (timedEvents.RunTimers);
+        Task? secondRunner = null;
+        var callbackStartedBeforeTimeout = false;
+        var secondRunnerReturned = false;
+
+        try
+        {
+            callbackStartedBeforeTimeout = callbackStarted.Wait (TimeSpan.FromSeconds (5), cancellationToken);
+
+            if (callbackStartedBeforeTimeout)
+            {
+                secondRunner = RunOnDedicatedThread (timedEvents.RunTimers);
+                secondRunnerReturned = await CompletesWithinAsync (secondRunner, cancellationToken);
+            }
+        }
+        finally
+        {
+            releaseCallback.Set ();
+        }
+
+        InvalidOperationException actualException = await Assert.ThrowsAsync<InvalidOperationException> (
+            async () => await firstRunner);
+
+        if (secondRunner is not null)
+        {
+            await secondRunner;
+        }
+
+        Assert.True (callbackStartedBeforeTimeout, "The throwing callback should start.");
+        Assert.True (callbackReleased, "The throwing callback should be released before its wait times out.");
+        Assert.True (secondRunnerReturned, "The competing RunTimers call should return while the runner is active.");
+        Assert.Same (expectedException, actualException);
+        Assert.Equal (1, followUpCallbackCount);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public void RunTimers_StopAll_Cancels_Duplicate_Active_Timeout_Occurrences ()
+    {
+        VirtualTimeProvider timeProvider = new ();
+        TimedEvents timedEvents = new (timeProvider);
+        var callbackCount = 0;
+        Terminal.Gui.App.Timeout timeout = new () { Span = TimeSpan.FromSeconds (1) };
+
+        timeout.Callback = () =>
+                           {
+                               callbackCount++;
+
+                               if (callbackCount == 1)
+                               {
+                                   timedEvents.RunTimers ();
+
+                                   return true;
+                               }
+
+                               timedEvents.StopAll ();
+
+                               return true;
+                           };
+
+        timedEvents.Add (timeout);
+        timedEvents.Add (timeout);
+        timeProvider.Advance (TimeSpan.FromSeconds (2));
+
+        timedEvents.RunTimers ();
+
+        Assert.Equal (2, callbackCount);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
+    // CoPilot - GPT-5
+    [Fact]
+    public async Task RunTimers_Remove_Cancels_Repeating_Duplicate_Active_Timeout_Occurrence ()
+    {
+        VirtualTimeProvider timeProvider = new ();
+        TimedEvents timedEvents = new (timeProvider);
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using ManualResetEventSlim removeCompleted = new ();
+        var callbackCount = 0;
+        var removeCompletedBeforeCallbackReturned = false;
+        Task<bool>? removeTask = null;
+        Terminal.Gui.App.Timeout timeout = new () { Span = TimeSpan.FromSeconds (1) };
+
+        timeout.Callback = () =>
+                           {
+                               callbackCount++;
+
+                               if (callbackCount == 1)
+                               {
+                                   timedEvents.RunTimers ();
+
+                                   return true;
+                               }
+
+                               removeTask = RunOnDedicatedThread (
+                                                                  () =>
+                                                                  {
+                                                                      try
+                                                                      {
+                                                                          return timedEvents.Remove (timeout);
+                                                                      }
+                                                                      finally
+                                                                      {
+                                                                          removeCompleted.Set ();
+                                                                      }
+                                                                  });
+                               removeCompletedBeforeCallbackReturned = removeCompleted.Wait (
+                                                                                                TimeSpan.FromSeconds (5),
+                                                                                                cancellationToken);
+
+                               return false;
+                           };
+
+        timedEvents.Add (timeout);
+        timedEvents.Add (timeout);
+        timeProvider.Advance (TimeSpan.FromSeconds (2));
+
+        timedEvents.RunTimers ();
+        bool removed = await removeTask!;
+
+        Assert.Equal (2, callbackCount);
+        Assert.True (removeCompletedBeforeCallbackReturned, "Remove should return while both occurrences are active.");
+        Assert.True (removed);
+        Assert.Empty (timedEvents.Timeouts);
+    }
+
     [Fact]
     public void HighFrequency_Concurrent_Invocations_No_Lost_Timeouts ()
     {
@@ -166,4 +961,34 @@ public class TimedEventsTests
 
         Assert.Equal (0, executeCount);
     }
+
+    private static async Task<bool> CompletesWithinAsync (Task task, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await task.WaitAsync (TimeSpan.FromSeconds (5), cancellationToken).ConfigureAwait (false);
+
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static Task RunOnDedicatedThread (Action action) =>
+        Task.Factory.StartNew (
+                               action,
+                               CancellationToken.None,
+                               TaskCreationOptions.LongRunning,
+                               TaskScheduler.Default);
+
+    private static Task<TResult> RunOnDedicatedThread<TResult> (Func<TResult> action) =>
+        Task.Factory.StartNew (
+                               action,
+                               CancellationToken.None,
+                               TaskCreationOptions.LongRunning,
+                               TaskScheduler.Default);
+
+    private static bool WaitForCleanup (ManualResetEventSlim waitHandle) => waitHandle.Wait (TimeSpan.FromSeconds (5));
 }

--- a/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Timeouts/TimedEventsTests.cs
@@ -746,28 +746,6 @@ public class TimedEventsTests
 
     // Claude - Opus 5
     [Fact]
-    public void RunTimers_Added_Handler_Exception_Does_Not_Replace_Callback_Exception ()
-    {
-        TimedEvents timedEvents = new ();
-        InvalidOperationException expectedException = new ("Expected callback failure.");
-
-        // A repeating timeout that throws. Added is raised outside the finally that completes the
-        // occurrence, so a throwing subscriber must not be able to displace the callback's exception.
-        timedEvents.Add (TimeSpan.FromMilliseconds (1), () => throw expectedException);
-        timedEvents.Added += (_, _) => throw new NotSupportedException ("Added handler failure.");
-
-        Thread.Sleep (5);
-
-        InvalidOperationException actualException = Assert.Throws<InvalidOperationException> (timedEvents.RunTimers);
-
-        Assert.Same (expectedException, actualException);
-
-        // A throwing callback is not rescheduled, so the queue drains.
-        Assert.Empty (timedEvents.Timeouts);
-    }
-
-    // Claude - Opus 5
-    [Fact]
     public void RunTimers_Added_Handler_Exception_During_Reschedule_Leaves_Timeout_Scheduled ()
     {
         TimedEvents timedEvents = new ();


### PR DESCRIPTION
- Fixes #5652

## Summary

- Execute timeout callbacks outside the timeout-queue lock so callbacks can add or remove timers and `IApplication.Invoke` can enqueue work from other threads. Because `Invoke` is implemented as `TimedEvents.Add (TimeSpan.Zero, …)`, every cross-thread `Invoke`, `Post`, and `Send` previously blocked for the full duration of every timer callback.
- Serialize callbacks with a reentrant runner gate. A competing `RunTimers` call returns, a later pass handles remaining due timers, and callback exceptions propagate directly and end the current pass.
- Assign each queued timeout occurrence an identity and execute only occurrences already due when a timer pass starts. This prevents an immediately repeating timeout from spinning or consuming every pass slot ahead of an already-due peer.
- Treat a reused `Timeout` reference as one cancellation token: `Remove` cancels all queued and active occurrences ordered before it without interrupting an executing callback. Removal generations and a `StopAll` epoch keep later additions unaffected without allocating per callback.
- Scan the whole queue by reference in `Remove` and `GetTimeout`. Both previously used `SortedList.IndexOfValue`, which returns only the first match, so removing a `Timeout` that had been queued more than once left the remaining occurrences scheduled and still firing.
- Cancel an in-flight repeating callback. `Remove` during execution was previously a silent no-op, and the callback rescheduled itself regardless.
- Return a synchronized snapshot from `Timeouts`, validate `Add(Timeout)` inputs at the call site, and report the collision-adjusted queue key through `Added`.
- Raise `TimedEvents.Added` after releasing the queue lock. A concurrent runner may execute a due timeout before its `Added` handler runs.
- Evaluate virtual `Timeout.Span` getters and injected time providers outside the queue lock. Repeating occurrences remain active during these reads and revalidate their removal generation and `StopAll` epoch before rescheduling. Empty timer passes return before reading the provider.
- Replace the orphaned `<inheritdoc/>` on `CheckTimers`, which is not declared on `ITimedEvents` and therefore inherited nothing.
- Cover direct `IApplication.Invoke` and `MainLoopSyncContext.Post`/`Send` paths introduced by #5641. `Send` enqueues without the timeout-queue lock but still waits synchronously for main-loop execution by design.
- Document the concurrency, cancellation, event-ordering, exception, and synchronous-dispatch contracts, including that an `Added` handler exception ends the timer pass while leaving the timeout scheduled.

### SkillView consumer reproduction

SkillView 0.3 exposed the lock cycle in a real nested-modal workflow. A timeout-delivered UI callback opened the cleanup modal, then the removal worker tried to report its terminal progress through `IApplication.Invoke`. The captured stacks were:

```text
UI:     CleanupScreen.Show → IApplication.Run → TimedEvents.RunTimersImpl
worker: RemoveService.BatchProgressAdapter.CompleteBatch → CallbackProgress.Report
        → CleanupScreen.InvokeIfActive → IApplication.Invoke → TimedEvents.AddTimeout → Monitor.Enter
```

The worker had completed two removal validations with refusals, but it could not enqueue the completion callback while the outer timer callback retained the queue lock. The modal therefore stayed on `removing...`; pressing Escape changed it to `canceling removal...`, but cancellation could not finish and the rest of the UI remained unavailable. `CrossThread_Invoke_Executes_During_Nested_Run_Started_From_Timeout` now covers this combined condition and verifies that the queued callback executes while the nested dialog is active.

## Testing

- Required CI: all build, documentation, performance, integration, and unit-test jobs passed on macOS, Ubuntu, and Windows
- Targeted build: 0 errors and 3 pre-existing warnings — `CS0419` in `ViewBase/View.Drawing.cs` and `CS1574` ×2 in `Views/DropDownList.cs`. None are in files this PR touches, and the change introduces no new warnings.
- `TimedEventsTests`: 40 passed
- Nested-run tests: 6 passed
- Timeout tests: 38 passed
- Non-parallel tests: 72 passed, 2 skipped
- Integration tests: 343 passed, with the known local GitVersion assembly-version failure
- Full parallel run: 17,628 passed, 17 skipped, with 5 unrelated ANSI/color-output baseline failures

### Verified behaviors

Beyond the assertions in the suite, these were confirmed with throwaway probes:

- A repeating `TimeSpan.Zero` timeout runs exactly once per pass. Before the pass bound, it re-ran indefinitely — measured at ~17.4M invocations in 3 seconds with `RunTimers` never returning, which starves drawing, input, and shutdown.
- A zero-span repeater no longer prevents an already-due peer from running in the same pass. Both zero-delay regression tests use lock-free stop signals so a broken pass bound fails cleanly instead of hanging during cleanup.
- A throwing callback leaves no residue: the active-state map, the occurrence-ID map, and the queue all return to empty.
- A throwing `Added` subscriber on the reschedule path leaves the active-state map empty and the queue and occurrence-ID map consistent; the timeout stays scheduled and later passes keep running it.
- Blocking `Timeout.Span` overrides and time-provider reads no longer block concurrent timeout removal or addition; cancellation during a repeat-interval read still prevents rescheduling.

## Review notes

Draft pending final review. The normal local GitVersion step hung in `GitVersion.MsBuild` on one machine; the equivalent build with `DisableGitVersionTask=true` passed, as does a plain `dotnet build`. Solution builds emit only the pre-existing compiler warnings listed above plus sandbox-related NuGet audit-cache warnings (`NU1900`).

# To pull down this PR locally:
git remote add copilot https://github.com/harder/Terminal.Gui.git
git fetch copilot fix/5652-timed-events-locking
git checkout copilot/fix/5652-timed-events-locking




