### PR TITLE
Fixes #5635. Hide active popover on DeRegister to clear stale cells

### DIFF
--- a/Terminal.Gui/App/ApplicationPopover.cs
+++ b/Terminal.Gui/App/ApplicationPopover.cs
@@ -57,7 +57,9 @@ public sealed class ApplicationPopover : IDisposable
     ///     When a popover is registered, the View instance lifetime is managed by the application. Call
     ///     <see cref="DeRegister"/>
     ///     to manage the lifetime of the popover directly.
-    ///     If <paramref name="popover"/> is the active popover, it is hidden first so the region it covered is invalidated.
+    ///     If <paramref name="popover"/> is the active popover, it is removed from the registry first, then hidden so the
+    ///     region it covered is invalidated. Unregistering before <see cref="Hide"/> prevents a
+    ///     <see cref="View.VisibleChanged"/> handler from calling <see cref="Show"/> during hide.
     /// </remarks>
     /// <param name="popover"></param>
     /// <returns></returns>
@@ -68,22 +70,26 @@ public sealed class ApplicationPopover : IDisposable
             return false;
         }
 
-        if (GetActivePopover () == popover)
+        bool wasActive = GetActivePopover () == popover;
+
+        // Unregister before Hide. Hide sets Visible=false and raises VisibleChanged.
+        // A handler can call Show only while the popover is still registered.
+        _popovers.Remove (popover);
+
+        if (wasActive)
         {
-            // Hide first so Visible is cleared and the covered region is invalidated.
-            // Clearing _activePopover alone leaves stale cells (see #5635).
+            // Hide after unregister so the covered region is still invalidated (#5635).
             Hide (popover);
         }
 
-        _popovers.Remove (popover);
-
-        // Hide sets Visible=false, which raises VisibleChanged. A handler can call Show
-        // and restore _activePopover before we return. The caller asked to deregister,
-        // so do not leave an unregistered popover as the active one.
+        // A VisibleChanged handler may have re-registered via MakeVisible and restored
+        // _activePopover. The caller asked to deregister.
         if (GetActivePopover () == popover)
         {
             _activePopover = null;
         }
+
+        _popovers.Remove (popover);
 
         PopoverDeRegistered?.Invoke (this, new EventArgs<IPopoverView> (popover));
 

--- a/Terminal.Gui/App/ApplicationPopover.cs
+++ b/Terminal.Gui/App/ApplicationPopover.cs
@@ -57,6 +57,7 @@ public sealed class ApplicationPopover : IDisposable
     ///     When a popover is registered, the View instance lifetime is managed by the application. Call
     ///     <see cref="DeRegister"/>
     ///     to manage the lifetime of the popover directly.
+    ///     If <paramref name="popover"/> is the active popover, it is hidden first so the region it covered is invalidated.
     /// </remarks>
     /// <param name="popover"></param>
     /// <returns></returns>
@@ -69,7 +70,9 @@ public sealed class ApplicationPopover : IDisposable
 
         if (GetActivePopover () == popover)
         {
-            _activePopover = null;
+            // Hide first so Visible is cleared and the covered region is invalidated.
+            // Clearing _activePopover alone leaves stale cells (see #5635).
+            Hide (popover);
         }
 
         _popovers.Remove (popover);

--- a/Terminal.Gui/App/ApplicationPopover.cs
+++ b/Terminal.Gui/App/ApplicationPopover.cs
@@ -77,6 +77,14 @@ public sealed class ApplicationPopover : IDisposable
 
         _popovers.Remove (popover);
 
+        // Hide sets Visible=false, which raises VisibleChanged. A handler can call Show
+        // and restore _activePopover before we return. The caller asked to deregister,
+        // so do not leave an unregistered popover as the active one.
+        if (GetActivePopover () == popover)
+        {
+            _activePopover = null;
+        }
+
         PopoverDeRegistered?.Invoke (this, new EventArgs<IPopoverView> (popover));
 
         return true;

--- a/Terminal.Gui/Views/DropDownList.cs
+++ b/Terminal.Gui/Views/DropDownList.cs
@@ -234,6 +234,10 @@ public class DropDownList : TextField
             return false;
         }
 
