### PR TITLE
Fixes #5662. Restore nested paste focus after Begin

### DIFF
--- a/Terminal.Gui/Views/Runnable/Runnable.cs
+++ b/Terminal.Gui/Views/Runnable/Runnable.cs
@@ -177,7 +177,7 @@ public class Runnable : View, IRunnable
 
             // Set focus to self if becoming modal
             SetFocus ();
-            App?.Navigation?.SetFocused (Focused);
+            App?.Navigation?.SetFocused (MostFocused);
         }
         else
         {

--- a/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
+++ b/Tests/UnitTestsParallelizable/ViewBase/ViewPasteTests.cs
@@ -244,6 +244,28 @@ public class ViewPasteTests
         Assert.False (anyFired);
     }
 
+    // CoPilot - GPT-5
+    [Fact]
+    public void ApplicationPaste_BeginWithNestedFocusableView_DispatchesToMostFocusedView ()
+    {
+        using IApplication app = Application.Create ();
+        using Runnable runnable = new ();
+        View wrapper = new () { CanFocus = true };
+        TextField field = new () { Text = string.Empty };
+        wrapper.Add (field);
+        runnable.Add (wrapper);
+
+        app.Begin (runnable);
+
+        Assert.Same (field, runnable.MostFocused);
+        Assert.Same (field, app.Navigation!.GetFocused ());
+
+        bool handled = app.RaisePasteEvent ("hello");
+
+        Assert.True (handled);
+        Assert.Equal ("hello", field.Text);
+    }
+
     [Fact]
     public void ApplicationPaste_Handled_DoesNotDispatchToFocusedView ()
     {


### PR DESCRIPTION
## Fixes

- Fixes #5662

## Proposed Changes/Todos

- [x] Record the deepest focused descendant when a runnable becomes modal.
- [x] Add a regression test proving nested TextField paste dispatch immediately after Begin.

## Validation

- Regression test: failed before the production change and passes after it (1/1).
- ViewPasteTests: 21/21 passed.
- UnitTests.NonParallelizable: 32/32 passed.
- Debug solution build: succeeded with no new warnings.
- UnitTests.Parallelizable: 17,618 passed, 17 skipped, 6 failed. A clean checkout of the same develop commit reproduces the identical six failures (locale-sensitive NumericUpDown assertions and ANSI color-encoding assertions), so they are unrelated to this change.

## Pull Request checklist:

- [x] I've named my PR in the form of "Fixes #issue. Terse description."
- [x] My code follows the style guidelines of Terminal.Gui.
- [x] My code follows the Terminal.Gui library design guidelines.
- [x] I ran dotnet test before commit.
- [x] No API documentation changes are needed because this does not change public API.
- [x] My changes generate no new warnings.
- [x] I checked the code and corrected grammar and spelling.
- [x] I conducted basic QA through the focused and surrounding test suites.