### PR TITLE
Docs: 2.5.0 CM/MEC leftovers for #5630

### DIFF
--- a/Terminal.Gui/README.md
+++ b/Terminal.Gui/README.md
@@ -14,9 +14,11 @@ The [GitVersion.MsBuild](https://www.nuget.org/packages/GitVersion.MsBuild) NuGe
 |--------|----------------|-----------|-------|
 | `main` (stable) | `2.0.0` | Patch | Label set in `GitVersion.yml` (`label: ''`) |
 | `main` (pre-release) | `2.0.1-rc.1` | Patch | Label set in `GitVersion.yml` (e.g., `label: rc`) |
-| `develop` | `2.1.0-develop.42` | Minor | Always carries `-develop` pre-release label |
-| `feature/*`, `fix/*`, etc. | `2.1.0-my-feature.1` | Inherit | Inherits from `develop`; branch name becomes label |
+| `develop` | `2.5.0-develop.55` | Patch | Always carries `-develop` pre-release label |
+| `feature/*`, `fix/*`, etc. | `2.5.0-my-feature.1` | Inherit | Inherits from `develop`; branch name becomes label |
 | `pull-request/*` | `2.0.0-pr.123.1` | Inherit | PR number in label |
+
+`develop` increments **Patch** (`GitVersion.yml` `increment: Patch`). To bump Minor, include `+semver: minor` in a commit message. Do not pin `next-version`.
 
 ### Checking Versions Locally
 
@@ -135,7 +137,7 @@ These branches are **not** configured in `GitVersion.yml` (the config was remove
 
 - **Package**: [nuget.org/packages/Terminal.Gui](https://www.nuget.org/packages/Terminal.Gui)
 - **Auto-published** on every push to `develop` (pre-release versions) and on `v*` tag pushes (stable/pre-release versions tagged on `main`)
-- Pre-release versions (e.g., `2.1.0-develop.42`) are marked as pre-release on NuGet
+- Pre-release versions (e.g., `2.5.0-develop.55`) are marked as pre-release on NuGet
 
 ### Local Package Development
 

--- a/ai-v2-primer.md
+++ b/ai-v2-primer.md
@@ -37,7 +37,7 @@ most of what you "know" about Terminal.Gui is **wrong**. The API has fundamental
 | `view.Bounds` | `view.Viewport` |
 | `LayoutStyle.Computed` | Removed — all layout is declarative via `Pos`/`Dim` |
 | `new RadioGroup (...)` | `new OptionSelector { ... }` |
-| `Colors.ColorSchemes ["name"]` | `Schemes.Resolve ("name")` or use `Scheme` directly |
+| `Colors.ColorSchemes ["name"]` | `SchemeManager.GetScheme ("name")` or use `Scheme` directly |
 | `Application.RequestStop ()` | `App!.RequestStop ()` (from inside a `Runnable`) |
 | `Pos.At (n)` / `Pos.Left (v)` | Assign integers directly: `X = 5;` (implicit conversion) |
 

--- a/docfx/docs/breaking-changes-2.5.0.md
+++ b/docfx/docs/breaking-changes-2.5.0.md
@@ -1,0 +1,35 @@
+# Terminal.Gui 2.5.0 Breaking Changes
+
+Terminal.Gui 2.5.0 is a minor bump that includes planned API breaks. Apps that compiled against 2.4.17 may need source changes.
+
+The GitHub Release notes list for this train lives on [#5630](https://github.com/tui-cs/Terminal.Gui/issues/5630). This page covers the four breaks that belong in the conceptual docs.
+
+## `View.Text` is no longer virtual
+
+<xref:Terminal.Gui.ViewBase.View.Text> is a non-virtual property. To validate or cancel a change, override `OnTextChanging(string)` or subscribe to <xref:Terminal.Gui.ViewBase.View.TextChanging>. To react after a change, override `OnTextChanged` or subscribe to <xref:Terminal.Gui.ViewBase.View.TextChanged>.
+
+`TextField` uses `View.Text` directly (no `new` hider).
+
+See [Cancellable Work Pattern](cancellable-work-pattern.md) and [Events](events.md).
+
+## `IAcceptTarget` moved to `Terminal.Gui.Input`
+
+<xref:Terminal.Gui.Input.IAcceptTarget> now lives in `Terminal.Gui.Input`. To compile against 2.5.0, add `using Terminal.Gui.Input;`.
+
+See [Command](command.md).
+
+## `ConfigurationManager` and `[ConfigurationProperty]` removed
+
+2.5.0 deletes the legacy `ConfigurationManager` type and the `[ConfigurationProperty]` attribute that 2.4.17 marked `[Obsolete]`.
+
+To load themes and settings, use <xref:Terminal.Gui.Configuration.TuiConfigurationBuilder> and Settings POCOs such as `ButtonSettings.Current`.
+
+See [Configuration](config.md) and [Migrating ConfigurationManager to TuiConfigurationBuilder](migrate-cm-to-mec.md).
+
+## `config.json` is nested only
+
+A pre-2.5.0 file with dotted keys (`"Button.DefaultShadow"`) or array-shaped `Themes` / `Schemes` is not applied. A `WARN` log names the file.
+
+To convert a legacy file, run `Tools/MigrateConfig`. Nested JSON is the supported contract.
+
+See [Configuration](config.md) and [Migrating ConfigurationManager to TuiConfigurationBuilder](migrate-cm-to-mec.md).

--- a/docfx/docs/config.md
+++ b/docfx/docs/config.md
@@ -2,7 +2,7 @@
 
 Terminal.Gui loads themes, glyphs, key bindings, and view defaults from JSON using [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/core/extensions/configuration) via <xref:Terminal.Gui.Configuration.TuiConfigurationBuilder>.
 
-The legacy `ConfigurationManager` type was removed in 2.5.0. To convert a pre-2.5.0 `config.json`, see [Migrating ConfigurationManager to TuiConfigurationBuilder](migrate-cm-to-mec.md).
+The legacy `ConfigurationManager` type was removed in 2.5.0. To convert a pre-2.5.0 `config.json`, see [Migrating ConfigurationManager to TuiConfigurationBuilder](migrate-cm-to-mec.md). For the other 2.5.0 API breaks, see [2.5.0 Breaking Changes](breaking-changes-2.5.0.md).
 
 ## Quick start
 
@@ -150,6 +150,7 @@ IConfiguration config = new ConfigurationBuilder ()
 
 ## See also
 
+- [2.5.0 Breaking Changes](breaking-changes-2.5.0.md)
 - [Migrating ConfigurationManager to TuiConfigurationBuilder](migrate-cm-to-mec.md)
 - [Configuration JSON Schema](../schemas/tui-config-schema.json)
 - [Scheme Deep Dive](scheme.md)

--- a/docfx/docs/index.md
+++ b/docfx/docs/index.md
@@ -12,6 +12,7 @@ Welcome to the Terminal.Gui documentation! This comprehensive guide covers every
 - [Getting Started](~/docs/getting-started.md) - Quick start guide to create your first Terminal.Gui application
 - [Migrating from v1 to v2](~/docs/migratingfromv1.md) - Complete guide for upgrading existing applications
 - [What's New in v2](~/docs/newinv2.md) - Overview of new features and improvements
+- [2.5.0 Breaking Changes](~/docs/breaking-changes-2.5.0.md) - `View.Text` CWP, `IAcceptTarget` namespace, `ConfigurationManager` removal, nested `config.json`
 - [Showcase](~/docs/showcase.md) - Showcase of TUI apps built with Terminal.Gui
 - [Lexicon & Taxonomy](~/docs/lexicon.md) - Terminology and concepts used throughout Terminal.Gui
 - [Views](~/docs/views.md) - Comprehensive list of built-in views and controls

--- a/docfx/docs/migratingfromv1.md
+++ b/docfx/docs/migratingfromv1.md
@@ -8,6 +8,7 @@ For detailed breaking change documentation, check out this Discussion: https://g
 
 - [Overview of Major Changes](#overview-of-major-changes)
 - [Application Architecture](#application-architecture)
+- [Configuration](#configuration)
 - [View Construction and Initialization](#view-construction-and-initialization)
 - [Layout System Changes](#layout-system-changes)
 - [Color and Attribute Changes](#color-and-attribute-changes)
@@ -163,6 +164,16 @@ public class MyView : View
     }
 }
 ```
+
+---
+
+## Configuration
+
+v1 exposed `ConfigurationManager` (typically `ConfigurationManager.Enable`). That API is gone in 2.5.0.
+
+To load themes and settings in v2, use <xref:Terminal.Gui.Configuration.TuiConfigurationBuilder> and Settings POCOs. Do not call `ConfigurationManager.Enable`.
+
+To convert a pre-2.5.0 `config.json`, see [Migrating ConfigurationManager to TuiConfigurationBuilder](migrate-cm-to-mec.md). For the other 2.5.0 API breaks, see [2.5.0 Breaking Changes](breaking-changes-2.5.0.md).
 
 ---
 
@@ -1093,6 +1104,9 @@ While migration requires some effort, the result is a more robust, performant, a
 
 For more details, see:
 - [Application Deep Dive](application.md)
+- [Configuration Deep Dive](config.md)
+- [Migrating ConfigurationManager to TuiConfigurationBuilder](migrate-cm-to-mec.md)
+- [2.5.0 Breaking Changes](breaking-changes-2.5.0.md)
 - [Keyboard Deep Dive](keyboard.md)
 - [Mouse Deep Dive](mouse.md)
 - [Layout Deep Dive](layout.md)

--- a/docfx/docs/newinv2.md
+++ b/docfx/docs/newinv2.md
@@ -4,6 +4,8 @@ This document provides an in-depth overview of the new features, improvements, a
 
 **For migration guidance**, see the [v1 To v2 Migration Guide](migratingfromv1.md).
 
+For the 2.5.0 API breaks (`View.Text`, `IAcceptTarget`, `ConfigurationManager`, nested `config.json`), see [2.5.0 Breaking Changes](breaking-changes-2.5.0.md).
+
 ## Table of Contents
 
 - [Overview](#overview)
@@ -656,7 +658,7 @@ builder.ApplyToStaticFacades ();
 builder.ThemeManager.SwitchTheme ("Dark");
 ```
 
-See [Migrating ConfigurationManager to TuiConfigurationBuilder](migrate-cm-to-mec.md) if you still have 2.4.x `ConfigurationManager` calls or a flat-key `config.json`.
+See [Migrating ConfigurationManager to TuiConfigurationBuilder](migrate-cm-to-mec.md) if you still have 2.4.x `ConfigurationManager` calls or a flat-key `config.json`. See [2.5.0 Breaking Changes](breaking-changes-2.5.0.md) for the other 2.5.0 API breaks.
 
 **User Customization:**
 - End-users can personalize themes, colors, text styles

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -7,7 +7,9 @@
 - name: What's new in v2
   href: newinv2.md
 - name: v1 To v2 Migration
-  href: migratingfromv1.md  
+  href: migratingfromv1.md
+- name: 2.5.0 Breaking Changes
+  href: breaking-changes-2.5.0.md
 - name: Lexicon & Taxonomy
   href: lexicon.md
 - name: Views

--- a/llms.txt
+++ b/llms.txt
@@ -27,7 +27,7 @@
 | `view.Bounds` | `view.Viewport` |
 | `LayoutStyle.Computed` | Removed — all layout is declarative via `Pos`/`Dim` |
 | `new RadioGroup (...)` | `new OptionSelector { ... }` |
-| `Colors.ColorSchemes ["name"]` | `Schemes.Resolve ("name")` or use `Scheme` directly |
+| `Colors.ColorSchemes ["name"]` | `SchemeManager.GetScheme ("name")` or use `Scheme` directly |
 | `Application.RequestStop ()` | `App!.RequestStop ()` (from inside a `Runnable`) |
 
 > **Full v1→v2 corrections**: See [ai-v2-primer.md](ai-v2-primer.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

I finished the Workstream 3 conceptual-docs leftovers on #5630. I did not touch `GitVersion.yml`, and I did not run Prepare Release.

- Addresses #5630 (Workstream 3 leftovers only)

## Leftovers

1. **migratingfromv1.md: done.** On develop, `rg ConfigurationManager docfx/docs/migratingfromv1.md` was empty. The leftover was a missing pointer, not leftover CM how-to. I added `## Configuration` that tells v1 `ConfigurationManager.Enable` users to use `TuiConfigurationBuilder` and [migrate-cm-to-mec.md](docfx/docs/migrate-cm-to-mec.md). I did not rewrite the v1 history.

2. **2.5.0 breaking-changes page: done.** New page [docfx/docs/breaking-changes-2.5.0.md](docfx/docs/breaking-changes-2.5.0.md) is on the site via `docfx/docs/toc.yml` (`2.5.0 Breaking Changes`). Headings:
   - `View.Text` is no longer virtual.
   - `IAcceptTarget` moved to `Terminal.Gui.Input`.
   - `ConfigurationManager` and `[ConfigurationProperty]` removed.
   - `config.json` is nested only.
   Cross-links from `config.md` and `newinv2.md`. The GitHub Release notes list stays on #5630.

3. **README versioning table: done.** `GitVersion.yml` `develop.increment` is `Patch`. The table said `Minor`. I changed the Increment column to Patch, used `2.5.0-develop.55` as the example, and added a one-line note that `+semver: minor` is how you bump Minor. I did not change `GitVersion.yml`.

4. **Schemes.Resolve: done (was wrong).** `Schemes` is an enum with no `Resolve` method (`rg Resolve Terminal.Gui/Drawing/Schemes.cs` is empty). The live API is `SchemeManager.GetScheme`. I changed the row in `ai-v2-primer.md` and `llms.txt` from `Schemes.Resolve ("name")` to `SchemeManager.GetScheme ("name")`.

## Hypothesis

Leftover CM advice was not in `config.md` (already rewritten with #5416). It was a missing MEC pointer in `migratingfromv1.md`, plus the README increment lie.

## Out of scope

I left code and API behavior alone. I did not bump versions. I did not run Prepare Release.

## Testing

Docs and primer only. Snippet CI should run because I touched `ai-v2-primer.md` and `llms.txt`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb554514-a8b9-44a6-abd0-bd81888c73a7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb554514-a8b9-44a6-abd0-bd81888c73a7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