+        // Hide while the popover is still active so Hide can invalidate the covered region.
+        // DeRegister after that also hides if still active; doing Hide here covers the
+        // keyboard Accepting+Handled path that moves focus before OnAccepted runs (#5635).
+        App?.Popovers?.Hide (_listPopover);
         App?.Popovers?.DeRegister (_listPopover);
 
         return false;

--- a/Tests/AppTestHelpers/AppTestHelper.cs
+++ b/Tests/AppTestHelpers/AppTestHelper.cs
@@ -181,7 +181,7 @@ public partial class AppTestHelper : IDisposable
                                  catch (Exception ex)
                                  {
                                      _backgroundException = ex;
-                                     _ansiInput.ExternalCancellationTokenSource!.Cancel ();
+                                     _ansiInput.ExternalCancellationTokenSource?.Cancel ();
                                  }
                                  finally
                                  {
@@ -314,8 +314,15 @@ public partial class AppTestHelper : IDisposable
     /// <returns></returns>
     public AppTestHelper WaitIteration (Action<IApplication>? action = null)
     {
-        // If application has already exited don't wait!
-        if (Finished || _runCancellationTokenSource.Token.IsCancellationRequested || _ansiInput.ExternalCancellationTokenSource!.Token.IsCancellationRequested)
+        CancellationTokenSource? externalCts = _ansiInput.ExternalCancellationTokenSource;
+
+        // If application has already exited don't wait.
+        // ExternalCancellationTokenSource can already be null during shutdown:
+        // CleanupApplication nulls it, and Stop/Dispose still call WaitIteration.
+        if (Finished
+            || _runCancellationTokenSource.Token.IsCancellationRequested
+            || externalCts is null
+            || externalCts.Token.IsCancellationRequested)
         {
             Logging.Warning ("WaitIteration called after context was stopped");
 
@@ -359,7 +366,7 @@ public partial class AppTestHelper : IDisposable
         [
             _runCancellationTokenSource.Token.WaitHandle,
             ctsActionCompleted.Token.WaitHandle,
-            _ansiInput.ExternalCancellationTokenSource!.Token.WaitHandle
+            externalCts.Token.WaitHandle
         ];
 
         WaitHandle.WaitAny (waitHandles);
@@ -565,15 +572,27 @@ public partial class AppTestHelper : IDisposable
         throw new Exception (reason);
     }
 
+    /// <summary>
+    ///     Test hook: nulls the external cancellation source without marking <see cref="Finished"/>.
+    ///     Matches the shutdown race where <see cref="CleanupApplication"/> clears the source
+    ///     while <see cref="WaitIteration"/> is still running.
+    /// </summary>
+    internal void ClearExternalCancellationTokenSourceForTests ()
+    {
+        _ansiInput.ExternalCancellationTokenSource = null;
+    }
+
     private void CleanupApplication ()
     {
         Logging.Trace ("CleanupApplication");
+
+        // Mark finished first so WaitIteration can return without touching the CTS.
+        Finished = true;
         _ansiInput.ExternalCancellationTokenSource = null;
 
         App?.ResetState (true);
         _loggerScope?.Dispose ();
         _loggerScope = null;
-        Finished = true;
 
         Application.MaximumIterationsPerSecond = Application.DefaultMaximumIterationsPerSecond;
     }

--- a/Tests/AppTestHelpers/AppTestHelpers.csproj
+++ b/Tests/AppTestHelpers/AppTestHelpers.csproj
@@ -15,4 +15,8 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="UnitTests.Parallelizable" />
+	</ItemGroup>
+
 </Project>

--- a/Tests/UnitTestsParallelizable/AppTestHelpers/AppTestHelperShutdownTests.cs
+++ b/Tests/UnitTestsParallelizable/AppTestHelpers/AppTestHelperShutdownTests.cs
@@ -1,0 +1,24 @@
+using AppTestHelpers;
+
+namespace AppTestHelpersTests;
+
+public class AppTestHelperShutdownTests
+{
+    // CoPilot - Grok 4.6
+    /// <summary>
+    ///     Regression for the macOS IntegrationTests NRE on #5657:
+    ///     WaitIteration used ExternalCancellationTokenSource! during Stop/Dispose.
+    ///     CleanupApplication can null that source before Finished is set.
+    /// </summary>
+    [Fact]
+    public void WaitIteration_WhenExternalCancellationTokenSourceIsNull_DoesNotThrow ()
+    {
+        using AppTestHelper helper = new (DriverRegistry.Names.DOTNET);
+
+        helper.ClearExternalCancellationTokenSourceForTests ();
+
+        Exception? ex = Record.Exception (() => helper.WaitIteration ());
+
+        Assert.Null (ex);
+    }
+}

--- a/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
@@ -70,6 +70,48 @@ public class ApplicationPopoverTests
         app.End (token!);
     }
 
+    // CoPilot - Grok 4.6
+    /// <summary>
+    ///     If Hide raises VisibleChanged and a handler calls Show, DeRegister must not
+    ///     leave that popover active after removing it from the registry.
+    /// </summary>
+    [Fact]
+    public void DeRegister_ActivePopover_ReentrantShow_DoesNotLeaveUnregisteredActive ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (40, 15);
+
+        using Runnable top = new ();
+        SessionToken? token = app.Begin (top);
+
+        PopoverTestClass popover = new () { App = app, Width = 10, Height = 3 };
+        app.Popovers!.Register (popover);
+        app.Popovers.Show (popover);
+
+        var reopened = false;
+
+        popover.VisibleChanged += (_, _) =>
+                                  {
+                                      if (popover.Visible || reopened)
+                                      {
+                                          return;
+                                      }
+
+                                      reopened = true;
+                                      app.Popovers.Show (popover);
+                                  };
+
+        bool result = app.Popovers.DeRegister (popover);
+
+        Assert.True (result);
+        Assert.True (reopened);
+        Assert.DoesNotContain (popover, app.Popovers.Popovers);
+        Assert.Null (app.Popovers.GetActivePopover ());
+
+        app.End (token!);
+    }
+
     [Fact]
     public void Show_SetsActivePopover ()
     {

--- a/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
@@ -98,6 +98,11 @@ public class ApplicationPopoverTests
                                           return;
                                       }
 
