### PR TITLE
Addresses #5630. Bump next version to 2.5.0 for breaking API +semver: minor

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -21,6 +21,7 @@
 # - from develop: 2.0.0-develop.1 (patch version increments)
 # - from main (pre-release): 2.0.0-prealpha.1 or 2.0.0-beta.1
 # - from main (release): 2.0.0 (patch version increments)
+# - To bump minor on develop, include `+semver: minor` in a commit message. Do not pin next-version.
 #
 mode: ContinuousDelivery   # GitVersion 6.x is configured here to use ContinuousDelivery mode for this GitFlow-style setup
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fixes

- Addresses #5630 (Workstream 2: version bump on develop).

## Summary

I am landing the `+semver: minor` commit that #5630 Workstream 2 asked for.

PR #5416 merged to `develop` as `8c9b818d` without `+semver: minor`. Publish already ran on that push and shipped `Terminal.Gui` / `Terminal.Gui.Interop.Spectre` `2.4.18-develop.54` (GitVersion_SemVer in run 33698807209). That package contains the ConfigurationManager deletion breaking API.

`GitVersion.yml` on develop is `increment: Patch` and `commit-message-incrementing` stays at the GitVersion 6 default (`Enabled`). Subsequent develop packages will stay `2.4.18-develop.*` until a commit whose message matches `\+semver:\s?(feature|minor)` lands on develop.

The next develop NuGet after this merges should be `2.5.0-develop.N`.

I am not unlisting or deleting `2.4.18-develop.54`.

## Changes

- Add one header comment in `GitVersion.yml` documenting the `+semver: minor` commit-message bump.
- I did not add a `next-version` pin. The v2.5.0 tag remains the source of truth after release.
- I did not change develop `increment: Patch` to Minor.

I used a `GitVersion.yml` comment instead of a markdown-only or empty commit because `publish.yml`, `build-validation.yml`, and `unit-tests.yml` all ignore `**.md`. A markdown-only change would not trigger CI here, and would not trigger publish after merge.

The repo has no prior `+semver` commits and no `next-version` pin. GitVersion 6 commit-message incrementing is the established bump path.

## Merge note

Keep `+semver: minor` in the merge or squash commit message, and do not add a higher bump token. GitVersion 6 reads those tokens from commits since `v2.4.17`, and a higher bump wins. This PR's title and HEAD commit both include only the minor token. GitHub squash is set to `COMMIT_OR_PR_TITLE` with `COMMIT_MESSAGES`, so a single-commit squash should preserve the commit subject.

## Testing

I verified the bump locally with the GitVersion 6.8.2 standalone CLI (same major.minor.patch as `GitVersion.MsBuild` 6.8.2 in `Directory.Packages.props`):

- `origin/develop` at `8c9b818d`: `2.4.18-develop.54` (matches the already published package).
- Same commit cherry-picked onto a local `develop` branch: `2.5.0-develop.55`.
- A commit message that also includes a higher bump token: `3.0.0-*`.
- A commit message with only `+semver: minor`: `2.5.0-*`.

No product code changed. I did not run the unit-test suite for a header comment.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/tui-cs/Terminal.Gui/blob/develop/.editorconfig)
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/tui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit (not applicable: comment-only change)
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

## To pull down this PR locally:

```bash
git fetch origin cursor/semver-minor-2.5.0-25e1
git checkout cursor/semver-minor-2.5.0-25e1
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f303544c-ec36-4101-b8af-512cb8b525e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f303544c-ec36-4101-b8af-512cb8b525e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

