### PR TITLE
Fixes NativeAOT IL2026 in RuneJsonConverter

### DIFF
--- a/Terminal.Gui/Configuration/RuneJsonConverter.cs
+++ b/Terminal.Gui/Configuration/RuneJsonConverter.cs
@@ -21,7 +21,8 @@ namespace Terminal.Gui.Configuration;
 internal class RuneJsonConverter : JsonConverter<Rune>
 {
     /// <summary>
-    ///     Parses a configuration string using the same rules as <see cref="Read"/>.
+    ///     Parses a configuration string using the same rules as <see cref="Read"/> for a JSON string token.
+    ///     Does not round-trip through <see cref="JsonSerializer"/> (that path is trim-unsafe on NativeAOT).
     /// </summary>
     internal static bool TryParse (string? value, out Rune result)
     {
@@ -34,15 +35,7 @@ internal class RuneJsonConverter : JsonConverter<Rune>
 
         try
         {
-            byte [] utf8 = JsonSerializer.SerializeToUtf8Bytes (value);
-            Utf8JsonReader reader = new (utf8);
-
-            if (!reader.Read ())
-            {
-                return false;
-            }
-
-            result = new RuneJsonConverter ().Read (ref reader, typeof (Rune), JsonSerializerOptions.Default);
+            result = ParseString (value);
 
             return true;
         }
@@ -57,99 +50,7 @@ internal class RuneJsonConverter : JsonConverter<Rune>
         switch (reader.TokenType)
         {
             case JsonTokenType.String:
-                {
-                    string? value = reader.GetString ();
-                    int first = RuneExtensions.MaxUnicodeCodePoint + 1;
-                    int second = RuneExtensions.MaxUnicodeCodePoint + 1;
-
-                    if (value is { } && (value.StartsWith ("U+", StringComparison.OrdinalIgnoreCase)
-                                         || value.StartsWith ("\\U", StringComparison.OrdinalIgnoreCase)))
-                    {
-                        // Handle encoded single char, surrogate pair, or combining mark + char
-                        uint [] codePoints = Regex.Matches (value, @"(?:\\[uU]\+?|U\+)([0-9A-Fa-f]{1,8})")
-                                                  .Select (
-                                                           match => uint.Parse (
-                                                                                match.Groups [1].Value,
-                                                                                NumberStyles.HexNumber
-                                                                               )
-                                                          )
-                                                  .ToArray ();
-
-                        if (codePoints.Length is 0 or > 2)
-                        {
-                            throw new JsonException ($"{value}: Invalid Rune.");
-                        }
-
-                        if (codePoints.Length > 0)
-                        {
-                            first = (int)codePoints [0];
-                        }
-
-                        if (codePoints.Length == 2)
-                        {
-                            second = (int)codePoints [1];
-                        }
-                    }
-                    else
-                    {
-                        // Handle single character, surrogate pair, or combining mark + char
-                        if (value is { Length: 0 or > 2 })
-                        {
-                            throw new JsonException ($"{value}: Invalid Rune");
-                        }
-
-                        if (value is { Length: > 0 })
-                        {
-                            first = value [0];
-                        }
-
-                        if (value is { Length: 2 })
-                        {
-                            second = value [1];
-                        }
-                    }
-
-                    Rune result;
-
-                    if (second == RuneExtensions.MaxUnicodeCodePoint + 1)
-                    {
-                        // Single codepoint
-                        if (!Rune.TryCreate (first, out result))
-                        {
-                            throw new JsonException ($"{value}: Invalid Rune");
-                        }
-
-                        return result;
-                    }
-
-                    // Surrogate pair?
-                    if (Rune.TryCreate ((char)first, (char)second, out result))
-                    {
-                        return result;
-                    }
-
-                    if (!Rune.IsValid (second))
-                    {
-                        throw new JsonException ($"{value}: Invalid Rune. The second codepoint is not valid: {second}.");
-                    }
-
-                    var cm = new Rune (second);
-
-                    if (!cm.IsCombiningMark ())
-                    {
-                        throw new JsonException ($"{value}: Invalid Rune. The second codepoint is not a combining mark: {cm}.");
-                    }
-
-                    // not a surrogate pair, so a combining mark + char?
-                    string combined = string.Concat ((char)first, (char)second).Normalize ();
-
-                    if (!Rune.IsValid (combined [0]))
-                    {
-                        throw new JsonException ($"{value}: Invalid combined Rune.");
-                    }
-
-                    return new (combined [0]);
-                }
+                return ParseString (reader.GetString ());
             case JsonTokenType.Number:
                 {
                     uint num = reader.GetUInt32 ();
@@ -181,6 +82,103 @@ internal class RuneJsonConverter : JsonConverter<Rune>
             // Write as the actual glyph
             writer.WriteStringValue (value.ToString ());
         }
+    }
+
+    /// <summary>
+    ///     Parses a glyph, U+hex, or \u string using the same rules as a JSON string token in <see cref="Read"/>.
+    /// </summary>
+    private static Rune ParseString (string? value)
+    {
+        int first = RuneExtensions.MaxUnicodeCodePoint + 1;
+        int second = RuneExtensions.MaxUnicodeCodePoint + 1;
+
+        if (value is { } && (value.StartsWith ("U+", StringComparison.OrdinalIgnoreCase)
+                             || value.StartsWith ("\\U", StringComparison.OrdinalIgnoreCase)))
+        {
+            // Handle encoded single char, surrogate pair, or combining mark + char
+            uint [] codePoints = Regex.Matches (value, @"(?:\\[uU]\+?|U\+)([0-9A-Fa-f]{1,8})")
+                                      .Select (
+                                               match => uint.Parse (
+                                                                    match.Groups [1].Value,
+                                                                    NumberStyles.HexNumber
+                                                                   )
+                                              )
+                                      .ToArray ();
+
+            if (codePoints.Length is 0 or > 2)
+            {
+                throw new JsonException ($"{value}: Invalid Rune.");
+            }
+
+            if (codePoints.Length > 0)
+            {
+                first = (int)codePoints [0];
+            }
+
+            if (codePoints.Length == 2)
+            {
+                second = (int)codePoints [1];
+            }
+        }
+        else
+        {
+            // Handle single character, surrogate pair, or combining mark + char
+            if (value is { Length: 0 or > 2 })
+            {
+                throw new JsonException ($"{value}: Invalid Rune");
+            }
+
+            if (value is { Length: > 0 })
+            {
+                first = value [0];
+            }
+
+            if (value is { Length: 2 })
+            {
+                second = value [1];
+            }
+        }
+
+        Rune result;
+
+        if (second == RuneExtensions.MaxUnicodeCodePoint + 1)
+        {
+            // Single codepoint
+            if (!Rune.TryCreate (first, out result))
+            {
+                throw new JsonException ($"{value}: Invalid Rune");
+            }
+
+            return result;
+        }
+
+        // Surrogate pair?
+        if (Rune.TryCreate ((char)first, (char)second, out result))
+        {
+            return result;
+        }
+
+        if (!Rune.IsValid (second))
+        {
+            throw new JsonException ($"{value}: Invalid Rune. The second codepoint is not valid: {second}.");
+        }
+
+        var cm = new Rune (second);
+
+        if (!cm.IsCombiningMark ())
+        {
+            throw new JsonException ($"{value}: Invalid Rune. The second codepoint is not a combining mark: {cm}.");
+        }
+
+        // not a surrogate pair, so a combining mark + char?
+        string combined = string.Concat ((char)first, (char)second).Normalize ();
+
+        if (!Rune.IsValid (combined [0]))
+        {
+            throw new JsonException ($"{value}: Invalid combined Rune.");
+        }
+
+        return new (combined [0]);
     }
 }
 #pragma warning restore 1591

--- a/Tests/UnitTestsParallelizable/Configuration/RuneJsonConverterTests.cs
+++ b/Tests/UnitTestsParallelizable/Configuration/RuneJsonConverterTests.cs
@@ -143,4 +143,49 @@ public class RuneJsonConverterTests
         // Assert
         Assert.Equal ("a", deserialized.ToString ());
     }