+                                      if (!app.Popovers.IsRegistered (popover))
+                                      {
+                                          return;
+                                      }
+
                                       reopened = true;
                                       app.Popovers.Show (popover);
                                   };
@@ -105,9 +110,66 @@ public class ApplicationPopoverTests
         bool result = app.Popovers.DeRegister (popover);
 
         Assert.True (result);
-        Assert.True (reopened);
+        Assert.False (reopened);
         Assert.DoesNotContain (popover, app.Popovers.Popovers);
         Assert.Null (app.Popovers.GetActivePopover ());
+        Assert.False (popover.Visible);
+
+        app.End (token!);
+    }
+
+    // CoPilot - Grok 4.6
+    /// <summary>
+    ///     Codex P2 on #5657: Hide runs while the popover is still registered, so a
+    ///     VisibleChanged handler can call Show and restore Visible. After DeRegister
+    ///     the popover must be unregistered, not active, and not visible.
+    /// </summary>
+    [Fact]
+    public void DeRegister_VisibleChangedShow_LeavesUnregisteredInactiveAndHidden ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (40, 15);
+
+        using Runnable top = new ();
+        SessionToken? token = app.Begin (top);
+        app.LayoutAndDraw ();
+
+        PopoverTestClass popover = new () { App = app, Width = 10, Height = 3 };
+        app.Popovers!.Register (popover);
+        app.Popovers.Show (popover);
+        app.LayoutAndDraw ();
+
+        var registeredDuringHide = false;
+        var reopened = false;
+
+        popover.VisibleChanged += (_, _) =>
+                                  {
+                                      if (popover.Visible)
+                                      {
+                                          return;
+                                      }
+
+                                      registeredDuringHide = app.Popovers.IsRegistered (popover);
+
+                                      if (!registeredDuringHide)
+                                      {
+                                          return;
+                                      }
+
+                                      reopened = true;
+                                      app.Popovers.Show (popover);
+                                  };
+
+        bool result = app.Popovers.DeRegister (popover);
+
+        Assert.True (result);
+        Assert.False (registeredDuringHide, "DeRegister must unregister before Hide so Show cannot run during VisibleChanged.");
+        Assert.False (reopened);
+        Assert.False (app.Popovers.IsRegistered (popover));
+        Assert.Null (app.Popovers.GetActivePopover ());
+        Assert.False (popover.Visible);
+        Assert.True (top.NeedsDraw);
 
         app.End (token!);
     }

--- a/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
+++ b/Tests/UnitTestsParallelizable/Application/Popover/Application.PopoverTests.cs
@@ -35,6 +35,41 @@ public class ApplicationPopoverTests
         Assert.DoesNotContain (popover, popoverManager.Popovers);
     }
 
+    // CoPilot - Grok 4.6
+    /// <summary>
+    ///     Regression for https://github.com/tui-cs/Terminal.Gui/issues/5635.
+    ///     DeRegister of the active popover must Hide it so the covered region is invalidated.
+    /// </summary>
+    [Fact]
+    public void DeRegister_ActivePopover_HidesAndInvalidatesTopRunnable ()
+    {
+        using IApplication app = Application.Create ();
+        app.Init (DriverRegistry.Names.ANSI);
+        app.Driver!.SetScreenSize (40, 15);
+
+        using Runnable top = new ();
+        SessionToken? token = app.Begin (top);
+
+        PopoverTestClass popover = new () { App = app, Width = 10, Height = 3 };
+        app.Popovers!.Register (popover);
+        app.Popovers.Show (popover);
+        app.LayoutAndDraw ();
+
+        Assert.Equal (popover, app.Popovers.GetActivePopover ());
+        Assert.True (popover.Visible);
+        Assert.False (top.NeedsDraw);
+
+        bool result = app.Popovers.DeRegister (popover);
+
+        Assert.True (result);
+        Assert.DoesNotContain (popover, app.Popovers.Popovers);
+        Assert.Null (app.Popovers.GetActivePopover ());
+        Assert.False (popover.Visible);
+        Assert.True (top.NeedsDraw);
+
+        app.End (token!);
+    }
+
     [Fact]
     public void Show_SetsActivePopover ()
     {

--- a/Tests/UnitTestsParallelizable/Views/DropDownListTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/DropDownListTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Text;
 using UnitTests;
 
 namespace ViewsTests;
@@ -1223,8 +1224,201 @@ public class DropDownListTests (ITestOutputHelper output)
         app.End (token!);
     }
 