+
+    // CoPilot - Grok 4.6
+    [Theory]
+    [InlineData ("a", "a")]
+    [InlineData ("☑", "☑")]
+    [InlineData ("\\u2611", "☑")]
+    [InlineData ("U+2611", "☑")]
+    [InlineData ("🍎", "🍎")]
+    [InlineData ("U+1F34E", "🍎")]
+    [InlineData ("\\U0001F34E", "🍎")]
+    [InlineData ("\\ud83d \\udc69", "👩")]
+    [InlineData ("\\ud83d\\udc69", "👩")]
+    [InlineData ("U+d83d U+dc69", "👩")]
+    [InlineData ("U+1F469", "👩")]
+    [InlineData ("\\U0001F469", "👩")]
+    [InlineData ("\\u0065\\u0301", "é")]
+    [InlineData ("6", "6")]
+    public void TryParse_DoesNotNeedJsonSerializer_Positive (string rune, string expected)
+    {
+        Assert.True (RuneJsonConverter.TryParse (rune, out Rune result));
+        Assert.Equal (expected, result.ToString ());
+    }
+
+    // CoPilot - Grok 4.6
+    [Theory]
+    [InlineData (null)]
+    [InlineData ("")]
+    [InlineData ("aa")]
+    [InlineData ("☑☑")]
+    [InlineData ("\\x2611")]
+    [InlineData ("Z+2611")]
+    [InlineData ("🍎🍎")]
+    [InlineData ("U+FFF1F34E")]
+    [InlineData ("\\UFFF1F34E")]
+    [InlineData ("\\ud83d")]
+    [InlineData ("\\udc3d")]
+    [InlineData ("\\ud83d \\u1c69")]
+    [InlineData ("\\ud83ddc69")]
+    [InlineData ("U+1F469 U+200D U+1F469 U+200D U+1F467 U+200D U+1F467")]
+    [InlineData ("\\U0001F469\\u200D\\U0001F469\\u200D\\U0001F467\\u200D\\U0001F467")]
+    [InlineData ("9733")]
+    public void TryParse_DoesNotNeedJsonSerializer_Negative (string? rune)
+    {
+        Assert.False (RuneJsonConverter.TryParse (rune, out _));
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fixes

- Addresses [tui-cs/Terminal.Gui#5630](https://github.com/tui-cs/Terminal.Gui/issues/5630) (Workstream 4 / winprint AOT).
- Unblocks [tig/winprint#272](https://github.com/tig/winprint/issues/272) AOT publish against `2.5.0-develop.55`.

## Summary

winprint AOT publish against nuget.org `Terminal.Gui 2.5.0-develop.55` fails with:

- ILC trim analysis error IL2026 on `RuneJsonConverter.TryParse`: `JsonSerializer.SerializeToUtf8Bytes` has `RequiresUnreferencedCodeAttribute`.
- IL2026 on `JsonSerializerOptions.Default.get`.
- Assembly `Terminal.Gui` produced AOT analysis warnings (IL3053).
- MSB3077: ilc exited 0 but errors were detected.

`TryParse` was serializing the configuration string to UTF-8 only so `Read` could parse it. That is trim-unsafe and unnecessary.

I parse the string directly. Glyph, U+hex, and `\u` behavior is unchanged. Decimal JSON numbers still go through `Read`. Multi-digit MEC strings still fall through to `uint.TryParse` in `TuiConfigurationBuilder.ConvertValue` (so `"6"` stays the glyph `6`, and `"9733"` stays ★).

No sibling converter uses `SerializeToUtf8Bytes` or `JsonSerializerOptions.Default`. I did not add a consumer-side ILLink suppress.

## Proposed Changes/Todos

- [x] Replace the `SerializeToUtf8Bytes` / `JsonSerializerOptions.Default` round-trip in `TryParse` with a shared `ParseString`.
- [x] Keep `Read` / `Write` behavior for glyph, U+hex, `\u`, and decimal JSON numbers.
- [x] Add `TryParse` tests that do not go through `JsonSerializer`.
- [x] Unit tests green.

## Testing

- `RuneJsonConverterTests`: 62 passed (existing round-trip cases plus `TryParse_DoesNotNeedJsonSerializer_*`).
- `GlyphConfigConversionTests`: 4 passed (`"6"`, `"U+2611"`, `"X"`, and MEC decimal 9733).
- All parallelizable Configuration tests: 257 passed.
- NativeAOT publish of a net10.0 app that calls `TuiConfigurationBuilder.ApplyToStaticFacades` with `TreatWarningsAsErrors` and `WarningsAsErrors=IL2026;IL3050;IL3053`: succeeded. The published binary printed ☑.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the [style guidelines of Terminal.Gui](https://github.com/tui-cs/Terminal.Gui/blob/develop/.editorconfig)
- [x] My code follows the [Terminal.Gui library design guidelines](https://github.com/tui-cs/Terminal.Gui/blob/develop/CONTRIBUTING.md)
- [x] I ran `dotnet test` before commit
- [x] I have made corresponding changes to the API documentation (using `///` style comments)
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any poor grammar or misspellings
- [x] I conducted basic QA to assure all features are working

## To pull down this PR locally:

```bash
git fetch origin cursor/fix-rune-json-aot-il2026-8887
git checkout cursor/fix-rune-json-aot-il2026-8887
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-538ead68-8a2c-4b6b-8e83-72bd5ebc8887?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-538ead68-8a2c-4b6b-8e83-72bd5ebc8887&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