+    // CoPilot - Grok 4.6
+    /// <summary>
+    ///     Regression for https://github.com/tui-cs/Terminal.Gui/issues/5635.
+    ///     Keyboard Enter with Accepting Handled and a focus move must not leave the dropped
+    ///     list's text in cells the popover previously covered.
+    /// </summary>
+    [Fact]
+    public void Enter_HandledAccepting_DoesNotLeaveStalePopoverCells ()
+    {
+        using HandledAcceptRepro repro = HandledAcceptRepro.Create ();
+
+        repro.DropDown.SetFocus ();
+        repro.App.InjectKey (Key.F4);
+        repro.App.LayoutAndDraw ();
+
+        IPopoverView? popover = FindDropDownPopover (repro.App);
+        Assert.NotNull (popover);
+        Assert.True (popover.Visible);
+
+        string openBuffer = ReadScreen (repro.App);
+        output.WriteLine ("Open:\n{0}", openBuffer);
+        Assert.Contains ("Equipment", openBuffer, StringComparison.Ordinal);
+
+        repro.App.InjectKey (Key.CursorDown);
+        repro.App.InjectKey (Key.Enter);
+        repro.App.LayoutAndDraw ();
+
+        Assert.Equal ("Fuel/Energy", repro.DropDown.Text);
+        Assert.True (repro.NextView.HasFocus);
+        Assert.False (popover.Visible);
+        Assert.NotEqual (popover, repro.App.Popovers?.GetActivePopover ());
+
+        string closedBuffer = ReadScreen (repro.App);
+        output.WriteLine ("Closed:\n{0}", closedBuffer);
+        Assert.Contains ("COVERED-AREA-3", closedBuffer, StringComparison.Ordinal);
+        Assert.DoesNotContain ("Equipment", closedBuffer, StringComparison.Ordinal);
+    }
+
+    // CoPilot - Grok 4.6
+    /// <summary>
+    ///     Regression for https://github.com/tui-cs/Terminal.Gui/issues/5635.
+    ///     Mouse accept with Accepting Handled must still repaint the covered region.
+    /// </summary>
+    [Fact]
+    public void MouseAccept_HandledAccepting_DoesNotLeaveStalePopoverCells ()
+    {
+        using HandledAcceptRepro repro = HandledAcceptRepro.Create ();
+
+        repro.DropDown.SetFocus ();
+        repro.App.InjectKey (Key.F4);
+        repro.App.LayoutAndDraw ();
+
+        Popover<ListView, string?>? popover = FindDropDownPopover (repro.App) as Popover<ListView, string?>;
+        Assert.NotNull (popover);
+        Assert.True (popover.Visible);
+        Assert.NotNull (popover.ContentView);
+
+        Rectangle listFrame = popover.ContentView.FrameToScreen ();
+        Point clickPos = new (listFrame.X + 1, listFrame.Y + 1);
+
+        DateTime baseTime = new (2025, 1, 1, 12, 0, 0);
+        InputInjectionOptions options = new () { Mode = InputInjectionMode.Direct };
+        IInputInjector injector = repro.App.GetInputInjector ();
+
+        injector.InjectMouse (new Mouse { ScreenPosition = clickPos, Flags = MouseFlags.LeftButtonPressed, Timestamp = baseTime }, options);
+        injector.InjectMouse (new Mouse { ScreenPosition = clickPos, Flags = MouseFlags.LeftButtonReleased, Timestamp = baseTime.AddMilliseconds (50) }, options);
+
+        repro.App.LayoutAndDraw ();
+
+        Assert.Equal ("Fuel/Energy", repro.DropDown.Text);
+        Assert.True (repro.NextView.HasFocus);
+        Assert.False (popover.Visible);
+        Assert.NotEqual (popover, repro.App.Popovers?.GetActivePopover ());
+
+        string closedBuffer = ReadScreen (repro.App);
+        output.WriteLine ("Closed:\n{0}", closedBuffer);
+        Assert.Contains ("COVERED-AREA-3", closedBuffer, StringComparison.Ordinal);
+        Assert.DoesNotContain ("Equipment", closedBuffer, StringComparison.Ordinal);
+    }
+
     // Helper to find the DropDownList popover (excludes the context menu popover)
     private static IPopoverView? FindDropDownPopover (IApplication app) => app.Popovers?.Popovers.OfType<Popover<ListView, string?>> ().FirstOrDefault ();
+
+    private static string ReadScreen (IApplication app)
+    {
+        Cell [,]? contents = app.Driver!.GetOutputBuffer ().Contents;
+        Assert.NotNull (contents);
+
+        int rows = contents.GetLength (0);
+        int cols = contents.GetLength (1);
+        StringBuilder builder = new ();
+
+        for (var row = 0; row < rows; row++)
+        {
+            for (var col = 0; col < cols; col++)
+            {
+                builder.Append (contents [row, col].Grapheme);
+            }
+
+            builder.AppendLine ();
+        }
+
+        return builder.ToString ();
+    }
+
+    /// <summary>
+    ///     Dialog repro for handled Accepting: read-only DropDownList over a Label, ListView as the next focus target.
+    /// </summary>
+    private sealed class HandledAcceptRepro : IDisposable
+    {
+        private readonly SessionToken? _token;
+
+        private HandledAcceptRepro (IApplication app, Dialog dialog, DropDownList dropDown, ListView nextView, SessionToken? token)
+        {
+            App = app;
+            Dialog = dialog;
+            DropDown = dropDown;
+            NextView = nextView;
+            _token = token;
+        }
+
+        public IApplication App { get; }
+
+        public Dialog Dialog { get; }
+
+        public DropDownList DropDown { get; }
+
+        public ListView NextView { get; }
+
+        public static HandledAcceptRepro Create ()
+        {
+            IApplication app = Application.Create ();
+            app.Init (DriverRegistry.Names.ANSI);
+            app.Driver!.SetScreenSize (40, 15);
+
+            Dialog dialog = new ()
+            {
+                X = 0,
+                Y = 0,
+                Width = 40,
+                Height = 12,
+                Title = "Repro",
+                ShadowStyle = ShadowStyles.None
+            };
+
+            ObservableCollection<string> items = ["Labor", "Fuel/Energy", "Equipment"];
+
+            DropDownList dropDown = new ()
+            {
+                X = 0,
+                Y = 0,
+                Width = 20,
+                ReadOnly = true,
+                Source = new ListWrapper<string> (items),
+                Text = "Labor"
+            };
+
+            Label covered1 = new () { X = 0, Y = 1, Width = 20, Text = "COVERED-AREA-1" };
+            Label covered2 = new () { X = 0, Y = 2, Width = 20, Text = "COVERED-AREA-2" };
+            Label covered3 = new () { X = 0, Y = 3, Width = 20, Text = "COVERED-AREA-3" };
+
+            ListView nextView = new ()
+            {
+                X = 0,
+                Y = 5,
+                Width = 20,
+                Height = 3,
+                Source = new ListWrapper<string> (new ObservableCollection<string> (["NextA", "NextB", "NextC"]))
+            };
+
+            dropDown.Accepting += (_, e) =>
+                                  {
+                                      e.Handled = true;
+                                      nextView.SetFocus ();
+                                  };
+
+            dialog.Add (dropDown, covered1, covered2, covered3, nextView);
+
+            SessionToken? token = app.Begin (dialog);
+            app.LayoutAndDraw ();
+
+            return new HandledAcceptRepro (app, dialog, dropDown, nextView, token);
+        }
+
+        public void Dispose ()
+        {
+            if (_token is { })
+            {
+                App.End (_token);
+            }
+
+            Dialog.Dispose ();
+            App.Dispose ();
+        }
+    }
 }
 
 public class DropDownListGenericTests

--- a/Tests/UnitTestsParallelizable/Views/DropDownListTests.cs
+++ b/Tests/UnitTestsParallelizable/Views/DropDownListTests.cs
@@ -1248,13 +1248,19 @@ public class DropDownListTests (ITestOutputHelper output)
         Assert.Contains ("Equipment", openBuffer, StringComparison.Ordinal);
 
         repro.App.InjectKey (Key.CursorDown);
+        Assert.False (repro.CoveredLabel.NeedsDraw);
+        Assert.False (repro.Dialog.NeedsDraw);
+
         repro.App.InjectKey (Key.Enter);
-        repro.App.LayoutAndDraw ();
 
         Assert.Equal ("Fuel/Energy", repro.DropDown.Text);
         Assert.True (repro.NextView.HasFocus);
         Assert.False (popover.Visible);
         Assert.NotEqual (popover, repro.App.Popovers?.GetActivePopover ());
+        Assert.True (repro.Dialog.NeedsDraw, "Hide must invalidate the dialog so covered cells are repainted.");
+        Assert.True (repro.CoveredLabel.NeedsDraw, "The label the popover covered must be invalidated.");
+
+        repro.App.LayoutAndDraw ();
 
         string closedBuffer = ReadScreen (repro.App);
         output.WriteLine ("Closed:\n{0}", closedBuffer);
@@ -1291,12 +1297,15 @@ public class DropDownListTests (ITestOutputHelper output)
         injector.InjectMouse (new Mouse { ScreenPosition = clickPos, Flags = MouseFlags.LeftButtonPressed, Timestamp = baseTime }, options);
         injector.InjectMouse (new Mouse { ScreenPosition = clickPos, Flags = MouseFlags.LeftButtonReleased, Timestamp = baseTime.AddMilliseconds (50) }, options);
 
-        repro.App.LayoutAndDraw ();
-
+        // Mouse selection uses Activate, not Accept. The Accepting handler may not move focus.
+        // The covered region must still be invalidated.
         Assert.Equal ("Fuel/Energy", repro.DropDown.Text);
-        Assert.True (repro.NextView.HasFocus);
         Assert.False (popover.Visible);
         Assert.NotEqual (popover, repro.App.Popovers?.GetActivePopover ());
+        Assert.True (repro.Dialog.NeedsDraw, "Hide must invalidate the dialog so covered cells are repainted.");
+        Assert.True (repro.CoveredLabel.NeedsDraw, "The label the popover covered must be invalidated.");
+
+        repro.App.LayoutAndDraw ();
 
         string closedBuffer = ReadScreen (repro.App);
         output.WriteLine ("Closed:\n{0}", closedBuffer);
@@ -1336,12 +1345,13 @@ public class DropDownListTests (ITestOutputHelper output)
     {
         private readonly SessionToken? _token;
 
-        private HandledAcceptRepro (IApplication app, Dialog dialog, DropDownList dropDown, ListView nextView, SessionToken? token)
+        private HandledAcceptRepro (IApplication app, Dialog dialog, DropDownList dropDown, ListView nextView, Label coveredLabel, SessionToken? token)
         {
             App = app;
             Dialog = dialog;
             DropDown = dropDown;
             NextView = nextView;
+            CoveredLabel = coveredLabel;
             _token = token;
         }
 
@@ -1352,6 +1362,8 @@ public class DropDownListTests (ITestOutputHelper output)
         public DropDownList DropDown { get; }
 
         public ListView NextView { get; }
+
+        public Label CoveredLabel { get; }
 
         public static HandledAcceptRepro Create ()
         {
@@ -1405,7 +1417,7 @@ public class DropDownListTests (ITestOutputHelper output)
             SessionToken? token = app.Begin (dialog);
             app.LayoutAndDraw ();
 
-            return new HandledAcceptRepro (app, dialog, dropDown, nextView, token);
+            return new HandledAcceptRepro (app, dialog, dropDown, nextView, covered3, token);
         }
 
         public void Dispose ()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fixes

- Fixes #5635

## Summary

A read-only DropDownList left the dropped list's text on screen after Enter when Accepting was handled and focus moved. Selection and focus were correct. The popover was no longer active. The cells it covered were not repainted. Mouse accept already repainted.

The keyboard path lost focus and called DeRegister while the popover was still the active one. DeRegister cleared `_activePopover` without Hide. Hide is the method that calls `TopRunnableView.SetNeedsDraw()`. A later Visible=false Hide then no-oped because the popover was no longer active.

I hide the active popover so the covered region is invalidated. I unregister it first so a VisibleChanged handler cannot call Show during Hide and leave the popover visible, active, or registered.

## Changes

- `ApplicationPopover.DeRegister` removes the popover from the registry, then hides it if it was active.
- After Hide, it clears a restored active pointer and removes again if MakeVisible re-registered.
- `DropDownList.OnHasFocusChanging` hides the list popover before DeRegister on focus loss.

## Testing

I wrote tests that fail on `develop` and pass with this change.

- `DeRegister_ActivePopover_HidesAndInvalidatesTopRunnable` asserts Hide and NeedsDraw.
- `DeRegister_VisibleChangedShow_LeavesUnregisteredInactiveAndHidden` failed on `fa930207` because Hide still saw the popover as registered. After unregister-before-Hide it passes: not registered, not active, not visible.
- `Enter_HandledAccepting_DoesNotLeaveStalePopoverCells` is the issue repro.
- `MouseAccept_HandledAccepting_DoesNotLeaveStalePopoverCells` keeps the mouse path honest.

## CI follow-up

macOS Integration Tests failed on `WithListView_NavigatesItems` (dotnet driver) at SHA `766b96f00`. That test is ListView cursor navigation. It is not a DropDownList or popover test.

The NRE was in `AppTestHelper.WaitIteration` during Stop/Dispose. `CleanupApplication` can already have nulled `ExternalCancellationTokenSource` while Stop still calls WaitIteration. WaitIteration used `!` on that source.

This is a helper shutdown race. It is not caused by the DeRegister change. I did not Ignore the integration test.

I capture the CTS, treat a null or cancelled source as already stopped, and set Finished before clearing the source.

`WaitIteration_WhenExternalCancellationTokenSourceIsNull_DoesNotThrow` failed on the old `!` dereference and passes after the harden.

CI is green on `16d45a112`, including Integration Tests on macOS, Ubuntu, and Windows.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the style guidelines of Terminal.Gui
- [x] My code follows the Terminal.Gui library design guidelines
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

## To pull down this PR locally:

```bash
git fetch origin cursor/dropdown-stale-popover-enter-f842
git checkout cursor/dropdown-stale-popover-enter-f842
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-172960d0-42bf-4bd1-a8fc-e9d0d126f842?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-172960d0-42bf-4bd1-a8fc-e9d0d126f842&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

